### PR TITLE
docs: mentioned lack of issue claiming

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,6 +26,14 @@ With the exception of very small typos, all changes to this repository generally
 If this is your first time contributing, consider searching for [unassigned issues that also have the `good first issue` label](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22+label%3A%22good+first+issue%22+no%3Aassignee).
 If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
+#### Issue Claiming
+
+We don't use any kind of issue claiming system.
+We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
+
+If an issue has been marked as `accepting prs` and an open PR does not exist, feel free to send a PR.
+You don't need to ask for permission.
+
 ### Sending a Pull Request
 
 Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #741
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Continues the chain of https://github.com/microsoft/TypeScript/blob/a6df6c04d5dd16ecb031aba0d7499f6e9be940b6/CONTRIBUTING.md#issue-claiming -> https://github.com/typescript-eslint/typescript-eslint/pull/7356.