### PR TITLE
fix: update remaining actions/checkout versions from 3 to 4

### DIFF
--- a/.github/workflows/lint-packages.yml
+++ b/.github/workflows/lint-packages.yml
@@ -10,7 +10,6 @@ name: Lint Packages
 
 on:
   pull_request: ~
-
   push:
     branches:
       - main

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.test.ts
@@ -14,7 +14,7 @@ describe("createWorkflowFile", () => {
   test_name:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
       - run: pnpm build
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -78,7 +78,7 @@ export function createWorkflowFile({
 					steps:
 						"runs" in options
 							? [
-									{ uses: "actions/checkout@v3" },
+									{ uses: "actions/checkout@v4" },
 									{ uses: "./.github/actions/prepare" },
 									...options.runs.map((run) => ({ run })),
 							  ]

--- a/src/steps/writing/creation/dotGitHub/workflows.ts
+++ b/src/steps/writing/creation/dotGitHub/workflows.ts
@@ -77,7 +77,7 @@ export function createWorkflows(options: Options) {
 					},
 				},
 				steps: [
-					{ uses: "actions/checkout@v3", with: { "fetch-depth": 0 } },
+					{ uses: "actions/checkout@v4", with: { "fetch-depth": 0 } },
 					{ uses: "./.github/actions/prepare" },
 					{
 						env: { GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}" },
@@ -129,7 +129,7 @@ export function createWorkflows(options: Options) {
 					},
 				},
 				steps: [
-					{ uses: "actions/checkout@v3", with: { "fetch-depth": 0 } },
+					{ uses: "actions/checkout@v4", with: { "fetch-depth": 0 } },
 					{
 						run: `echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"`,
 					},
@@ -168,7 +168,7 @@ export function createWorkflows(options: Options) {
 				},
 				steps: [
 					{
-						uses: "actions/checkout@v3",
+						uses: "actions/checkout@v4",
 						with: {
 							"fetch-depth": 0,
 						},
@@ -268,7 +268,7 @@ export function createWorkflows(options: Options) {
 			"test.yml": createWorkflowFile({
 				name: "Test",
 				steps: [
-					{ uses: "actions/checkout@v3" },
+					{ uses: "actions/checkout@v4" },
 					{ uses: "./.github/actions/prepare" },
 					{ run: "pnpm run test --coverage" },
 					{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #796
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns out it was failing over diffs like:

```plaintext
diff --git a/.github/workflows/tsc.yml b/.github/workflows/tsc.yml
index 3b20f24..0e11a07 100644
--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -2,7 +2,7 @@ jobs:
   type_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/prepare
       - run: pnpm tsc
```

You can see them by downloading the raw logs artifacts from the failing builds.