### PR TITLE
fix: don't create src/ files during --mode migrate

### DIFF
--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -16,7 +16,7 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 		[
 			"Writing structure",
 			async () => {
-				await writeStructure(options);
+				await writeStructure(options, "create");
 			},
 		],
 		[

--- a/src/migrate/migrateWithOptions.ts
+++ b/src/migrate/migrateWithOptions.ts
@@ -19,7 +19,7 @@ export async function migrateWithOptions({
 		[
 			"Writing structure",
 			async () => {
-				await writeStructure(options);
+				await writeStructure(options, "migrate");
 			},
 		],
 		[

--- a/src/steps/writing/creation/index.ts
+++ b/src/steps/writing/creation/index.ts
@@ -1,3 +1,4 @@
+import { Mode } from "../../../bin/mode.js";
 import { Options } from "../../../shared/types.js";
 import { Structure } from "../types.js";
 import { createDotGitHub } from "./dotGitHub/index.js";
@@ -6,12 +7,15 @@ import { createDotVSCode } from "./dotVSCode.js";
 import { createRootFiles } from "./rootFiles.js";
 import { createSrc } from "./src.js";
 
-export async function createStructure(options: Options): Promise<Structure> {
+export async function createStructure(
+	options: Options,
+	mode: Mode,
+): Promise<Structure> {
 	return {
 		".github": await createDotGitHub(options),
 		".husky": createDotHusky(),
 		".vscode": await createDotVSCode(options),
-		src: await createSrc(options),
+		...(mode !== "migrate" && (await createSrc(options))),
 		...(await createRootFiles(options)),
 	};
 }

--- a/src/steps/writing/creation/index.ts
+++ b/src/steps/writing/creation/index.ts
@@ -15,7 +15,7 @@ export async function createStructure(
 		".github": await createDotGitHub(options),
 		".husky": createDotHusky(),
 		".vscode": await createDotVSCode(options),
-		...(mode !== "migrate" && (await createSrc(options))),
+		...(mode !== "migrate" && { src: await createSrc(options) }),
 		...(await createRootFiles(options)),
 	};
 }

--- a/src/steps/writing/writeStructure.ts
+++ b/src/steps/writing/writeStructure.ts
@@ -1,11 +1,12 @@
 import { $ } from "execa";
 
+import { Mode } from "../../bin/mode.js";
 import { Options } from "../../shared/types.js";
 import { createStructure } from "./creation/index.js";
 import { writeStructureWorker } from "./writeStructureWorker.js";
 
-export async function writeStructure(options: Options) {
-	await writeStructureWorker(await createStructure(options), ".");
+export async function writeStructure(options: Options, mode: Mode) {
+	await writeStructureWorker(await createStructure(options, mode), ".");
 
 	// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/718
 	await $`chmod ug+x .husky/pre-commit`;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #749
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Passes in the root `mode` to `writeStructure` -> `createStructure` so it knows not to call `createSrc` during migration.
