### PR TITLE
chore: use Renovate's minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,6 @@
 	"automerge": true,
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
-	"postUpdateOptions": ["pnpmDedupe"],
-	"stabilityDays": 3
+	"minimumReleaseAge": "3 days",
+	"postUpdateOptions": ["pnpmDedupe"]
 }

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -282,8 +282,8 @@ We appreciate your efforts and responsible disclosure and will make every effort
 				automerge: true,
 				internalChecksFilter: "strict",
 				labels: ["dependencies"],
+				minimumReleaseAge: "3 days",
 				postUpdateOptions: ["pnpmDedupe"],
-				stabilityDays: 3,
 			}),
 		}),
 	};


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #802
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the repo's `.github/renovate.json` and backing template.