### PR TITLE
fix: correct create-repository-by-default logic

### DIFF
--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -49,16 +49,10 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 
 	if (sendToGitHub) {
 		await withSpinner("Initializing GitHub repository", async () => {
-			console.log(
-				"git remote",
-				await $`git remote add origin https://github.com/${options.owner}/${options.repository}`,
-			);
-			console.log("git add", await $`git add -A`);
-			console.log(
-				"git commit",
-				await $`git commit --message ${"feat: initialized repo ✨"}`,
-			);
-			console.log("git push", await $`git push -u origin main --force`);
+			await $`git remote add origin https://github.com/${options.owner}/${options.repository}`;
+			await $`git add -A`;
+			await $`git commit --message ${"feat: initialized repo ✨"}`;
+			await $`git push -u origin main --force`;
 			await initializeGitHubRepository(github.octokit, options);
 		});
 	}

--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -49,10 +49,16 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 
 	if (sendToGitHub) {
 		await withSpinner("Initializing GitHub repository", async () => {
-			await $`git remote add origin https://github.com/${options.owner}/${options.repository}`;
-			await $`git add -A`;
-			await $`git commit --message ${"feat: initialized repo ✨"}`;
-			await $`git push -u origin main --force`;
+			console.log(
+				"git remote",
+				await $`git remote add origin https://github.com/${options.owner}/${options.repository}`,
+			);
+			console.log("git add", await $`git add -A`);
+			console.log(
+				"git commit",
+				await $`git commit --message ${"feat: initialized repo ✨"}`,
+			);
+			console.log("git push", await $`git push -u origin main --force`);
 			await initializeGitHubRepository(github.octokit, options);
 		});
 	}

--- a/src/shared/options/ensureRepositoryExists.test.ts
+++ b/src/shared/options/ensureRepositoryExists.test.ts
@@ -38,6 +38,7 @@ const createMockOctokit = () =>
 describe("ensureRepositoryExists", () => {
 	it("returns the repository when octokit is undefined", async () => {
 		const actual = await ensureRepositoryExists(undefined, {
+			mode: "initialize",
 			owner,
 			repository,
 		});
@@ -51,6 +52,7 @@ describe("ensureRepositoryExists", () => {
 		const actual = await ensureRepositoryExists(
 			{ auth, octokit },
 			{
+				mode: "initialize",
 				owner,
 				repository,
 			},
@@ -67,10 +69,7 @@ describe("ensureRepositoryExists", () => {
 
 		const actual = await ensureRepositoryExists(
 			{ auth, octokit },
-			{
-				owner,
-				repository,
-			},
+			{ mode: "initialize", owner, repository },
 		);
 
 		expect(actual).toEqual({ github: { auth, octokit }, repository });
@@ -80,6 +79,26 @@ describe("ensureRepositoryExists", () => {
 			template_owner: "JoshuaKGoldberg",
 			template_repo: "create-typescript-app",
 		});
+	});
+
+	it("defaults to creating a repository when mode is 'create'", async () => {
+		const octokit = createMockOctokit();
+
+		mockDoesRepositoryExist.mockResolvedValue(false);
+
+		const actual = await ensureRepositoryExists(
+			{ auth, octokit },
+			{ mode: "create", owner, repository },
+		);
+
+		expect(actual).toEqual({ github: { auth, octokit }, repository });
+		expect(octokit.rest.repos.createUsingTemplate).toHaveBeenCalledWith({
+			name: repository,
+			owner,
+			template_owner: "JoshuaKGoldberg",
+			template_repo: "create-typescript-app",
+		});
+		expect(mockSelect).not.toHaveBeenCalled();
 	});
 
 	it("returns the second repository when the prompt is 'different', the first repository does not exist, and the second repository exists", async () => {
@@ -94,10 +113,7 @@ describe("ensureRepositoryExists", () => {
 
 		const actual = await ensureRepositoryExists(
 			{ auth, octokit },
-			{
-				owner,
-				repository,
-			},
+			{ mode: "initialize", owner, repository },
 		);
 
 		expect(actual).toEqual({
@@ -119,10 +135,7 @@ describe("ensureRepositoryExists", () => {
 
 		const actual = await ensureRepositoryExists(
 			{ auth, octokit },
-			{
-				owner,
-				repository,
-			},
+			{ mode: "initialize", owner, repository },
 		);
 
 		expect(actual).toEqual({
@@ -145,10 +158,7 @@ describe("ensureRepositoryExists", () => {
 
 		const actual = await ensureRepositoryExists(
 			{ auth, octokit },
-			{
-				owner,
-				repository,
-			},
+			{ mode: "initialize", owner, repository },
 		);
 
 		expect(actual).toEqual({ octokit: undefined, repository });

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -137,6 +137,7 @@ export async function readOptions(
 			? undefined
 			: await withSpinner("Checking GitHub authentication", getGitHub),
 		{
+			mode,
 			owner: options.owner,
 			repository: options.repository,
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #920 (but better)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I remember now why `--create-repository` existed: if `mode` is `create`, then we'll want to attempt creating a new repo by default. So this PR infers a `createRepository` again in `ensureRepositoryExists`.