### PR TITLE
feat: reuse GitHub auth in all-contributors-cli

### DIFF
--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -3,7 +3,7 @@ import { $ } from "execa";
 
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
 import { doesRepositoryExist } from "../shared/doesRepositoryExist.js";
-import { OctokitAndOptions } from "../shared/options/readOptions.js";
+import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { addToolAllContributors } from "../steps/addToolAllContributors.js";
 import { finalizeDependencies } from "../steps/finalizeDependencies.js";
 import { initializeGitHubRepository } from "../steps/initializeGitHubRepository/index.js";
@@ -11,10 +11,7 @@ import { runCommands } from "../steps/runCommands.js";
 import { writeReadme } from "../steps/writeReadme.js";
 import { writeStructure } from "../steps/writing/writeStructure.js";
 
-export async function createWithOptions({
-	octokit,
-	options,
-}: OctokitAndOptions) {
+export async function createWithOptions({ github, options }: GitHubAndOptions) {
 	await withSpinners("Creating repository structure", [
 		[
 			"Writing structure",
@@ -49,8 +46,8 @@ export async function createWithOptions({
 	]);
 
 	const sendToGitHub =
-		octokit &&
-		(await doesRepositoryExist(octokit, options)) &&
+		github &&
+		(await doesRepositoryExist(github.octokit, options)) &&
 		(options.createRepository ??
 			(await prompts.confirm({
 				message:
@@ -63,7 +60,7 @@ export async function createWithOptions({
 			await $`git add -A`;
 			await $`git commit --message ${"feat: initialized repo ✨"}`;
 			await $`git push -u origin main --force`;
-			await initializeGitHubRepository(octokit, options);
+			await initializeGitHubRepository(github.octokit, options);
 		});
 	}
 

--- a/src/initialize/initializeWithOptions.ts
+++ b/src/initialize/initializeWithOptions.ts
@@ -1,5 +1,5 @@
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
-import { OctokitAndOptions } from "../shared/options/readOptions.js";
+import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { addOwnerAsAllContributor } from "../steps/addOwnerAsAllContributor.js";
 import { clearChangelog } from "../steps/clearChangelog.js";
 import { initializeGitHubRepository } from "../steps/initializeGitHubRepository/index.js";
@@ -12,9 +12,9 @@ import { updateLocalFiles } from "../steps/updateLocalFiles.js";
 import { updateReadme } from "../steps/updateReadme.js";
 
 export async function initializeWithOptions({
-	octokit,
+	github,
 	options,
-}: OctokitAndOptions) {
+}: GitHubAndOptions) {
 	await withSpinners("Initializing local files", [
 		[
 			"Updating local files",
@@ -39,9 +39,9 @@ export async function initializeWithOptions({
 		});
 	}
 
-	if (octokit) {
+	if (github) {
 		await withSpinner("Initializing GitHub repository", async () => {
-			await initializeGitHubRepository(octokit, options);
+			await initializeGitHubRepository(github.octokit, options);
 		});
 	}
 

--- a/src/migrate/migrateWithOptions.ts
+++ b/src/migrate/migrateWithOptions.ts
@@ -1,5 +1,5 @@
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
-import { OctokitAndOptions } from "../shared/options/readOptions.js";
+import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { clearUnnecessaryFiles } from "../steps/clearUnnecessaryFiles.js";
 import { detectExistingContributors } from "../steps/detectExistingContributors.js";
 import { finalizeDependencies } from "../steps/finalizeDependencies.js";
@@ -11,9 +11,9 @@ import { writeReadme } from "../steps/writeReadme.js";
 import { writeStructure } from "../steps/writing/writeStructure.js";
 
 export async function migrateWithOptions({
-	octokit,
+	github,
 	options,
-}: OctokitAndOptions) {
+}: GitHubAndOptions) {
 	await withSpinners("Migrating repository structure", [
 		["Clearing unnecessary files", clearUnnecessaryFiles],
 		[
@@ -42,15 +42,15 @@ export async function migrateWithOptions({
 		],
 	]);
 
-	if (octokit) {
+	if (github) {
 		await withSpinner("Initializing GitHub repository", async () => {
-			await initializeGitHubRepository(octokit, options);
+			await initializeGitHubRepository(github.octokit, options);
 		});
 	}
 
 	if (!options.excludeContributors) {
 		await withSpinner("Detecting existing contributors", async () =>
-			detectExistingContributors(options),
+			detectExistingContributors(github?.auth, options),
 		);
 	}
 

--- a/src/shared/options/ensureRepositoryExists.test.ts
+++ b/src/shared/options/ensureRepositoryExists.test.ts
@@ -26,6 +26,7 @@ vi.mock("../doesRepositoryExist.js", () => ({
 	},
 }));
 
+const auth = "abc123";
 const owner = "StubOwner";
 const repository = "stub-repository";
 
@@ -48,13 +49,16 @@ describe("ensureRepositoryExists", () => {
 	it("returns the repository when octokit is defined and the repository exists", async () => {
 		mockDoesRepositoryExist.mockResolvedValue(true);
 		const octokit = createMockOctokit();
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: false,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: false,
+				owner,
+				repository,
+			},
+		);
 
-		expect(actual).toEqual({ octokit, repository });
+		expect(actual).toEqual({ github: { auth, octokit }, repository });
 	});
 
 	it("creates a new repository when createRepository is true and the repository does not exist", async () => {
@@ -62,13 +66,16 @@ describe("ensureRepositoryExists", () => {
 
 		mockDoesRepositoryExist.mockResolvedValue(false);
 
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: true,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: true,
+				owner,
+				repository,
+			},
+		);
 
-		expect(actual).toEqual({ octokit, repository });
+		expect(actual).toEqual({ github: { auth, octokit }, repository });
 		expect(octokit.rest.repos.createUsingTemplate).toHaveBeenCalledWith({
 			name: repository,
 			owner,
@@ -83,13 +90,16 @@ describe("ensureRepositoryExists", () => {
 		mockDoesRepositoryExist.mockResolvedValue(false);
 		mockSelect.mockResolvedValue("create");
 
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: false,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: false,
+				owner,
+				repository,
+			},
+		);
 
-		expect(actual).toEqual({ octokit, repository });
+		expect(actual).toEqual({ github: { auth, octokit }, repository });
 		expect(octokit.rest.repos.createUsingTemplate).toHaveBeenCalledWith({
 			name: repository,
 			owner,
@@ -108,13 +118,19 @@ describe("ensureRepositoryExists", () => {
 		mockSelect.mockResolvedValueOnce("different");
 		mockText.mockResolvedValue(newRepository);
 
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: false,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: false,
+				owner,
+				repository,
+			},
+		);
 
-		expect(actual).toEqual({ octokit, repository: newRepository });
+		expect(actual).toEqual({
+			github: { auth, octokit },
+			repository: newRepository,
+		});
 		expect(octokit.rest.repos.createUsingTemplate).not.toHaveBeenCalled();
 	});
 
@@ -128,13 +144,19 @@ describe("ensureRepositoryExists", () => {
 			.mockResolvedValueOnce("create");
 		mockText.mockResolvedValue(newRepository);
 
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: false,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: false,
+				owner,
+				repository,
+			},
+		);
 
-		expect(actual).toEqual({ octokit, repository: newRepository });
+		expect(actual).toEqual({
+			github: { auth, octokit },
+			repository: newRepository,
+		});
 		expect(octokit.rest.repos.createUsingTemplate).toHaveBeenCalledWith({
 			name: newRepository,
 			owner,
@@ -149,11 +171,14 @@ describe("ensureRepositoryExists", () => {
 		mockDoesRepositoryExist.mockResolvedValue(false);
 		mockSelect.mockResolvedValue("local");
 
-		const actual = await ensureRepositoryExists(octokit, {
-			createRepository: false,
-			owner,
-			repository,
-		});
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{
+				createRepository: false,
+				owner,
+				repository,
+			},
+		);
 
 		expect(actual).toEqual({ octokit: undefined, repository });
 		expect(octokit.rest.repos.createUsingTemplate).not.toHaveBeenCalled();

--- a/src/shared/options/getGitHub.test.ts
+++ b/src/shared/options/getGitHub.test.ts
@@ -1,7 +1,7 @@
 import { Octokit } from "octokit";
 import { describe, expect, it, vi } from "vitest";
 
-import { getOctokit } from "./getOctokit.js";
+import { getGitHub } from "./getGitHub.js";
 
 const mock$ = vi.fn();
 
@@ -17,7 +17,7 @@ describe("getOctokit", () => {
 	it("throws an error when gh auth status fails", async () => {
 		mock$.mockRejectedValueOnce(new Error("Oh no!"));
 
-		await expect(getOctokit).rejects.toMatchInlineSnapshot(
+		await expect(getGitHub).rejects.toMatchInlineSnapshot(
 			"[Error: GitHub authentication failed.]",
 		);
 	});
@@ -26,8 +26,8 @@ describe("getOctokit", () => {
 		const auth = "abc123";
 		mock$.mockResolvedValueOnce({}).mockResolvedValueOnce({ stdout: auth });
 
-		const actual = await getOctokit();
+		const actual = await getGitHub();
 
-		expect(actual).toEqual(new Octokit({ auth }));
+		expect(actual).toEqual({ auth, octokit: new Octokit({ auth }) });
 	});
 });

--- a/src/shared/options/getGitHub.ts
+++ b/src/shared/options/getGitHub.ts
@@ -1,7 +1,12 @@
 import { $ } from "execa";
 import { Octokit } from "octokit";
 
-export async function getOctokit(): Promise<Octokit | undefined> {
+export interface GitHub {
+	auth: string;
+	octokit: Octokit;
+}
+
+export async function getGitHub(): Promise<GitHub | undefined> {
 	try {
 		await $`gh auth status`;
 	} catch (error) {
@@ -11,6 +16,7 @@ export async function getOctokit(): Promise<Octokit | undefined> {
 	}
 
 	const auth = (await $`gh auth token`).stdout.trim();
+	const octokit = new Octokit({ auth });
 
-	return new Octokit({ auth });
+	return { auth, octokit };
 }

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -1,5 +1,4 @@
 import { parseArgs } from "node:util";
-import { Octokit } from "octokit";
 import { titleCase } from "title-case";
 
 import { withSpinner } from "../cli/spinners.js";
@@ -7,12 +6,12 @@ import { InputBase, Options } from "../types.js";
 import { allArgOptions } from "./args.js";
 import { augmentOptionsWithExcludes } from "./augmentOptionsWithExcludes.js";
 import { ensureRepositoryExists } from "./ensureRepositoryExists.js";
-import { getOctokit } from "./getOctokit.js";
+import { GitHub, getGitHub } from "./getGitHub.js";
 import { getPrefillOrPromptedOption } from "./getPrefillOrPromptedOption.js";
 import { getGitAndNpmDefaults } from "./readGitAndNpmDefaults/index.js";
 
-export interface OctokitAndOptions {
-	octokit: Octokit | undefined;
+export interface GitHubAndOptions {
+	github: GitHub | undefined;
 	options: Options;
 }
 
@@ -21,7 +20,7 @@ export interface OptionsParseCancelled {
 	options: Partial<Options>;
 }
 
-export interface OptionsParseSuccess extends OctokitAndOptions {
+export interface OptionsParseSuccess extends GitHubAndOptions {
 	cancelled: false;
 }
 
@@ -94,10 +93,10 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 		};
 	}
 
-	const { octokit, repository } = await ensureRepositoryExists(
+	const { github, repository } = await ensureRepositoryExists(
 		values["skip-github-api"]
 			? undefined
-			: await withSpinner("Checking GitHub authentication", getOctokit),
+			: await withSpinner("Checking GitHub authentication", getGitHub),
 		{
 			createRepository: options.createRepository,
 			owner: options.owner,
@@ -145,7 +144,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 
 	return {
 		cancelled: false,
-		octokit,
+		github,
 		options: augmentedOptions,
 	};
 }

--- a/src/steps/detectExistingContributors.test.ts
+++ b/src/steps/detectExistingContributors.test.ts
@@ -10,7 +10,7 @@ vi.mock("all-contributors-for-repository", () => ({
 	},
 }));
 
-const mock$ = vi.fn();
+const mock$ = vi.fn().mockImplementation(() => mock$);
 
 vi.mock("execa", () => ({
 	get $() {
@@ -29,10 +29,17 @@ describe("detectExistingContributors", () => {
 			username: ["bug", "docs"],
 		});
 
-		await detectExistingContributors(options);
+		await detectExistingContributors("auth-token", options);
 
 		expect(mock$.mock.calls).toMatchInlineSnapshot(`
 			[
+			  [
+			    {
+			      "env": {
+			        "PRIVATE_TOKEN": "auth-token",
+			      },
+			    },
+			  ],
 			  [
 			    [
 			      "npx -y all-contributors-cli add ",

--- a/src/steps/detectExistingContributors.ts
+++ b/src/steps/detectExistingContributors.ts
@@ -4,15 +4,19 @@ import { $ } from "execa";
 import { Options } from "../shared/types.js";
 
 export async function detectExistingContributors(
+	auth: string | undefined,
 	options: Pick<Options, "owner" | "repository">,
 ) {
 	const contributors = await getAllContributorsForRepository({
+		auth,
 		owner: options.owner,
 		repo: options.repository,
 	});
 
 	for (const [contributor, contributions] of Object.entries(contributors)) {
 		const contributionTypes = Object.keys(contributions).join(",");
-		await $`npx -y all-contributors-cli add ${contributor} ${contributionTypes}`;
+		await $({
+			env: { PRIVATE_TOKEN: auth },
+		})`npx -y all-contributors-cli add ${contributor} ${contributionTypes}`;
 	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #787
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Wraps the existing `octokit` property in one that also has `auth`.