### PR TITLE
fix: remove redundant format at end of finalizeDependencies

### DIFF
--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -41,8 +41,8 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 
 	await runCommands("Cleaning up files", [
 		"pnpm dedupe",
-		"pnpm format --write",
 		"pnpm lint --fix",
+		"pnpm format --write",
 	]);
 
 	const sendToGitHub =

--- a/src/steps/finalizeDependencies.test.ts
+++ b/src/steps/finalizeDependencies.test.ts
@@ -64,9 +64,6 @@ describe("finalize", () => {
 			  [
 			    "npx all-contributors-cli generate",
 			  ],
-			  [
-			    "pnpm run format:write",
-			  ],
 			]
 		`);
 	});
@@ -93,9 +90,6 @@ describe("finalize", () => {
 			[
 			  [
 			    "pnpm add @types/eslint@latest @typescript-eslint/eslint-plugin@latest @typescript-eslint/parser@latest eslint@latest eslint-plugin-deprecation@latest eslint-plugin-eslint-comments@latest eslint-plugin-jsdoc@latest eslint-plugin-n@latest eslint-plugin-regexp@latest husky@latest lint-staged@latest prettier@latest prettier-plugin-curly@latest prettier-plugin-packagejson@latest tsup@latest typescript@latest -D",
-			  ],
-			  [
-			    "pnpm run format:write",
 			  ],
 			]
 		`);

--- a/src/steps/finalizeDependencies.ts
+++ b/src/steps/finalizeDependencies.ts
@@ -76,6 +76,4 @@ export async function finalizeDependencies(options: Options) {
 			"-D",
 		);
 	}
-
-	await execaCommand("pnpm run format:write");
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #748
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

🔪.

Also fixes a `lint --fix` command I found that was running after formatting. Lint rule auto-fixers might introduce formatting issues, so they should be run first.