### PR TITLE
feat: allow specific GitHub and/or npm emails

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-npm@joshuakgoldberg.com.
+github@joshuakgoldberg.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,6 +4,6 @@ We take all security vulnerabilities seriously.
 If you have a vulnerability or other security issues to disclose:
 
 - Thank you very much, please do!
-- Please send them to us by emailing `npm@joshuakgoldberg.com`
+- Please send them to us by emailing `github@joshuakgoldberg.com`
 
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -51,6 +51,7 @@ The setup scripts also allow for optional overrides of the following inputs whos
 
 - `--author` _(`string`)_: Username on npm to publish packages under (by default, an existing npm author, or the currently logged in npm user, or `owner.toLowerCase()`)
 - `--email` _(`string`)_: Email address to be listed as the point of contact in docs and packages (e.g. `example@joshuakgoldberg.com`)
+  - Optionally, `--email-github` _(`string`)_ and/or `--email-npm` _(`string`)_ may be provided to use different emails in `.md` files and `package.json`, respectively
 - `--funding` _(`string`)_: GitHub organization or username to mention in `funding.yml` (by default, `owner`)
 - `--logo` _(`string`)_: Local image file in the repository to display near the top of the README.md as a logo
   - `--logo-alt` _(`string`)_: If `--logo` is provided or detected from an existing README.md, alt text that describes the image will be prompted for if not provided

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -4,12 +4,14 @@ import { $, execaCommand } from "execa";
 import packageData from "../package.json" assert { type: "json" };
 
 const { description, name: repository } = packageData;
+const emailGithub = "github@joshuakgoldberg.com";
+const emailNpm = "npm@joshuakgoldberg.com";
 const owner = "JoshuaKGoldberg";
 const title = "Create TypeScript App";
 
 await $({
 	stdio: "inherit",
-})`c8 -o ./coverage-migrate -r html -r lcov --src src node ./bin/index.js --base everything --mode migrate --description ${description} --owner ${owner} --title ${title} --repository ${repository} --exclude-contributors --skip-github-api --skip-install`;
+})`c8 -o ./coverage-migrate -r html -r lcov --src src node ./bin/index.js --base everything --mode migrate --description ${description} --email-github ${emailGithub} --email-npm ${emailNpm} --owner ${owner} --title ${title} --repository ${repository} --exclude-contributors --skip-github-api --skip-install`;
 
 const { stdout: gitStatus } = await $`git status`;
 console.log(`Stdout from running \`git status\`:\n${gitStatus}`);

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -120,7 +120,30 @@ describe("bin", () => {
 		expect(result).toEqual(code);
 	});
 
-	it("returns the cancel result containing zod error of the corresponding runner and output plus cancel logs when promptForMode returns a mode that cancels", async () => {
+	it("returns the cancel result containing a zod error of the corresponding runner and output plus cancel logs when promptForMode returns a mode that cancels with a string error", async () => {
+		const mode = "initialize";
+		const args = ["--email", "abc123"];
+		const code = 2;
+		const error = "Oh no!";
+
+		mockPromptForMode.mockResolvedValue(mode);
+		mockInitialize.mockResolvedValue({
+			code: 2,
+			error,
+			options: {},
+		});
+
+		const result = await bin(args);
+
+		expect(mockInitialize).toHaveBeenCalledWith(args);
+		expect(mockLogLine).toHaveBeenCalledWith(chalk.red(error));
+		expect(mockCancel).toHaveBeenCalledWith(
+			`Operation cancelled. Exiting - maybe another time? 👋`,
+		);
+		expect(result).toEqual(code);
+	});
+
+	it("returns the cancel result containing a zod error of the corresponding runner and output plus cancel logs when promptForMode returns a mode that cancels with a zod error", async () => {
 		const mode = "initialize";
 		const args = ["--email", "abc123"];
 		const code = 2;

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -132,8 +132,8 @@ describe("bin", () => {
 		mockPromptForMode.mockResolvedValue(mode);
 		mockInitialize.mockResolvedValue({
 			code: 2,
+			error: (validationResult as z.SafeParseError<{ email: string }>).error,
 			options: {},
-			zodError: (validationResult as z.SafeParseError<{ email: string }>).error,
 		});
 
 		const result = await bin(args);

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -65,9 +65,9 @@ export async function bin(args: string[]) {
 		logLine();
 
 		if (error) {
-			const validationError =
-				typeof error === "string" ? error : fromZodError(error);
-			logLine(chalk.red(validationError));
+			logLine(
+				chalk.red(typeof error === "string" ? error : fromZodError(error)),
+			);
 			logLine();
 		}
 

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -52,7 +52,7 @@ export async function bin(args: string[]) {
 	}
 
 	const runners = { create, initialize, migrate };
-	const { code, options, zodError } = await runners[mode](args);
+	const { code, error, options } = await runners[mode](args);
 
 	prompts.log.info(
 		[
@@ -64,8 +64,9 @@ export async function bin(args: string[]) {
 	if (code) {
 		logLine();
 
-		if (zodError) {
-			const validationError = fromZodError(zodError);
+		if (error) {
+			const validationError =
+				typeof error === "string" ? error : fromZodError(error);
 			logLine(chalk.red(validationError));
 			logLine();
 		}

--- a/src/bin/mode.ts
+++ b/src/bin/mode.ts
@@ -8,8 +8,8 @@ import { Options } from "../shared/types.js";
 
 export interface ModeResult {
 	code: StatusCode;
+	error?: string | z.ZodError<object>;
 	options: Partial<Options>;
-	zodError?: z.ZodError<object>;
 }
 
 export type ModeRunner = (args: string[]) => Promise<ModeResult>;

--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -8,7 +8,10 @@ const options = {
 	base: "everything",
 	createRepository: true,
 	description: "Test description.",
-	email: "test@test.com",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: true,
 	excludeContributors: true,
 	excludeLintJson: true,
@@ -39,7 +42,7 @@ describe("createRerunSuggestion", () => {
 		const actual = createRerunSuggestion("initialize", options);
 
 		expect(actual).toMatchInlineSnapshot(
-			'"npx create-typescript-app --mode initialize --author TestAuthor --base everything --create-repository true --description \\"Test description.\\" --email test@test.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
+			'"npx create-typescript-app --mode initialize --base everything --author TestAuthor --create-repository true --description \\"Test description.\\" --email-github github@email.com --email-npm npm@email.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
 		);
 	});
 
@@ -53,7 +56,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			'"npx create-typescript-app --mode initialize --author TestAuthor --base everything --create-repository true --description \\"Test description.\\" --email test@test.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --logo test/src.png --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\" --logo-alt \\"Test alt.\\""',
+			'"npx create-typescript-app --mode initialize --base everything --author TestAuthor --create-repository true --description \\"Test description.\\" --email-github github@email.com --email-npm npm@email.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --logo test/src.png --logo-alt \\"Test alt.\\" --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
 		);
 	});
 
@@ -66,7 +69,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			'"npx create-typescript-app --mode initialize --author TestAuthor --base everything --create-repository true --description \\"Test description.\\" --email test@test.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-md true --exclude-lint-package-json true --exclude-lint-perfectionist true --exclude-lint-spelling true --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
+			'"npx create-typescript-app --mode initialize --base everything --author TestAuthor --create-repository true --description \\"Test description.\\" --email-github github@email.com --email-npm npm@email.com --exclude-compliance true --exclude-contributors true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-md true --exclude-lint-package-json true --exclude-lint-perfectionist true --exclude-lint-spelling true --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title \\"Test Title\\""',
 		);
 	});
 });

--- a/src/create/createRerunSuggestion.ts
+++ b/src/create/createRerunSuggestion.ts
@@ -14,6 +14,13 @@ export function createRerunSuggestion(
 ): string {
 	const optionsNormalized = {
 		...options,
+		...(options.email
+			? {
+					email: undefined,
+					emailGitHub: options.email.github,
+					emailNpm: options.email.npm,
+			  }
+			: { email: undefined }),
 		...(options.logo
 			? {
 					logo: options.logo.src,
@@ -23,6 +30,9 @@ export function createRerunSuggestion(
 	};
 
 	const args = Object.entries(optionsNormalized)
+		.sort(([a], [b]) =>
+			a === "base" ? -1 : b === "base" ? 1 : a.localeCompare(b),
+		)
 		.filter(([, value]) => !!value)
 		.map(([key, value]) => {
 			const valueStringified = `${value}`;

--- a/src/create/index.ts
+++ b/src/create/index.ts
@@ -15,8 +15,8 @@ export async function create(args: string[]): Promise<ModeResult> {
 	if (inputs.cancelled) {
 		return {
 			code: StatusCodes.Cancelled,
+			error: inputs.error,
 			options: inputs.options,
-			zodError: inputs.zodError,
 		};
 	}
 

--- a/src/initialize/index.ts
+++ b/src/initialize/index.ts
@@ -11,8 +11,8 @@ export const initialize: ModeRunner = async (args) => {
 	if (inputs.cancelled) {
 		return {
 			code: StatusCodes.Cancelled,
+			error: inputs.error,
 			options: inputs.options,
-			zodError: inputs.zodError,
 		};
 	}
 

--- a/src/migrate/index.ts
+++ b/src/migrate/index.ts
@@ -11,8 +11,8 @@ export const migrate: ModeRunner = async (args) => {
 	if (inputs.cancelled) {
 		return {
 			code: StatusCodes.Cancelled,
+			error: inputs.error,
 			options: inputs.options,
-			zodError: inputs.zodError,
 		};
 	}
 

--- a/src/shared/options/args.ts
+++ b/src/shared/options/args.ts
@@ -4,6 +4,8 @@ export const allArgOptions = {
 	"create-repository": { type: "boolean" },
 	description: { type: "string" },
 	email: { type: "string" },
+	"email-github": { type: "string" },
+	"email-npm": { type: "string" },
 	"exclude-compliance": { type: "boolean" },
 	"exclude-contributors": { type: "boolean" },
 	"exclude-lint-json": { type: "boolean" },

--- a/src/shared/options/augmentOptionsWithExcludes.test.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.test.ts
@@ -8,7 +8,10 @@ const optionsBase = {
 	base: undefined,
 	createRepository: undefined,
 	description: "",
-	email: undefined,
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/shared/options/detectEmailRedundancy.test.ts
+++ b/src/shared/options/detectEmailRedundancy.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { detectEmailRedundancy } from "./detectEmailRedundancy.js";
+
+describe("detectEmailRedundancy", () => {
+	it("returns undefined when only email is specified", () => {
+		expect(detectEmailRedundancy({ email: "test@email.com" })).toBeUndefined();
+	});
+
+	it("returns undefined when email-github and email-npm are specified while email is not", () => {
+		expect(
+			detectEmailRedundancy({
+				"email-github": "test@email.com",
+				"email-npm": "test@email.com",
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns a complaint when email-github is specified while email and email-npm are not", () => {
+		expect(
+			detectEmailRedundancy({
+				"email-github": "test@email.com",
+			}),
+		).toBe(
+			"If --email-github is specified, either --email or --email-npm should be.",
+		);
+	});
+
+	it("returns a complaint when email-npm is specified while email and email-github are not", () => {
+		expect(
+			detectEmailRedundancy({
+				"email-npm": "test@email.com",
+			}),
+		).toBe(
+			"If --email-npm is specified, either --email or --email-github should be.",
+		);
+	});
+});

--- a/src/shared/options/detectEmailRedundancy.ts
+++ b/src/shared/options/detectEmailRedundancy.ts
@@ -1,0 +1,23 @@
+export interface EmailValues {
+	email?: boolean | string;
+	"email-github"?: boolean | string;
+	"email-npm"?: boolean | string;
+}
+
+export function detectEmailRedundancy(values: EmailValues) {
+	if (values.email) {
+		return values["email-github"] && values["email-npm"]
+			? "--email should not be specified if both --email-github and --email-npm are specified."
+			: undefined;
+	}
+
+	if (values["email-github"] && !values["email-npm"]) {
+		return "If --email-github is specified, either --email or --email-npm should be.";
+	}
+
+	if (values["email-npm"] && !values["email-github"]) {
+		return "If --email-npm is specified, either --email or --email-github should be.";
+	}
+
+	return undefined;
+}

--- a/src/shared/options/optionsSchema.ts
+++ b/src/shared/options/optionsSchema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const optionsSchemaShape = {
+	author: z.string().optional(),
+	base: z
+		.union([
+			z.literal("common"),
+			z.literal("everything"),
+			z.literal("minimum"),
+			z.literal("prompt"),
+		])
+		.optional(),
+	createRepository: z.boolean().optional(),
+	description: z.string().optional(),
+	email: z
+		.object({
+			github: z.string().email(),
+			npm: z.string().email(),
+		})
+		.optional(),
+	excludeCompliance: z.boolean().optional(),
+	excludeContributors: z.boolean().optional(),
+	excludeLintJson: z.boolean().optional(),
+	excludeLintKnip: z.boolean().optional(),
+	excludeLintMd: z.boolean().optional(),
+	excludeLintPackageJson: z.boolean().optional(),
+	excludeLintPackages: z.boolean().optional(),
+	excludeLintPerfectionist: z.boolean().optional(),
+	excludeLintSpelling: z.boolean().optional(),
+	excludeLintYml: z.boolean().optional(),
+	excludeReleases: z.boolean().optional(),
+	excludeRenovate: z.boolean().optional(),
+	excludeTests: z.boolean().optional(),
+	funding: z.string().optional(),
+	logo: z.string().optional(),
+	logoAlt: z.string().optional(),
+	owner: z.string().optional(),
+	repository: z.string().optional(),
+	skipGitHubApi: z.boolean().optional(),
+	skipInstall: z.boolean().optional(),
+	skipRemoval: z.boolean().optional(),
+	skipRestore: z.boolean().optional(),
+	skipUninstall: z.boolean().optional(),
+	title: z.string().optional(),
+};
+
+export const optionsSchema = z.object(optionsSchemaShape);

--- a/src/shared/options/readOptionDefaults/index.test.ts
+++ b/src/shared/options/readOptionDefaults/index.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readOptionDefaults } from "./index.js";
+
+const mock$ = vi.fn();
+
+vi.mock("execa", () => ({
+	get $() {
+		return mock$;
+	},
+}));
+
+const mockNpmUser = vi.fn();
+
+vi.mock("npm-user", () => ({
+	get default() {
+		return mockNpmUser;
+	},
+}));
+
+const mockReadPackageData = vi.fn();
+
+vi.mock("../../packages.js", () => ({
+	get readPackageData() {
+		return mockReadPackageData;
+	},
+}));
+
+describe("readOptionDefaults", () => {
+	describe("email", () => {
+		it("returns the npm whoami email from npm when only an npm exists", async () => {
+			mock$.mockImplementation(([command]: string[]) =>
+				command === "npm whoami" ? { stdout: "npm-username" } : undefined,
+			);
+			mockNpmUser.mockImplementation((username: string) => ({
+				email: `test@${username}.com`,
+			}));
+
+			const actual = await readOptionDefaults().email();
+
+			expect(actual).toEqual({
+				github: "test@npm-username.com",
+				npm: "test@npm-username.com",
+			});
+		});
+
+		it("returns the npm whoami email from npm when only a package author email exists", async () => {
+			mock$.mockResolvedValue({ stdout: "" });
+			mockReadPackageData.mockResolvedValue({
+				author: {
+					email: "test@package.com",
+				},
+			});
+
+			const actual = await readOptionDefaults().email();
+
+			expect(actual).toEqual({
+				github: "test@package.com",
+				npm: "test@package.com",
+			});
+		});
+
+		it("returns the git user email when only a git user email exists", async () => {
+			mock$.mockImplementation(([command]: string[]) =>
+				command === "git config --get user.email"
+					? { stdout: "test@git.com" }
+					: undefined,
+			);
+			mockReadPackageData.mockResolvedValue({});
+
+			const actual = await readOptionDefaults().email();
+
+			expect(actual).toEqual({
+				github: "test@git.com",
+				npm: "test@git.com",
+			});
+		});
+
+		it("returns both the git user email and the npm user email when both exist", async () => {
+			mock$.mockImplementation(([command]: string[]) => ({
+				stdout:
+					command === "git config --get user.email"
+						? "test@git.com"
+						: "npm-username",
+			}));
+			mockReadPackageData.mockResolvedValue({});
+
+			const actual = await readOptionDefaults().email();
+
+			expect(actual).toEqual({
+				github: "test@git.com",
+				npm: "test@npm-username.com",
+			});
+		});
+
+		it("returns undefined when neither git nor npm emails exist", async () => {
+			mock$.mockResolvedValue({ stdout: "" });
+			mockReadPackageData.mockResolvedValue({});
+
+			const actual = await readOptionDefaults().email();
+
+			expect(actual).toBeUndefined();
+		});
+	});
+});

--- a/src/shared/options/readOptionDefaults/index.ts
+++ b/src/shared/options/readOptionDefaults/index.ts
@@ -11,14 +11,15 @@ import { tryCatchLazyValueAsync } from "../../tryCatchLazyValueAsync.js";
 import { parsePackageAuthor } from "./parsePackageAuthor.js";
 import { readDefaultsFromReadme } from "./readDefaultsFromReadme.js";
 
-export function getGitAndNpmDefaults() {
+export function readOptionDefaults() {
 	const gitDefaults = tryCatchLazyValueAsync(async () =>
 		gitUrlParse(await gitRemoteOriginUrl()),
 	);
 
-	const npmDefaults = tryCatchLazyValueAsync(
-		async () => await npmUser((await $`npm whoami`).stdout),
-	);
+	const npmDefaults = tryCatchLazyValueAsync(async () => {
+		const whoami = (await $`npm whoami`).stdout;
+		return whoami ? await npmUser(whoami) : undefined;
+	});
 
 	const packageData = lazyValue(readPackageData);
 	const packageAuthor = lazyValue(async () =>
@@ -28,12 +29,19 @@ export function getGitAndNpmDefaults() {
 	return {
 		author: async () => (await packageAuthor()).author ?? npmDefaults.name,
 		description: async () => (await packageData()).description,
-		email: async () =>
-			(await npmDefaults())?.email ??
-			(await packageAuthor()).email ??
-			(await tryCatchAsync(
+		email: async () => {
+			const gitEmail = await tryCatchAsync(
 				async () => (await $`git config --get user.email`).stdout,
-			)),
+			);
+			const npmEmail =
+				(await npmDefaults())?.email ?? (await packageAuthor()).email;
+
+			/* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/no-non-null-assertion */
+			return gitEmail || npmEmail
+				? { github: (gitEmail || npmEmail)!, npm: (npmEmail || gitEmail)! }
+				: undefined;
+			/* eslint-enable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/no-non-null-assertion */
+		},
 		funding: async () =>
 			await tryCatchAsync(
 				async () =>

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -52,6 +52,14 @@ vi.mock("./augmentOptionsWithExcludes.js", () => ({
 	},
 }));
 
+const mockDetectEmailRedundancy = vi.fn();
+
+vi.mock("./detectEmailRedundancy.js", () => ({
+	get detectEmailRedundancy() {
+		return mockDetectEmailRedundancy;
+	},
+}));
+
 const mockGetPrefillOrPromptedOption = vi.fn();
 
 vi.mock("./getPrefillOrPromptedOption.js", () => ({
@@ -104,7 +112,22 @@ describe("readOptions", () => {
 		});
 	});
 
+	it("returns a cancellation when an email redundancy is detected", async () => {
+		const error = "Too many emails!";
+		mockDetectEmailRedundancy.mockReturnValue(error);
+		mockGetPrefillOrPromptedOption.mockImplementation(() => undefined);
+
+		expect(await readOptions([])).toStrictEqual({
+			cancelled: true,
+			error,
+			options: {
+				...emptyOptions,
+			},
+		});
+	});
+
 	it("returns a cancellation when the owner prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption.mockImplementation(() => undefined);
 
 		expect(await readOptions([])).toStrictEqual({
@@ -116,6 +139,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when the repository prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementation(() => undefined);
@@ -130,6 +154,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when ensureRepositoryPrompt does not return a repository", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
@@ -147,6 +172,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when the description prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
@@ -167,6 +193,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when the title prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
@@ -189,6 +216,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when the logo alt prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
@@ -211,6 +239,7 @@ describe("readOptions", () => {
 	});
 
 	it("returns a cancellation when the email prompt is cancelled", async () => {
+		mockDetectEmailRedundancy.mockReturnValue(false);
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -210,6 +210,30 @@ describe("readOptions", () => {
 		});
 	});
 
+	it("returns a cancellation when the email prompt is cancelled", async () => {
+		mockGetPrefillOrPromptedOption
+			.mockImplementationOnce(() => "MockOwner")
+			.mockImplementationOnce(() => "MockRepository")
+			.mockImplementationOnce(() => "Mock description.")
+			.mockImplementationOnce(() => "Mock title.")
+			.mockImplementation(() => undefined);
+		mockEnsureRepositoryExists.mockResolvedValue({
+			github: mockOptions.github,
+			repository: mockOptions.repository,
+		});
+
+		expect(await readOptions([])).toStrictEqual({
+			cancelled: true,
+			options: {
+				...emptyOptions,
+				description: "Mock description.",
+				owner: "MockOwner",
+				repository: "MockRepository",
+				title: "Mock title.",
+			},
+		});
+	});
+
 	it("returns success options when --base is valid", async () => {
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import z from "zod";
 
+import { optionsSchemaShape } from "./optionsSchema.js";
 import { readOptions } from "./readOptions.js";
 
 const emptyOptions = {
@@ -25,11 +26,11 @@ const emptyOptions = {
 	funding: undefined,
 	owner: undefined,
 	repository: undefined,
-	skipGitHubApi: false,
-	skipInstall: false,
-	skipRemoval: false,
+	skipGitHubApi: undefined,
+	skipInstall: undefined,
+	skipRemoval: undefined,
 	skipRestore: undefined,
-	skipUninstall: false,
+	skipUninstall: undefined,
 	title: undefined,
 };
 
@@ -75,7 +76,7 @@ vi.mock("./getGitHub.js", () => ({
 }));
 
 vi.mock("./readOptionDefaults/index.js", () => ({
-	getGitAndNpmDefaults() {
+	readOptionDefaults() {
 		return {
 			author: vi.fn(),
 			description: vi.fn(),
@@ -92,13 +93,15 @@ vi.mock("./readOptionDefaults/index.js", () => ({
 describe("readOptions", () => {
 	it("returns a cancellation when an arg is invalid", async () => {
 		const validationResult = z
-			.object({ email: z.string().email() })
-			.safeParse({ email: "wrongEmail" });
+			.object({ base: optionsSchemaShape.base })
+			.safeParse({ base: "b" });
 
-		expect(await readOptions(["--email", "wrongEmail"])).toStrictEqual({
+		const actual = await readOptions(["--base", "b"]);
+
+		expect(actual).toStrictEqual({
 			cancelled: true,
-			options: { ...emptyOptions, email: "wrongEmail" },
-			zodError: (validationResult as z.SafeParseError<{ email: string }>).error,
+			error: (validationResult as z.SafeParseError<{ base: string }>).error,
+			options: { ...emptyOptions, base: "b" },
 		});
 	});
 

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -60,12 +60,11 @@ vi.mock("./getPrefillOrPromptedOption.js", () => ({
 	},
 }));
 
+const mockEnsureRepositoryExists = vi.fn();
+
 vi.mock("./ensureRepositoryExists.js", () => ({
-	ensureRepositoryExists() {
-		return {
-			github: mockOptions.github,
-			repository: mockOptions.repository,
-		};
+	get ensureRepositoryExists() {
+		return mockEnsureRepositoryExists;
 	},
 }));
 
@@ -130,11 +129,32 @@ describe("readOptions", () => {
 		});
 	});
 
+	it("returns a cancellation when ensureRepositoryPrompt does not return a repository", async () => {
+		mockGetPrefillOrPromptedOption
+			.mockImplementationOnce(() => "MockOwner")
+			.mockImplementationOnce(() => "MockRepository")
+			.mockImplementation(() => undefined);
+		mockEnsureRepositoryExists.mockResolvedValue({});
+
+		expect(await readOptions([])).toStrictEqual({
+			cancelled: true,
+			options: {
+				...emptyOptions,
+				owner: "MockOwner",
+				repository: "MockRepository",
+			},
+		});
+	});
+
 	it("returns a cancellation when the description prompt is cancelled", async () => {
 		mockGetPrefillOrPromptedOption
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementation(() => undefined);
+		mockEnsureRepositoryExists.mockResolvedValue({
+			github: mockOptions.github,
+			repository: mockOptions.repository,
+		});
 
 		expect(await readOptions([])).toStrictEqual({
 			cancelled: true,
@@ -152,6 +172,10 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementation(() => undefined);
+		mockEnsureRepositoryExists.mockResolvedValue({
+			github: mockOptions.github,
+			repository: mockOptions.repository,
+		});
 
 		expect(await readOptions([])).toStrictEqual({
 			cancelled: true,
@@ -170,6 +194,10 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementation(() => undefined);
+		mockEnsureRepositoryExists.mockResolvedValue({
+			github: mockOptions.github,
+			repository: mockOptions.repository,
+		});
 
 		expect(await readOptions(["--logo", "logo.svg"])).toStrictEqual({
 			cancelled: true,

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -169,11 +169,22 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 		logo = { alt, src: options.logo };
 	}
 
+	const email =
+		options.email ??
+		(await defaults.email()) ??
+		(await getPrefillOrPromptedOption(
+			undefined,
+			"What email should be used in package.json and .md files?",
+		));
+	if (!email) {
+		return { cancelled: true, options };
+	}
+
 	const augmentedOptions = await augmentOptionsWithExcludes({
 		...options,
 		author: options.author ?? (await defaults.owner()),
 		description: options.description,
-		email: options.email ?? (await defaults.email()),
+		email: typeof email === "string" ? { github: email, npm: email } : email,
 		funding: options.funding ?? (await defaults.funding()),
 		logo,
 		owner: options.owner,

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -79,8 +79,7 @@ export async function readOptions(args: string[]): Promise<OptionsParseResult> {
 	if (emailError) {
 		return {
 			cancelled: true,
-			error:
-				"--email should not be specified if both --email-github and --email-npm are specified.",
+			error: emailError,
 			options: mappedOptions,
 		};
 	}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,7 +34,7 @@ export interface Options {
 	base?: InputBase;
 	createRepository?: boolean;
 	description: string;
-	email?: OptionsEmail;
+	email: OptionsEmail;
 	excludeCompliance?: boolean;
 	excludeContributors?: boolean;
 	excludeLintJson?: boolean;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -24,12 +24,17 @@ export interface OptionsLogo {
 	src: string;
 }
 
+export interface OptionsEmail {
+	github: string;
+	npm: string;
+}
+
 export interface Options {
 	author?: string;
 	base?: InputBase;
 	createRepository?: boolean;
 	description: string;
-	email?: string;
+	email?: OptionsEmail;
 	excludeCompliance?: boolean;
 	excludeContributors?: boolean;
 	excludeLintJson?: boolean;
@@ -47,7 +52,7 @@ export interface Options {
 	logo: OptionsLogo | undefined;
 	owner: string;
 	repository: string;
-	skipGitHubApi: boolean;
+	skipGitHubApi?: boolean;
 	skipInstall?: boolean;
 	skipRemoval?: boolean;
 	skipRestore?: boolean;

--- a/src/steps/finalizeDependencies.test.ts
+++ b/src/steps/finalizeDependencies.test.ts
@@ -21,7 +21,10 @@ const options = {
 	base: "everything",
 	createRepository: undefined,
 	description: "Stub description.",
-	email: undefined,
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -24,7 +24,10 @@ const options = {
 	base: "everything",
 	createRepository: undefined,
 	description: "Stub description.",
-	email: undefined,
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/steps/writeReadme/generateTopContent.test.ts
+++ b/src/steps/writeReadme/generateTopContent.test.ts
@@ -7,7 +7,10 @@ const optionsBase = {
 	base: undefined,
 	createRepository: undefined,
 	description: "",
-	email: undefined,
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/steps/writeReadme/index.test.ts
+++ b/src/steps/writeReadme/index.test.ts
@@ -28,7 +28,10 @@ const options = {
 	base: "everything",
 	createRepository: false,
 	description: "Test description.",
-	email: "test@test.test",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/steps/writing/creation/dotGitHub/createDevelopment.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDevelopment.test.ts
@@ -8,7 +8,10 @@ const options = {
 	base: "everything",
 	createRepository: false,
 	description: "Test description.",
-	email: "test@test.test",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -68,7 +68,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-${options.email}.
+${options.email.github}.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -272,7 +272,7 @@ We take all security vulnerabilities seriously.
 If you have a vulnerability or other security issues to disclose:
 
 - Thank you very much, please do!
-- Please send them to us by emailing \`${options.email}\`
+- Please send them to us by emailing \`${options.email.github}\`
 
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 `,

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -16,7 +16,10 @@ const options = {
 	base: "everything",
 	createRepository: undefined,
 	description: "test-description",
-	email: "test-email",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
 	excludeCompliance: undefined,
 	excludeContributors: undefined,
 	excludeLintJson: undefined,
@@ -73,7 +76,10 @@ describe("writePackageJson", () => {
 		expect(JSON.parse(packageJson)).toMatchInlineSnapshot(`
 			{
 			  "author": {
-			    "email": "test-email",
+			    "email": {
+			      "github": "github@email.com",
+			      "npm": "npm@email.com",
+			    },
 			    "name": "test-author",
 			  },
 			  "description": "test-description",
@@ -144,7 +150,10 @@ describe("writePackageJson", () => {
 		expect(JSON.parse(packageJson)).toMatchInlineSnapshot(`
 			{
 			  "author": {
-			    "email": "test-email",
+			    "email": {
+			      "github": "github@email.com",
+			      "npm": "npm@email.com",
+			    },
 			    "name": "test-author",
 			  },
 			  "description": "test-description",

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -76,10 +76,7 @@ describe("writePackageJson", () => {
 		expect(JSON.parse(packageJson)).toMatchInlineSnapshot(`
 			{
 			  "author": {
-			    "email": {
-			      "github": "github@email.com",
-			      "npm": "npm@email.com",
-			    },
+			    "email": "npm@email.com",
 			    "name": "test-author",
 			  },
 			  "description": "test-description",
@@ -150,10 +147,7 @@ describe("writePackageJson", () => {
 		expect(JSON.parse(packageJson)).toMatchInlineSnapshot(`
 			{
 			  "author": {
-			    "email": {
-			      "github": "github@email.com",
-			      "npm": "npm@email.com",
-			    },
+			    "email": "npm@email.com",
 			    "name": "test-author",
 			  },
 			  "description": "test-description",

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -38,7 +38,7 @@ export async function writePackageJson(options: Options) {
 		// To start, copy over all existing package fields (e.g. "dependencies")
 		...existingPackageJson,
 
-		author: { email: options.email, name: options.author },
+		author: { email: options.email.npm, name: options.author },
 		description: options.description,
 
 		// We copy all existing dev dependencies except those we know are not used anymore


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #542
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Builds off the ideas in #851 by adding optional `--email-github` and `--email-npm` overrides. Adds a string complaint if an improper combination is specified: one of those two without the other or `email`, or both of those two along with `email`. At this point `email` is now a required option.

Adjusts the sorting of rerun suggestions a bit to make sure emails are sorted inline and `--base` comes immediately after `--mode`.

Also fills in some unit test coverage in the area.