### PR TITLE
fix: base suggested next steps on options

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -84,6 +84,10 @@ module.exports = {
 						allowConstantLoopConditions: true,
 					},
 				],
+				"@typescript-eslint/prefer-nullish-coalescing": [
+					"error",
+					{ ignorePrimitives: true },
+				],
 			},
 		},
 		{

--- a/cspell.json
+++ b/cspell.json
@@ -32,6 +32,7 @@
 		"tada",
 		"tsup",
 		"Unstaged",
-		"wontfix"
+		"wontfix",
+		"vitest"
 	]
 }

--- a/src/create/index.ts
+++ b/src/create/index.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { ModeResult } from "../bin/mode.js";
 import { outro } from "../shared/cli/outro.js";
 import { StatusCodes } from "../shared/codes.js";
+import { generateNextSteps } from "../shared/generateNextSteps.js";
 import { readOptions } from "../shared/options/readOptions.js";
 import { runOrRestore } from "../shared/runOrRestore.js";
 import { createAndEnterRepository } from "./createAndEnterRepository.js";
@@ -34,15 +35,11 @@ export async function create(args: string[]): Promise<ModeResult> {
 		code: await runOrRestore({
 			run: async () => {
 				const { sentToGitHub } = await createWithOptions(inputs);
+				const nextSteps = generateNextSteps(inputs.options);
 
 				outro(
 					sentToGitHub
-						? [
-								{
-									label:
-										"Now all you have to do is populate the repository's ACCESS_TOKEN and NPM_TOKEN secrets, and enable the Codecov and Renovate GitHub apps.",
-								},
-						  ]
+						? nextSteps
 						: [
 								{
 									label:
@@ -59,11 +56,9 @@ export async function create(args: string[]): Promise<ModeResult> {
 										`git commit -m "feat: initial commit ✨"`,
 										`git push -u origin main`,
 									],
+									variant: "code",
 								},
-								{
-									label:
-										"If you do, be sure to populate its ACCESS_TOKEN and NPM_TOKEN secrets, and enable the Codecov and Renovate GitHub apps.",
-								},
+								...nextSteps,
 						  ],
 				);
 			},

--- a/src/initialize/index.ts
+++ b/src/initialize/index.ts
@@ -2,6 +2,7 @@ import { ModeRunner } from "../bin/mode.js";
 import { outro } from "../shared/cli/outro.js";
 import { StatusCodes } from "../shared/codes.js";
 import { ensureGitRepository } from "../shared/ensureGitRepository.js";
+import { generateNextSteps } from "../shared/generateNextSteps.js";
 import { readOptions } from "../shared/options/readOptions.js";
 import { runOrRestore } from "../shared/runOrRestore.js";
 import { initializeWithOptions } from "./initializeWithOptions.js";
@@ -31,11 +32,9 @@ export const initialize: ModeRunner = async (args) => {
 							`git commit -m "feat: initialized repo ✨`,
 							`git push`,
 						],
+						variant: "code",
 					},
-					{
-						label:
-							"Otherwise, all you have to do is populate the repository's ACCESS_TOKEN and NPM_TOKEN secrets, and enable the Codecov and Renovate GitHub apps.",
-					},
+					...generateNextSteps(inputs.options),
 				]);
 			},
 			skipRestore: inputs.options.skipRestore,

--- a/src/migrate/index.ts
+++ b/src/migrate/index.ts
@@ -2,6 +2,7 @@ import { ModeRunner } from "../bin/mode.js";
 import { outro } from "../shared/cli/outro.js";
 import { StatusCodes } from "../shared/codes.js";
 import { ensureGitRepository } from "../shared/ensureGitRepository.js";
+import { generateNextSteps } from "../shared/generateNextSteps.js";
 import { readOptions } from "../shared/options/readOptions.js";
 import { runOrRestore } from "../shared/runOrRestore.js";
 import { migrateWithOptions } from "./migrateWithOptions.js";
@@ -31,7 +32,9 @@ export const migrate: ModeRunner = async (args) => {
 							`git commit -m "migrated repo to create-typescript-app ✨`,
 							`git push`,
 						],
+						variant: "code",
 					},
+					...generateNextSteps(inputs.options),
 				]);
 			},
 			skipRestore: inputs.options.skipRestore,

--- a/src/shared/__snapshots__/generateNextSteps.test.ts.snap
+++ b/src/shared/__snapshots__/generateNextSteps.test.ts.snap
@@ -1,0 +1,183 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":false,"excludeRenovate":false,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the GitHub apps: 
+   - Codecov (https://github.com/apps/codecov)
+   - Renovate (https://github.com/apps/renovate)",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":false,"excludeRenovate":false,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Renovate GitHub app (https://github.com/apps/renovate).",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":false,"excludeRenovate":true,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Codecov GitHub app (https://github.com/apps/codecov).",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":false,"excludeRenovate":true,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":true,"excludeRenovate":false,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the GitHub apps: 
+   - Codecov (https://github.com/apps/codecov)
+   - Renovate (https://github.com/apps/renovate)",
+      "- populate the ACCESS_TOKEN secret (a GitHub PAT with repo and workflow permissions).",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":true,"excludeRenovate":false,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Renovate GitHub app (https://github.com/apps/renovate).",
+      "- populate the ACCESS_TOKEN secret (a GitHub PAT with repo and workflow permissions).",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":true,"excludeRenovate":true,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Codecov GitHub app (https://github.com/apps/codecov).",
+      "- populate the ACCESS_TOKEN secret (a GitHub PAT with repo and workflow permissions).",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":false,"excludeReleases":true,"excludeRenovate":true,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to populate the ACCESS_TOKEN secret (a GitHub PAT with repo and workflow permissions).",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":false,"excludeRenovate":false,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the GitHub apps: 
+   - Codecov (https://github.com/apps/codecov)
+   - Renovate (https://github.com/apps/renovate)",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":false,"excludeRenovate":false,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Renovate GitHub app (https://github.com/apps/renovate).",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":false,"excludeRenovate":true,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to:",
+    "lines": [
+      "- enable the Codecov GitHub app (https://github.com/apps/codecov).",
+      "- populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+    ],
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":false,"excludeRenovate":true,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to populate the secrets: 
+   - ACCESS_TOKEN (a GitHub PAT with repo and workflow permissions)
+   - NPM_TOKEN (an npm access token with automation permissions)",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":true,"excludeRenovate":false,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to enable the GitHub apps: 
+   - Codecov (https://github.com/apps/codecov)
+   - Renovate (https://github.com/apps/renovate)",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":true,"excludeRenovate":false,"excludeTests":true} 1`] = `
+[
+  {
+    "label": "Be sure to enable the Renovate GitHub app (https://github.com/apps/renovate).",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":true,"excludeRenovate":true,"excludeTests":false} 1`] = `
+[
+  {
+    "label": "Be sure to enable the Codecov GitHub app (https://github.com/apps/codecov).",
+  },
+]
+`;
+
+exports[`generateNextSteps > {"excludeAllContributors":true,"excludeReleases":true,"excludeRenovate":true,"excludeTests":true} 1`] = `[]`;

--- a/src/shared/cli/outro.test.ts
+++ b/src/shared/cli/outro.test.ts
@@ -37,6 +37,20 @@ describe("outro", () => {
 		expect(mockConsoleLog.mock.calls).toEqual([
 			[chalk.blue("Abc 123")],
 			[],
+			["one"],
+			["two"],
+			[],
+			[chalk.greenBright(`See ya! 👋`)],
+			[],
+		]);
+	});
+
+	it("logs lines as code when variant is specified", () => {
+		outro([{ label: "Abc 123", lines: ["one", "two"], variant: "code" }]);
+
+		expect(mockConsoleLog.mock.calls).toEqual([
+			[chalk.blue("Abc 123")],
+			[],
 			[chalk.gray("one")],
 			[chalk.gray("two")],
 			[],

--- a/src/shared/cli/outro.ts
+++ b/src/shared/cli/outro.ts
@@ -1,21 +1,22 @@
 import * as prompts from "@clack/prompts";
 import chalk from "chalk";
 
-export interface outroGroup {
+export interface OutroGroup {
 	label: string;
 	lines?: string[];
+	variant?: "code";
 }
 
-export function outro(groups: outroGroup[]) {
+export function outro(groups: OutroGroup[]) {
 	prompts.outro(chalk.blue(`Great, looks like the script finished! 🎉`));
 
-	for (const { label, lines } of groups) {
+	for (const { label, lines, variant } of groups) {
 		console.log(chalk.blue(label));
 		console.log();
 
 		if (lines) {
 			for (const line of lines) {
-				console.log(chalk.gray(line));
+				console.log(variant === "code" ? chalk.gray(line) : line);
 			}
 
 			console.log();

--- a/src/shared/generateNextSteps.test.ts
+++ b/src/shared/generateNextSteps.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { generateNextSteps } from "./generateNextSteps.js";
+import { Options } from "./types.js";
+
+const options = {
+	access: "public",
+	base: "everything",
+	description: "Test description.",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
+	logo: undefined,
+	mode: "create",
+	owner: "TestOwner",
+	repository: "test-repository",
+	title: "Test Title",
+} satisfies Options;
+
+describe("generateNextSteps", () => {
+	for (const excludeAllContributors of [false, true]) {
+		for (const excludeReleases of [false, true]) {
+			for (const excludeRenovate of [false, true]) {
+				for (const excludeTests of [false, true]) {
+					test(
+						// eslint-disable-next-line vitest/valid-title
+						JSON.stringify({
+							excludeAllContributors,
+							excludeReleases,
+							excludeRenovate,
+							excludeTests,
+						}),
+						() => {
+							expect(
+								generateNextSteps({
+									...options,
+									excludeAllContributors,
+									excludeReleases,
+									excludeRenovate,
+									excludeTests,
+								}),
+							).toMatchSnapshot();
+						},
+					);
+				}
+			}
+		}
+	}
+});

--- a/src/shared/generateNextSteps.ts
+++ b/src/shared/generateNextSteps.ts
@@ -1,0 +1,69 @@
+import { OutroGroup } from "./cli/outro.js";
+import { Options } from "./types.js";
+
+export function generateNextSteps(options: Options): OutroGroup[] {
+	const lines = [
+		joinedMessage(
+			"enable the",
+			[
+				options.excludeTests || ["Codecov", "https://github.com/apps/codecov"],
+				options.excludeRenovate || [
+					"Renovate",
+					"https://github.com/apps/renovate",
+				],
+			],
+			"GitHub app",
+		),
+		joinedMessage(
+			"populate the",
+			[
+				(options.excludeAllContributors && options.excludeReleases) || [
+					"ACCESS_TOKEN",
+					"a GitHub PAT with repo and workflow permissions",
+				],
+				options.excludeReleases || [
+					"NPM_TOKEN",
+					"an npm access token with automation permissions",
+				],
+			],
+			"secret",
+		),
+	].filter((line): line is string => !!line);
+
+	switch (lines.length) {
+		case 0:
+			return [];
+		case 1:
+			return [{ label: `Be sure to ${lines[0]}` }];
+		default:
+			return [
+				{
+					label: "Be sure to:",
+					lines: lines.map((line) => `- ${line}`),
+				},
+			];
+	}
+}
+
+const itemBreak = "\n   - ";
+
+function joinedMessage(
+	prefix: string,
+	entries: ([string, string] | true)[],
+	suffix: string,
+) {
+	const realEntries = entries.filter(
+		(entry): entry is [string, string] => entry !== true,
+	);
+
+	switch (realEntries.length) {
+		case 0:
+			return undefined;
+		case 1:
+			return `${prefix} ${realEntries[0][0]} ${suffix} (${realEntries[0][1]}).`;
+		default:
+			return `${prefix} ${suffix}s: ${itemBreak}${realEntries
+				.map((entry) => `${entry[0]} (${entry[1]})`)
+				.join(itemBreak)}`;
+	}
+}

--- a/src/shared/options/readOptionDefaults/index.ts
+++ b/src/shared/options/readOptionDefaults/index.ts
@@ -36,11 +36,11 @@ export function readOptionDefaults() {
 			const npmEmail =
 				(await npmDefaults())?.email ?? (await packageAuthor()).email;
 
-			/* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/no-non-null-assertion */
+			/* eslint-disable @typescript-eslint/no-non-null-assertion */
 			return gitEmail || npmEmail
 				? { github: (gitEmail || npmEmail)!, npm: (npmEmail || gitEmail)! }
 				: undefined;
-			/* eslint-enable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/no-non-null-assertion */
+			/* eslint-enable @typescript-eslint/no-non-null-assertion */
 		},
 		funding: async () =>
 			await tryCatchAsync(

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -126,6 +126,7 @@ describe("createESLintRC", () => {
 				    \\"plugin:n/recommended\\",
 				    \\"plugin:perfectionist/recommended-natural\\",
 				    \\"plugin:regexp/recommended\\",
+				    \\"plugin:vitest/recommended\\",
 				  ],
 				  overrides: [
 				    {

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -20,7 +20,9 @@ module.exports = {
 				? ""
 				: `
 		"plugin:perfectionist/recommended-natural",`
-		}${options.excludeLintRegex ? "" : `"plugin:regexp/recommended",`}
+		}${options.excludeLintRegex ? "" : `"plugin:regexp/recommended",`}${
+			options.excludeTests ? "" : `"plugin:vitest/recommended",`
+		}
 	],
 	overrides: [${
 		options.excludeLintMd


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #903
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Pulls the logging of next steps (app(s) and/or token(s) to enable) into a dedicated `generateNextSteps` function, with unit tests. `outro` now allows a `variant` for each group, as this new logging isn't the preivously-always-gray code-style logging.