### PR TITLE
fix: preserve package version during migration

### DIFF
--- a/src/initialize/initializeWithOptions.ts
+++ b/src/initialize/initializeWithOptions.ts
@@ -19,7 +19,7 @@ export async function initializeWithOptions({
 		[
 			"Updating local files",
 			async () => {
-				await updateLocalFiles(options);
+				await updateLocalFiles(options, { resetPackageVersion: true });
 			},
 		],
 		["Updating README.md", updateReadme],

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -340,7 +340,7 @@ describe("updateLocalFiles", () => {
 		});
 		mockReplaceInFile.mockResolvedValue([]);
 
-		await updateLocalFiles(options);
+		await updateLocalFiles(options, { resetPackageVersion: true });
 
 		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -482,6 +482,153 @@ describe("updateLocalFiles", () => {
 			      "files": "./package.json",
 			      "from": /"version": "1\\.2\\.3"/g,
 			      "to": "\\"version\\": \\"0.0.0\\"",
+			    },
+			  ],
+			]
+		`);
+	});
+	it("does not overwrite package version when resetPackageVersion parameter is not set", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue({
+			description: "Existing description",
+			version: "1.2.3",
+		});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(options);
+
+		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Create TypeScript App/g,
+			      "to": "Stub Title",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /JoshuaKGoldberg\\(\\?!\\\\/console-fail-test\\)/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /create-typescript-app/g,
+			      "to": "stub-repository",
+			    },
+			  ],
+			  [
+			    {
+			      "files": ".eslintrc.cjs",
+			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"author": "\\.\\+"/g,
+			      "to": "\\"author\\": \\"undefined\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"bin": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"test:create": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"test:initialize": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"initialize": "\\.\\*/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./package.json",
+			      "from": /"test:migrate": "\\.\\+\\\\n/g,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./README.md",
+			      "from": /## Getting Started\\.\\*## Development/gs,
+			      "to": "## Development",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./.github/DEVELOPMENT.md",
+			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/initialize/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "		\\"src/migrate/index.ts\\",
+			",
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
+			      "to": "\\"src/index.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": "./knip.jsonc",
+			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
+			      "to": "\\"src/**/*.ts!\\"",
+			    },
+			  ],
+			  [
+			    {
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Existing description/g,
+			      "to": "Stub description.",
 			    },
 			  ],
 			]

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -644,6 +644,13 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "files": "./README.md",
+			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
+			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
+			    },
+			  ],
+			  [
+			    {
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -8,7 +8,10 @@ interface ExistingPackageData {
 	version?: string;
 }
 
-export async function updateLocalFiles(options: Options) {
+export async function updateLocalFiles(
+	options: Options,
+	config = { resetPackageVersion: false },
+) {
 	const existingPackage = ((await readFileSafeAsJson("./package.json")) ??
 		{}) as ExistingPackageData;
 
@@ -42,7 +45,7 @@ export async function updateLocalFiles(options: Options) {
 		]);
 	}
 
-	if (existingPackage.version) {
+	if (config.resetPackageVersion && existingPackage.version) {
 		replacements.push([
 			new RegExp(`"version": "${existingPackage.version}"`, "g"),
 			`"version": "0.0.0"`,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #798
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added additional config parameter to `updateLocalFiles`, so we can skip overwriting package version inside migrate script.
