### PR TITLE
fix: use setTimeout, not setInterval

### DIFF
--- a/src/shared/cli/startLineWithDots.ts
+++ b/src/shared/cli/startLineWithDots.ts
@@ -1,9 +1,9 @@
 import readline from "readline";
 
 export function startLineWithDots(line: string) {
+	const timer = [setTimeout(tick, 500)];
 	let dots = 0;
 	let lastLogged!: string;
-	let timer: NodeJS.Timeout;
 
 	function clearLine() {
 		readline.clearLine(process.stdout, -1);
@@ -25,15 +25,14 @@ export function startLineWithDots(line: string) {
 	function tick() {
 		clearLine();
 		writeLine();
-		timer = setTimeout(tick, 500);
+		timer[0] = setTimeout(tick, 500);
 	}
 
 	writeLine();
-	setTimeout(tick, 500);
 
 	return () => {
 		clearLine();
-		clearInterval(timer);
+		clearInterval(timer[0]);
 		return lastLogged.length;
 	};
 }

--- a/src/shared/cli/startLineWithDots.ts
+++ b/src/shared/cli/startLineWithDots.ts
@@ -3,6 +3,7 @@ import readline from "readline";
 export function startLineWithDots(line: string) {
 	let dots = 0;
 	let lastLogged!: string;
+	let timer: NodeJS.Timeout;
 
 	function clearLine() {
 		readline.clearLine(process.stdout, -1);
@@ -21,13 +22,14 @@ export function startLineWithDots(line: string) {
 		return toLog;
 	}
 
-	writeLine();
-
-	const timer = setInterval(() => {
+	function tick() {
 		clearLine();
 		writeLine();
-		dots += 1;
-	}, 500);
+		timer = setTimeout(tick, 500);
+	}
+
+	writeLine();
+	setTimeout(tick, 500);
 
 	return () => {
 		clearLine();


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #804
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches from `setInterval` to `setTimeout` so if one crashes, new timers won't continue to be created.

Also removes a duplicate `dots += 1`.