### PR TITLE
fix: allow existing labels (never gh label delete)

### DIFF
--- a/src/steps/initializeGitHubRepository/labels/getExistingEquivalentLabel.test.ts
+++ b/src/steps/initializeGitHubRepository/labels/getExistingEquivalentLabel.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { getExistingEquivalentLabel } from "./getExistingEquivalentLabel.js";
 
+const createLabel = (name: string) => ({
+	color: "#000000",
+	description: "A good label.",
+	name,
+});
+
 describe("getExistingEquivalentLabel", () => {
 	it("returns undefined when there are no existing labels", () => {
 		const actual = getExistingEquivalentLabel([], "abc");
@@ -10,38 +16,45 @@ describe("getExistingEquivalentLabel", () => {
 	});
 
 	it("returns undefined when no existing label matches", () => {
-		const actual = getExistingEquivalentLabel(["abc"], "def");
+		const actual = getExistingEquivalentLabel([createLabel("abc")], "def");
 
 		expect(actual).toBe(undefined);
 	});
 
 	it("returns an existing un-prefixed label when it matches by name", () => {
-		const actual = getExistingEquivalentLabel(["def", "abc", "ghi"], "abc");
+		const abcLabel = createLabel("abc");
+		const actual = getExistingEquivalentLabel(
+			[createLabel("def"), abcLabel, createLabel("ghi")],
+			"abc",
+		);
 
-		expect(actual).toBe("abc");
+		expect(actual).toBe(abcLabel);
 	});
 
 	it("returns an existing prefixed label when it matches by name", () => {
-		const actual = getExistingEquivalentLabel(["abc: def"], "abc: def");
+		const abcDefLabel = createLabel("abc: def");
+		const actual = getExistingEquivalentLabel([abcDefLabel], "abc: def");
 
-		expect(actual).toBe("abc: def");
+		expect(actual).toBe(abcDefLabel);
 	});
 
 	it("returns the existing label when it matches excluding prefix", () => {
+		const abcLabel = createLabel("abc");
 		const actual = getExistingEquivalentLabel(
-			["abc: def", "abc", "ghi"],
+			[createLabel("abc: def"), abcLabel, createLabel("ghi")],
 			"type: abc",
 		);
 
-		expect(actual).toBe("abc");
+		expect(actual).toBe(abcLabel);
 	});
 
 	it("returns the existing label when it matches an alias", () => {
+		const enhancementLabel = createLabel("enhancement");
 		const actual = getExistingEquivalentLabel(
-			["abc: def", "enhancement", "ghi"],
+			[createLabel("abc: def"), enhancementLabel, createLabel("ghi")],
 			"type: feature",
 		);
 
-		expect(actual).toBe("enhancement");
+		expect(actual).toBe(enhancementLabel);
 	});
 });

--- a/src/steps/initializeGitHubRepository/labels/getExistingEquivalentLabel.ts
+++ b/src/steps/initializeGitHubRepository/labels/getExistingEquivalentLabel.ts
@@ -3,18 +3,24 @@ const aliases = new Map([
 	["help wanted", "status: accepting prs"],
 ]);
 
+export interface GhLabelData {
+	color: string;
+	description: string;
+	name: string;
+}
+
 export function getExistingEquivalentLabel(
-	existingLabels: string[],
+	existingLabels: GhLabelData[],
 	outcomeLabel: string,
 ) {
 	const outcomeTrimmed = outcomeLabel.replace(/\w+: (\w+)/, "$1");
 
-	return existingLabels.find((existingLabel) => {
+	return existingLabels.find(({ name: existingName }) => {
 		return (
-			existingLabel === outcomeLabel ||
-			existingLabel === outcomeTrimmed ||
-			aliases.get(existingLabel) === outcomeLabel ||
-			existingLabel.replace(/\w+: (\w+)/, "$1") === outcomeLabel
+			existingName === outcomeLabel ||
+			existingName === outcomeTrimmed ||
+			aliases.get(existingName) === outcomeLabel ||
+			existingName.replace(/\w+: (\w+)/, "$1") === outcomeLabel
 		);
 	});
 }

--- a/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.test.ts
+++ b/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.test.ts
@@ -10,18 +10,20 @@ vi.mock("execa", () => ({
 	},
 }));
 
+const mockOutcomeLabel = {
+	color: "000000",
+	description: "def ghi",
+	name: "abc",
+};
+
 vi.mock("./outcomeLabels.js", () => ({
-	outcomeLabels: [
-		{
-			color: "000000",
-			description: "def ghi",
-			name: "abc",
-		},
-	],
+	get outcomeLabels() {
+		return [mockOutcomeLabel];
+	},
 }));
 
 describe("migrateRepositoryLabels", () => {
-	it("creates a setup label when it doesn't already exist", async () => {
+	it("creates a outcome label when it doesn't already exist", async () => {
 		mock$.mockResolvedValue({
 			stdout: JSON.stringify([
 				{
@@ -34,15 +36,119 @@ describe("migrateRepositoryLabels", () => {
 
 		await initializeRepositoryLabels();
 
-		expect(mock$).toHaveBeenCalledWith(
-			["gh label create ", " --color ", " --description ", ""],
-			"abc",
-			"000000",
-			"def ghi",
-		);
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label create ",
+			      " --color ",
+			      " --description ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			  ],
+			]
+		`);
 	});
 
-	it("edits a setup label when it already exists", async () => {
+	it("doesn't edit a outcome label when it already exists with the same information", async () => {
+		mock$.mockResolvedValue({
+			stdout: JSON.stringify([mockOutcomeLabel]),
+		});
+
+		await initializeRepositoryLabels();
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			]
+		`);
+	});
+
+	it("edits a outcome label when it already exists with different color", async () => {
+		mock$.mockResolvedValue({
+			stdout: JSON.stringify([
+				{
+					...mockOutcomeLabel,
+					color: "111111",
+				},
+			]),
+		});
+
+		await initializeRepositoryLabels();
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label edit ",
+			      " --color ",
+			      " --description ",
+			      " --name ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			    "abc",
+			  ],
+			]
+		`);
+	});
+
+	it("edits a outcome label when it already exists with different description", async () => {
+		mock$.mockResolvedValue({
+			stdout: JSON.stringify([
+				{
+					...mockOutcomeLabel,
+					description: "updated",
+				},
+			]),
+		});
+
+		await initializeRepositoryLabels();
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label edit ",
+			      " --color ",
+			      " --description ",
+			      " --name ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			    "abc",
+			  ],
+			]
+		`);
+	});
+
+	it("deletes an existing non-outcome label when the equivalent outcome label already exists", async () => {
 		mock$.mockResolvedValue({
 			stdout: JSON.stringify([
 				{
@@ -50,21 +156,28 @@ describe("migrateRepositoryLabels", () => {
 					description: "def ghi",
 					name: "abc",
 				},
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "area: abc",
+				},
 			]),
 		});
 
 		await initializeRepositoryLabels();
 
-		expect(mock$).toHaveBeenCalledWith(
-			["gh label edit ", " --color ", " --description ", " --name ", ""],
-			"abc",
-			"000000",
-			"def ghi",
-			"abc",
-		);
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			]
+		`);
 	});
 
-	it("deletes a pre-existing label when it isn't a setup label", async () => {
+	it("deletes a pre-existing label when it isn't a outcome label", async () => {
 		mock$.mockResolvedValue({
 			stdout: JSON.stringify([
 				{
@@ -77,30 +190,60 @@ describe("migrateRepositoryLabels", () => {
 
 		await initializeRepositoryLabels();
 
-		expect(mock$).toHaveBeenCalledWith(
-			["gh label delete ", " --yes"],
-			"unknown",
-		);
-		expect(mock$).toHaveBeenCalledTimes(3);
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label create ",
+			      " --color ",
+			      " --description ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			  ],
+			]
+		`);
 	});
 
-	it("doesn't delete a pre-existing label when it isn't a setup label", async () => {
+	it("doesn't delete a pre-existing label when it isn't a outcome label", async () => {
 		mock$.mockResolvedValue({
 			stdout: JSON.stringify([
 				{
 					color: "000000",
 					description: "def ghi",
-					name: "abc",
+					name: "jkl",
 				},
 			]),
 		});
 
 		await initializeRepositoryLabels();
 
-		expect(mock$).not.toHaveBeenCalledWith(
-			["gh label delete ", " --yes"],
-			"abc",
-		);
-		expect(mock$).toHaveBeenCalledTimes(2);
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label create ",
+			      " --color ",
+			      " --description ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			  ],
+			]
+		`);
 	});
 });

--- a/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.test.ts
+++ b/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.test.ts
@@ -23,6 +23,35 @@ vi.mock("./outcomeLabels.js", () => ({
 }));
 
 describe("migrateRepositoryLabels", () => {
+	it("creates a outcome label when labels stdout is returned", async () => {
+		mock$.mockResolvedValue({
+			stdout: "",
+		});
+
+		await initializeRepositoryLabels();
+
+		expect(mock$.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    [
+			      "gh label list --json color,description,name",
+			    ],
+			  ],
+			  [
+			    [
+			      "gh label create ",
+			      " --color ",
+			      " --description ",
+			      "",
+			    ],
+			    "abc",
+			    "000000",
+			    "def ghi",
+			  ],
+			]
+		`);
+	});
+
 	it("creates a outcome label when it doesn't already exist", async () => {
 		mock$.mockResolvedValue({
 			stdout: JSON.stringify([

--- a/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.ts
+++ b/src/steps/initializeGitHubRepository/labels/initializeRepositoryLabels.ts
@@ -1,21 +1,15 @@
 import { $ } from "execa";
 
-import { getExistingEquivalentLabel } from "./getExistingEquivalentLabel.js";
+import {
+	GhLabelData,
+	getExistingEquivalentLabel,
+} from "./getExistingEquivalentLabel.js";
 import { outcomeLabels } from "./outcomeLabels.js";
 
-interface GhLabelData {
-	name: string;
-}
-
 export async function initializeRepositoryLabels() {
-	const getLabelName = (label: { name: string }) => label.name;
-
-	const existingLabels = (
-		JSON.parse(
-			(await $`gh label list --json name`).stdout || "[]",
-		) as GhLabelData[]
-	).map(getLabelName);
-	const allowedLabels = new Set(outcomeLabels.map(getLabelName));
+	const existingLabels = JSON.parse(
+		(await $`gh label list --json color,description,name`).stdout || "[]",
+	) as GhLabelData[];
 
 	for (const outcome of outcomeLabels) {
 		const existingEquivalent = getExistingEquivalentLabel(
@@ -24,16 +18,14 @@ export async function initializeRepositoryLabels() {
 		);
 
 		if (existingEquivalent) {
-			allowedLabels.add(existingEquivalent);
-			await $`gh label edit ${existingEquivalent} --color ${outcome.color} --description ${outcome.description} --name ${outcome.name}`;
+			if (
+				outcome.color !== existingEquivalent.color ||
+				outcome.description !== existingEquivalent.description
+			) {
+				await $`gh label edit ${existingEquivalent.name} --color ${outcome.color} --description ${outcome.description} --name ${outcome.name}`;
+			}
 		} else {
 			await $`gh label create ${outcome.name} --color ${outcome.color} --description ${outcome.description}`;
-		}
-	}
-
-	for (const existingLabel of existingLabels) {
-		if (!allowedLabels.has(existingLabel)) {
-			await $`gh label delete ${existingLabel} --yes`;
 		}
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #735
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes `gh label delete` because if a label already exists, we're always either...
* ...editing it to be the equivalent outcome label
* ...leaving it be because it's an unrelated repo-specific label

While I'm here, applies a quick optimization to only send edit requests for existing labels whose info is different from their equivalent outcome.