### PR TITLE
fix: place newlines between README.md badges

### DIFF
--- a/src/steps/writeReadme.test.ts
+++ b/src/steps/writeReadme.test.ts
@@ -74,13 +74,18 @@ describe("writeReadme", () => {
 			<img alt=\\"All Contributors: 2\\" src=\\"https://img.shields.io/badge/all_contributors-17-21bb42.svg\\" />
 			<!-- ALL-CONTRIBUTORS-BADGE:END -->
 			<!-- prettier-ignore-end -->
-			</a><a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
 				<img alt=\\"Codecov Test Coverage\\" src=\\"https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg\\"/>
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
 				<img alt=\\"Contributor Covenant\\" src=\\"https://img.shields.io/badge/code_of_conduct-enforced-21bb42\\" />
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
 				<img alt=\\"License: MIT\\" src=\\"https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42\\">
-			</a><img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" /><img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
+			</a>
+			<img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" />
+			<img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
 			</p>
 
 			## Contributors
@@ -126,13 +131,18 @@ describe("writeReadme", () => {
 			<img alt=\\"All Contributors: 2\\" src=\\"https://img.shields.io/badge/all_contributors-17-21bb42.svg\\" />
 			<!-- ALL-CONTRIBUTORS-BADGE:END -->
 			<!-- prettier-ignore-end -->
-			</a><a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
 				<img alt=\\"Codecov Test Coverage\\" src=\\"https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg\\"/>
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
 				<img alt=\\"Contributor Covenant\\" src=\\"https://img.shields.io/badge/code_of_conduct-enforced-21bb42\\" />
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
 				<img alt=\\"License: MIT\\" src=\\"https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42\\">
-			</a><img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" /><img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
+			</a>
+			<img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" />
+			<img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
 			</p>
 
 			## Contributors
@@ -224,13 +234,18 @@ describe("writeReadme", () => {
 			<img alt=\\"All Contributors: 2\\" src=\\"https://img.shields.io/badge/all_contributors-17-21bb42.svg\\" />
 			<!-- ALL-CONTRIBUTORS-BADGE:END -->
 			<!-- prettier-ignore-end -->
-			</a><a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://codecov.io/gh/TestOwner/test-repository\\" target=\\"_blank\\">
 				<img alt=\\"Codecov Test Coverage\\" src=\\"https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg\\"/>
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md\\" target=\\"_blank\\">
 				<img alt=\\"Contributor Covenant\\" src=\\"https://img.shields.io/badge/code_of_conduct-enforced-21bb42\\" />
-			</a><a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
+			</a>
+			<a href=\\"https://github.com/TestOwner/test-repository/blob/main/LICENSE.md\\" target=\\"_blank\\">
 				<img alt=\\"License: MIT\\" src=\\"https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42\\">
-			</a><img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" /><img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
+			</a>
+			<img alt=\\"Style: Prettier\\" src=\\"https://img.shields.io/badge/style-prettier-21bb42.svg\\" />
+			<img alt=\\"TypeScript: Strict\\" src=\\"https://img.shields.io/badge/typescript-strict-21bb42.svg\\" />
 			</p>
 
 			<p align=\\"center\\">Test description.</p>

--- a/src/steps/writeReadme.ts
+++ b/src/steps/writeReadme.ts
@@ -105,6 +105,6 @@ function generateTopContent(options: Options) {
 <p align="center">${options.description}</p>
 
 <p align="center">
-	${badgeLines.join("")}
+	${badgeLines.join("\n")}
 </p>`;
 }

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -92,7 +92,7 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@8.5.0",
+			  "packageManager": "pnpm@8.7.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },
@@ -163,7 +163,7 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@8.5.0",
+			  "packageManager": "pnpm@8.7.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #753
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Joins with `"\n"` instead of `""`.