### PR TITLE
fix: correct key for excluding lint-packages.yml

### DIFF
--- a/src/steps/writing/creation/dotGitHub/workflows.ts
+++ b/src/steps/writing/creation/dotGitHub/workflows.ts
@@ -108,7 +108,7 @@ export function createWorkflows(options: Options) {
 				runs: ["pnpm lint:package-json"],
 			}),
 		}),
-		...(!options.excludeLintPackageJson && {
+		...(!options.excludeLintPackages && {
 			"lint-packages.yml": createWorkflowFile({
 				name: "Lint Packages",
 				runs: ["pnpm lint:packages"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #752
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Turns out it'd been using the wrong excludes key.