### PR TITLE
fix: remove cancel-in-progress from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 concurrency:
-  cancel-in-progress: true
   group: ${{ github.workflow }}
 
 jobs:
@@ -9,6 +8,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: git config user.name "${GITHUB_ACTOR}"

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -1,7 +1,7 @@
 import { formatYaml } from "../formatters/formatYaml.js";
 
 interface WorkflowFileConcurrency {
-	"cancel-in-progress": boolean;
+	"cancel-in-progress"?: boolean;
 	group: string;
 }
 

--- a/src/steps/writing/creation/dotGitHub/workflows.ts
+++ b/src/steps/writing/creation/dotGitHub/workflows.ts
@@ -153,7 +153,6 @@ export function createWorkflows(options: Options) {
 			}),
 			"release.yml": createWorkflowFile({
 				concurrency: {
-					"cancel-in-progress": true,
 					group: "${{ github.workflow }}",
 				},
 				name: "Release",
@@ -171,6 +170,7 @@ export function createWorkflows(options: Options) {
 						uses: "actions/checkout@v4",
 						with: {
 							"fetch-depth": 0,
+							ref: "main",
 						},
 					},
 					{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #862
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches `actions/checkout@4` to fetch from `ref: main` (the branch) instead of the commit that triggered the workflow. Doing so should mean that every release workflow runs on the latest commit as of when it _starts_.

This should mean that if N release-worthy commits occur quickly:

1. The first one should always finish releasing nicely
2. The remaining 1...N commits will each 

I don't love that this solution results in 1...N release workflows each deleting branch protection, doing nothing, then recreating the branch protection. But given https://github.com/orgs/community/discussions/12835 I don't see a way around it. The branch protection shenanigans should be made better by #145.