### PR TITLE
feat: added a 'common' config base, with more docs

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -93,7 +93,7 @@ As described in the `README.md` file and `docs/`, this template repository comes
 
 Each follows roughly the same general flow:
 
-1. `bin/index.ts` uses `bin/mode.ts` determines which of the three setup scripts to run
+1. `bin/index.ts` uses `bin/mode.ts` to determine which of the three setup scripts to run
 2. `readOptions` parses in options from local files, Git commands, npm APIs, and/or files on disk
 3. `runOrRestore` wraps the setup script's main logic in a friendly prompt wrapper
 4. The setup script wraps each portion of its main logic with `withSpinner`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 </p>
 
 Note that this template is early stage, opinionated, and not endorsed by the TypeScript team.
-It sets up a _lot_ of tooling out of the box.
+It can be configured to set up a _lot_ of tooling out of the box.
 Each of the included tools exists for a good reason and provides real value.
 
 If you don't want to use any particular tool, you can always remove it manually.
@@ -50,7 +50,7 @@ Use the corresponding docs page to get started:
 ## Explainer
 
 This template is available for anybody who wants to set up a Node application using TypeScript.
-It sets up the following tooling for you:
+It can set up the following tooling for you:
 
 - [**All Contributors**](https://allcontributors.org): Tracks various kinds of contributions and displays them in a nicely formatted table in the README.md.
 - [**ESLint**](https://eslint.org): Static analysis for JavaScript code, configured with [typescript-eslint](https://typescript-eslint.io) for TypeScript code and other general-use plugins.

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -21,6 +21,19 @@ Each of the included tools exists for a good reason and provides real value.
 
 If you don't want to use any particular tool, you can always remove it manually.
 
+### What determines which "base" a tool goes into?
+
+The four bases correspond to what have seemed to be the most common user needs of template consumers:
+
+1. **Minimum**: Developers who just want the barest of starting templates.
+   - They may be very new to TypeScript tooling, or they may have made an informed decision that the additional tooling isn't worth the complexity and/or time investment.
+   - Tooling in this base is only what would be essential for a small TypeScript package that can be built, formatted, and linted.
+2. **Common**: The common case of users who want the minimum tooling along with common repository management.
+   - Tooling added in this base should be essential for a TypeScript repository that additionally automates useful GitHub tasks: contributor recognition, release management, and testing.
+3. **Everything**: Power users (including this repository) who want as much of the latest and greatest safety checks and standardization as possible.
+
+Note that users can always customize exactly with portions are kept in with `--base` **`prompt`**.
+
 ### Which tools can't I remove?
 
 The following pieces of this template's tooling don't have options to be removed:

--- a/src/shared/options/augmentOptionsWithExcludes.test.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.test.ts
@@ -45,7 +45,54 @@ describe("augmentOptionsWithExcludes", () => {
 		expect(actual).toBe(options);
 	});
 
-	it("uses base without prompting when base is provided manually", async () => {
+	it("uses the 'common' base without prompting when provided manually", async () => {
+		const options = {
+			...optionsBase,
+			base: "common",
+		} satisfies Options;
+
+		const actual = await augmentOptionsWithExcludes(options);
+
+		expect(actual).toEqual({
+			...options,
+			excludeCompliance: true,
+			excludeLintJson: true,
+			excludeLintMd: true,
+			excludeLintPackageJson: true,
+			excludeLintPackages: true,
+			excludeLintPerfectionist: true,
+			excludeLintSpelling: true,
+			excludeLintYml: true,
+		});
+	});
+
+	it("uses the 'minimum' base without prompting when provided manually", async () => {
+		const options = {
+			...optionsBase,
+			base: "minimum",
+		} satisfies Options;
+
+		const actual = await augmentOptionsWithExcludes(options);
+
+		expect(actual).toEqual({
+			...options,
+			excludeCompliance: true,
+			excludeContributors: true,
+			excludeLintJson: true,
+			excludeLintKnip: true,
+			excludeLintMd: true,
+			excludeLintPackageJson: true,
+			excludeLintPackages: true,
+			excludeLintPerfectionist: true,
+			excludeLintSpelling: true,
+			excludeLintYml: true,
+			excludeReleases: true,
+			excludeRenovate: true,
+			excludeTests: true,
+		});
+	});
+
+	it("uses the 'everything' base without prompting when provided manually", async () => {
 		const options = {
 			...optionsBase,
 			base: "everything",

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -106,7 +106,7 @@ export async function augmentOptionsWithExcludes(
 					{
 						label: makeLabel(
 							"everything",
-							"Sort and spellcheck all files! Deduplicate packages versions! Formalize PRs!",
+							"The most comprehensive tooling imaginable: sorting, spellchecking, and more!",
 						),
 						value: "everything",
 					},

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -113,7 +113,7 @@ export async function augmentOptionsWithExcludes(
 					{
 						hint: "recommended",
 						label: makeLabel(
-							"essentials",
+							"common",
 							"Bare starters plus testing and automation for all-contributors and releases.",
 						),
 						value: "common",

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -114,7 +114,7 @@ export async function augmentOptionsWithExcludes(
 						hint: "recommended",
 						label: makeLabel(
 							"essentials",
-							"Essentials, plus useful tooling for all-contributors, releases, and testing.",
+							"The starter tools plus automation for all-contributors, releases, and tests.",
 						),
 						value: "common",
 					},

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -114,7 +114,7 @@ export async function augmentOptionsWithExcludes(
 						hint: "recommended",
 						label: makeLabel(
 							"essentials",
-							"The starter tools plus automation for all-contributors, releases, and tests.",
+							"Bare starters plus testing and automation for all-contributors and releases.",
 						),
 						value: "common",
 					},

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -1,4 +1,5 @@
 import * as prompts from "@clack/prompts";
+import chalk from "chalk";
 
 import { filterPromptCancel } from "../prompts.js";
 import { InputBase, Options } from "../types.js";
@@ -103,23 +104,29 @@ export async function augmentOptionsWithExcludes(
 				message: `How much tooling would you like the template to set up for you?`,
 				options: [
 					{
-						label:
-							"Everything! Lint and sort all the things! Deduplicate and auto-update packages! 🙌",
+						label: makeLabel(
+							"everything",
+							"Sort and spellcheck all files! Deduplicate packages versions! Formalize PRs!",
+						),
 						value: "everything",
 					},
 					{
 						hint: "recommended",
-						label:
-							"Essentials plus useful tooling for all-contributors, releases, and testing.",
+						label: makeLabel(
+							"essentials",
+							"Essentials, plus useful tooling for all-contributors, releases, and testing.",
+						),
 						value: "common",
 					},
 					{
-						label:
-							"Just the bare essentials, please: building, formatting, linting, and type checking.",
+						label: makeLabel(
+							"minimum",
+							"Just bare starter tooling: building, formatting, linting, and type checking.",
+						),
 						value: "minimum",
 					},
 					{
-						label: "Allow me to customize.",
+						label: makeLabel("prompt", "(allow me to customize)"),
 						value: "prompt",
 					},
 				],
@@ -182,4 +189,8 @@ export async function augmentOptionsWithExcludes(
 				),
 			};
 	}
+}
+
+function makeLabel(label: string, message: string) {
+	return [chalk.bold(label), message].join("\t ");
 }

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -165,7 +165,12 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 const optionsSchema = z.object({
 	author: z.string().optional(),
 	base: z
-		.union([z.literal("everything"), z.literal("minimum"), z.literal("prompt")])
+		.union([
+			z.literal("common"),
+			z.literal("everything"),
+			z.literal("minimum"),
+			z.literal("prompt"),
+		])
 		.optional(),
 	createRepository: z.boolean().optional(),
 	description: z.string().optional(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,7 @@ export interface PartialPackageData {
 	repository?: { type: string; url: string } | string;
 }
 
-export type InputBase = "everything" | "minimum" | "prompt";
+export type InputBase = "common" | "everything" | "minimum" | "prompt";
 
 export interface Options {
 	author?: string;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #835
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Describes the new "common" base as what I imagine most repositories would want, and gives it the `hint: "recommended"` instead of the "everything" base. And adds some more test coverage to `augmentOptionsWithExcludes`.

I think Knip might technically belong in the "everything" base per the current descriptions... but gosh darn is it so useful. I wonder what's better: including it in "common" so everyone gets the benefit? Or pushing it to "everything" so as a reward for trying that one out? For now I think the former is more likely to be beneficial.

```plaintext
│
◆  How much tooling would you like the template to set up for you?
│  ○ everything  The most comprehensive tooling imaginable: sorting, spellchecking, and more!
│  ● essentials  Bare starters plus testing and automation for all-contributors and releases. (recommended)
│  ○ minimum     Just bare starter tooling: building, formatting, linting, and type checking.
│  ○ prompt      (allow me to customize)
└
```