### PR TITLE
feat: add typescript sort keys to devDependenciesToRemove array

### DIFF
--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -16,6 +16,7 @@ const devDependenciesToRemove = [
 	"eslint-config-prettier",
 	"eslint-plugin-prettier",
 	"eslint-plugin-simple-import-sort",
+	"eslint-plugin-typescript-sort-keys",
 	"jasmine",
 	"jest",
 	"mocha",


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #758 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR adds the `eslint-plugin-typescript-sort-keys` package to the `devDependenciesToRemove` array
