### PR TITLE
feat: run getGitAndNpmDefaults lazily

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"git-remote-origin-url": "^4.0.0",
 		"git-url-parse": "^13.1.0",
 		"js-yaml": "^4.1.0",
+		"lazy-value": "^3.0.0",
 		"npm-user": "^5.0.1",
 		"octokit": "^3.1.0",
 		"prettier": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   js-yaml:
     specifier: ^4.1.0
     version: 4.1.0
+  lazy-value:
+    specifier: ^3.0.0
+    version: 3.0.0
   npm-user:
     specifier: ^5.0.1
     version: 5.0.1
@@ -4971,6 +4974,11 @@ packages:
     dependencies:
       package-json: 8.1.0
     dev: true
+
+  /lazy-value@3.0.0:
+    resolution: {integrity: sha512-BBcLu68yjVhYSqRLYbiDOCWOD7Q8pm39SNL+UfhSfroJScJKRZMaoDJMXLYA2wBA+JCY/5ICoVEvG3yQjqQtKw==}
+    engines: {node: '>=12'}
+    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}

--- a/src/shared/options/getPrefillOrPromptedOption.test.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.test.ts
@@ -29,4 +29,33 @@ describe("getPrefillOrPromptedValue", () => {
 
 		expect(actual).toEqual(expected);
 	});
+
+	it("provides no placeholder when one is not provided", async () => {
+		const message = "Test message";
+
+		await getPrefillOrPromptedOption(undefined, message);
+
+		expect(mockText).toHaveBeenCalledWith({
+			message,
+			placeholder: undefined,
+			validate: expect.any(Function),
+		});
+	});
+
+	it("provides the placeholder's awaited return when a placeholder function is provided", async () => {
+		const message = "Test message";
+		const placeholder = "Test placeholder";
+
+		await getPrefillOrPromptedOption(
+			undefined,
+			message,
+			vi.fn().mockResolvedValue(placeholder),
+		);
+
+		expect(mockText).toHaveBeenCalledWith({
+			message,
+			placeholder,
+			validate: expect.any(Function),
+		});
+	});
 });

--- a/src/shared/options/getPrefillOrPromptedOption.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.ts
@@ -5,7 +5,7 @@ import { filterPromptCancel } from "../prompts.js";
 export async function getPrefillOrPromptedOption(
 	existingValue: string | undefined,
 	message: string,
-	placeholder?: string,
+	getPlaceholder?: () => Promise<string | undefined>,
 ) {
 	if (existingValue) {
 		return existingValue;
@@ -14,7 +14,7 @@ export async function getPrefillOrPromptedOption(
 	const value = filterPromptCancel(
 		await prompts.text({
 			message,
-			placeholder,
+			placeholder: await getPlaceholder?.(),
 			validate: (val) => {
 				if (val.length === 0) {
 					return "Please enter a value.";

--- a/src/shared/options/readGitAndNpmDefaults/index.ts
+++ b/src/shared/options/readGitAndNpmDefaults/index.ts
@@ -1,44 +1,51 @@
 import { $ } from "execa";
 import gitRemoteOriginUrl from "git-remote-origin-url";
 import gitUrlParse from "git-url-parse";
+import lazyValue from "lazy-value";
 import fs from "node:fs/promises";
 import npmUser from "npm-user";
 
 import { readPackageData } from "../../packages.js";
 import { tryCatchAsync } from "../../tryCatchAsync.js";
+import { tryCatchLazyValueAsync } from "../../tryCatchLazyValueAsync.js";
 import { parsePackageAuthor } from "./parsePackageAuthor.js";
 import { readTitleFromReadme } from "./readTitleFromReadme.js";
 
-export async function getGitAndNpmDefaults() {
-	const gitDefaults = await tryCatchAsync(async () =>
+export function getGitAndNpmDefaults() {
+	const gitDefaults = tryCatchLazyValueAsync(async () =>
 		gitUrlParse(await gitRemoteOriginUrl()),
 	);
 
-	const npmDefaults = await tryCatchAsync(
+	const npmDefaults = tryCatchLazyValueAsync(
 		async () => await npmUser((await $`npm whoami`).stdout),
 	);
 
-	const packageData = await readPackageData();
-	const packageAuthor = parsePackageAuthor(packageData);
+	const packageData = lazyValue(readPackageData);
+	const packageAuthor = lazyValue(async () =>
+		parsePackageAuthor(await packageData()),
+	);
 
 	return {
-		author: packageAuthor.author ?? npmDefaults?.name,
-		description: packageData.description,
-		email:
-			npmDefaults?.email ??
-			packageAuthor.email ??
+		author: async () => (await packageAuthor()).author ?? npmDefaults.name,
+		description: async () => (await packageData()).description,
+		email: async () =>
+			(await npmDefaults())?.email ??
+			(await packageAuthor()).email ??
 			(await tryCatchAsync(
 				async () => (await $`git config --get user.email`).stdout,
 			)),
-		funding: await tryCatchAsync(
-			async () =>
-				(await fs.readFile(".github/FUNDING.yml"))
-					.toString()
-					.split(":")[1]
-					?.trim(),
-		),
-		owner: gitDefaults?.organization ?? packageAuthor.author,
-		repository: gitDefaults?.name ?? packageData.name,
-		title: await readTitleFromReadme(),
+		funding: async () =>
+			await tryCatchAsync(
+				async () =>
+					(await fs.readFile(".github/FUNDING.yml"))
+						.toString()
+						.split(":")[1]
+						?.trim(),
+			),
+		owner: async () =>
+			(await gitDefaults())?.organization ?? (await packageAuthor()).author,
+		repository: async () =>
+			(await gitDefaults())?.name ?? (await packageData()).name,
+		title: async () => await readTitleFromReadme(),
 	};
 }

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -130,9 +130,9 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 
 	const augmentedOptions = await augmentOptionsWithExcludes({
 		...options,
-		author: options.author ?? defaults.owner,
-		email: options.email ?? defaults.email,
-		funding: options.funding ?? defaults.funding,
+		author: options.author ?? (await defaults.owner()),
+		email: options.email ?? (await defaults.email()),
+		funding: options.funding ?? (await defaults.funding()),
 		repository,
 	} as Options);
 

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -28,7 +28,7 @@ export interface OptionsParseSuccess extends OctokitAndOptions {
 export type OptionsParseResult = OptionsParseCancelled | OptionsParseSuccess;
 
 export async function readOptions(args: string[]): Promise<OptionsParseResult> {
-	const defaults = await getGitAndNpmDefaults();
+	const defaults = getGitAndNpmDefaults();
 	const { values } = parseArgs({
 		args,
 		options: allArgOptions,
@@ -73,7 +73,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.owner ??= await getPrefillOrPromptedOption(
 		values.owner as string | undefined,
 		"What organization or user will the repository be under?",
-		defaults.owner,
+		await defaults.owner(),
 	);
 	if (!options.owner) {
 		return {
@@ -85,7 +85,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.repository ??= await getPrefillOrPromptedOption(
 		options.repository,
 		"What will the kebab-case name of the repository be?",
-		defaults.repository,
+		await defaults.repository(),
 	);
 	if (!options.repository) {
 		return {
@@ -111,7 +111,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.description ??= await getPrefillOrPromptedOption(
 		options.description,
 		"How would you describe the new package?",
-		defaults.description ?? "A very lovely package. Hooray!",
+		(await defaults.description()) ?? "A very lovely package. Hooray!",
 	);
 	if (!options.description) {
 		return { cancelled: true, options };
@@ -120,7 +120,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.title ??= await getPrefillOrPromptedOption(
 		options.title,
 		"What will the Title Case title of the repository be?",
-		defaults.title ?? titleCase(repository).replaceAll("-", " "),
+		(await defaults.title()) ?? titleCase(repository).replaceAll("-", " "),
 	);
 	if (!options.title) {
 		return { cancelled: true, options };
@@ -128,9 +128,9 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 
 	const augmentedOptions = await augmentOptionsWithExcludes({
 		...options,
-		author: options.author ?? defaults.owner,
-		email: options.email ?? defaults.email,
-		funding: options.funding ?? defaults.funding,
+		author: options.author ?? (await defaults.owner()),
+		email: options.email ?? (await defaults.email()),
+		funding: options.funding ?? (await defaults.funding()),
 		repository,
 	} as Options);
 

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -73,7 +73,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.owner ??= await getPrefillOrPromptedOption(
 		values.owner as string | undefined,
 		"What organization or user will the repository be under?",
-		await defaults.owner(),
+		defaults.owner,
 	);
 	if (!options.owner) {
 		return {
@@ -85,7 +85,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.repository ??= await getPrefillOrPromptedOption(
 		options.repository,
 		"What will the kebab-case name of the repository be?",
-		await defaults.repository(),
+		defaults.repository,
 	);
 	if (!options.repository) {
 		return {
@@ -111,7 +111,8 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.description ??= await getPrefillOrPromptedOption(
 		options.description,
 		"How would you describe the new package?",
-		(await defaults.description()) ?? "A very lovely package. Hooray!",
+		async () =>
+			(await defaults.description()) ?? "A very lovely package. Hooray!",
 	);
 	if (!options.description) {
 		return { cancelled: true, options };
@@ -120,7 +121,8 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	options.title ??= await getPrefillOrPromptedOption(
 		options.title,
 		"What will the Title Case title of the repository be?",
-		(await defaults.title()) ?? titleCase(repository).replaceAll("-", " "),
+		async () =>
+			(await defaults.title()) ?? titleCase(repository).replaceAll("-", " "),
 	);
 	if (!options.title) {
 		return { cancelled: true, options };
@@ -128,9 +130,9 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 
 	const augmentedOptions = await augmentOptionsWithExcludes({
 		...options,
-		author: options.author ?? (await defaults.owner()),
-		email: options.email ?? (await defaults.email()),
-		funding: options.funding ?? (await defaults.funding()),
+		author: options.author ?? defaults.owner,
+		email: options.email ?? defaults.email,
+		funding: options.funding ?? defaults.funding,
 		repository,
 	} as Options);
 

--- a/src/shared/tryCatchLazyValueAsync.test.ts
+++ b/src/shared/tryCatchLazyValueAsync.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { tryCatchLazyValueAsync } from "./tryCatchLazyValueAsync.js";
+
+describe("tryCatchLazyValueAsync", () => {
+	it("does not run get when it has not been called", () => {
+		const get = vi.fn();
+
+		tryCatchLazyValueAsync(get);
+
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it("returns get's resolved value when it resolves", async () => {
+		const expected = "value";
+		const get = vi.fn().mockResolvedValue(expected);
+
+		const lazy = tryCatchLazyValueAsync(get);
+
+		expect(await lazy()).toEqual(expected);
+	});
+
+	it("returns undefined when get rejects", async () => {
+		const get = vi.fn().mockRejectedValue(new Error("Oh no!"));
+
+		const lazy = tryCatchLazyValueAsync(get);
+
+		expect(await lazy()).toEqual(undefined);
+	});
+});

--- a/src/shared/tryCatchLazyValueAsync.ts
+++ b/src/shared/tryCatchLazyValueAsync.ts
@@ -1,0 +1,7 @@
+import lazyValue from "lazy-value";
+
+import { tryCatchAsync } from "./tryCatchAsync.js";
+
+export function tryCatchLazyValueAsync<T>(get: () => Promise<T>) {
+	return lazyValue(async () => await tryCatchAsync(get));
+}

--- a/src/steps/uninstallPackages.ts
+++ b/src/steps/uninstallPackages.ts
@@ -13,6 +13,7 @@ export async function uninstallPackages() {
 			"execa",
 			"git-remote-origin-url",
 			"git-url-parse",
+			"lazy-value",
 			"js-yaml",
 			"npm-user",
 			"octokit",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #781
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Wraps all the defaults in `lazy-value` to lazily evaluate them.

The `getGitAndNpmDefaults` function itself is pretty complex so I'm still not unit testing it. Ah well.