### PR TITLE
chore: automatically generate release notes

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -5,7 +5,8 @@
 	},
 	"github": {
 		"release": true,
-		"releaseName": "v${version}"
+		"releaseName": "v${version}",
+		"autoGenerate": true
 	},
 	"hooks": {
 		"before:bump": "if ! pnpm run should-semantic-release --verbose ; then exit 1 ; fi"


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to template-typescript-node-package! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #201 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR enables automatic generation of release notes by Github (https://dev.to/github/how-to-automatically-generate-release-notes-for-your-project-2ng8)

Their template looks like this:

![Screenshot_2023-02-25_17-00-35](https://user-images.githubusercontent.com/12304307/221366981-ebff3bab-6b69-4c11-b7e6-da28666997aa.png)

Fortunately `release-it` had a way to enable this https://github.com/release-it/release-it/blob/master/docs/github-releases.md#release-notes

When it comes to modifying changelog, I haven't found a way to add "new contributors" through handlebar template.

https://github.com/release-it/release-it/blob/master/docs/changelog.md#auto-changelog
https://github.com/cookpete/auto-changelog/tree/master/templates