### PR TITLE
fix: replace existing description with string, not regex

### DIFF
--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -351,9 +351,37 @@ describe("updateLocalFiles", () => {
 		`);
 	});
 
+	it("does not replace an existing description when it does not exist", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue({});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(options, "initialize");
+
+		expect(mockReplaceInFile).not.toHaveBeenCalledWith({
+			files: ["./.github/**/*", "./*.*"],
+			from: expect.anything(),
+			to: options.description,
+		});
+	});
+	it("replaces an existing description when it exists", async () => {
+		const existingDescription = "Existing description.";
+
+		mockReadFileSafeAsJson.mockResolvedValue({
+			description: existingDescription,
+		});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles(options, "initialize");
+
+		expect(mockReplaceInFile).toHaveBeenCalledWith({
+			files: ["./.github/**/*", "./*.*"],
+			from: existingDescription,
+			to: options.description,
+		});
+	});
+
 	it("removes bin when the mode is initialize", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
-			description: "Existing description",
 			version: "1.2.3",
 		});
 		mockReplaceInFile.mockResolvedValue([]);
@@ -369,7 +397,6 @@ describe("updateLocalFiles", () => {
 
 	it("does not remove bin when the mode is migrate", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
-			description: "Existing description",
 			version: "1.2.3",
 		});
 		mockReplaceInFile.mockResolvedValue([]);
@@ -385,7 +412,6 @@ describe("updateLocalFiles", () => {
 
 	it("resets package version to 0.0.0 when mode is initialize", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
-			description: "Existing description",
 			version: "1.2.3",
 		});
 		mockReplaceInFile.mockResolvedValue([]);
@@ -401,7 +427,6 @@ describe("updateLocalFiles", () => {
 
 	it("does not reset package version to 0.0.0 when mode is migrate", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
-			description: "Existing description",
 			version: "1.2.3",
 		});
 		mockReplaceInFile.mockResolvedValue([]);

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -43,10 +43,7 @@ export async function updateLocalFiles(options: Options, mode: Mode) {
 	];
 
 	if (existingPackage.description) {
-		replacements.push([
-			new RegExp(existingPackage.description, "g"),
-			options.description,
-		]);
+		replacements.push([existingPackage.description, options.description]);
 	}
 
 	if (mode === "initialize" && existingPackage.version) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #803
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies two tangentially related fixes:

* The original description can be replaced with a plain string - it doesn't need a regular expression
* The rerun suggestion for descriptions should escape `$`s