### PR TITLE
fix: undo overwriting of README.md attribution in updateLocalFiles

### DIFF
--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -194,6 +194,13 @@ describe("updateLocalFiles", () => {
 			      "to": "\\"src/**/*.ts!\\"",
 			    },
 			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
+			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
+			    },
+			  ],
 			]
 		`);
 	});
@@ -327,6 +334,13 @@ describe("updateLocalFiles", () => {
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
 			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
+			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
 			    },
 			  ],
 			]
@@ -465,6 +479,13 @@ describe("updateLocalFiles", () => {
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
 			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
+			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
 			    },
 			  ],
 			  [

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -33,6 +33,12 @@ export async function updateLocalFiles(options: Options) {
 			"./knip.jsonc",
 		],
 		[`["src/**/*.ts!", "script/**/*.js"]`, `"src/**/*.ts!"`, "./knip.jsonc"],
+		// Edge case: migration scripts will rewrite README.md attribution
+		[
+			`> 💙 This package is based on [@${options.owner}](https://github.com/${options.owner})'s [${options.repository}](https://github.com/JoshuaKGoldberg/${options.repository}).`,
+			`> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
+			"./README.md",
+		],
 	];
 
 	if (existingPackage.description) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #750
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a manual find-and-replace back in `updateLocalFiles`.