### PR TITLE
fix: only append README.md notice if it doesn't yet exist

### DIFF
--- a/src/steps/updateReadme.test.ts
+++ b/src/steps/updateReadme.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { updateReadme } from "./updateReadme.js";
+
+const mockAppendFile = vi.fn();
+
+vi.mock("node:fs/promises", () => ({
+	default: {
+		get appendFile() {
+			return mockAppendFile;
+		},
+	},
+}));
+
+const mockReadFileSafe = vi.fn();
+
+vi.mock("../shared/readFileSafe.js", () => ({
+	get readFileSafe() {
+		return mockReadFileSafe;
+	},
+}));
+
+describe("updateReadme", () => {
+	it("adds a notice when the file does not contain it already", async () => {
+		mockReadFileSafe.mockResolvedValue("");
+
+		await updateReadme();
+
+		expect(mockAppendFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "./README.md",
+			    "
+			<!-- You can remove this notice if you don't want it 🙂 no worries! -->
+
+			> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+			",
+			  ],
+			]
+		`);
+	});
+
+	it("doesn't adds a notice when the file contains it already", async () => {
+		mockReadFileSafe.mockResolvedValue(
+			"<!-- You can remove this notice if you don't want it 🙂 no worries! -->",
+		);
+
+		await updateReadme();
+
+		expect(mockAppendFile.mock.calls).toMatchInlineSnapshot("[]");
+	});
+});

--- a/src/steps/updateReadme.ts
+++ b/src/steps/updateReadme.ts
@@ -1,14 +1,22 @@
 import fs from "node:fs/promises";
 import { EOL } from "node:os";
 
+import { readFileSafe } from "../shared/readFileSafe.js";
+
+const detectionLine = `<!-- You can remove this notice if you don't want it 🙂 no worries! -->`;
+
 export const endOfReadmeNotice = [
 	``,
-	`<!-- You can remove this notice if you don't want it 🙂 no worries! -->`,
+	detectionLine,
 	``,
 	`> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
 	``,
 ].join(EOL);
 
 export async function updateReadme() {
-	await fs.appendFile("./README.md", endOfReadmeNotice);
+	const contents = await readFileSafe("./README.md", "");
+
+	if (!contents.includes(detectionLine)) {
+		await fs.appendFile("./README.md", endOfReadmeNotice);
+	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #843
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the `<!-- ... -->` line as a detector to know whether to append.

Note that _creation_ was fixed previously, just not _appending_ (updating).