### PR TITLE
fix: use options.repository for n/no-missing-import's allowedModules

### DIFF
--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -77,10 +77,7 @@ describe("createESLintRC", () => {
 				    {
 				      files: \\"**/*.md/*.ts\\",
 				      rules: {
-				        \\"n/no-missing-import\\": [
-				          \\"error\\",
-				          { allowModules: [\\"create-typescript-app\\"] },
-				        ],
+				        \\"n/no-missing-import\\": [\\"error\\", { allowModules: [\\"test-repository\\"] }],
 				      },
 				    },
 				    {
@@ -162,10 +159,7 @@ describe("createESLintRC", () => {
 				    {
 				      files: \\"**/*.md/*.ts\\",
 				      rules: {
-				        \\"n/no-missing-import\\": [
-				          \\"error\\",
-				          { allowModules: [\\"create-typescript-app\\"] },
-				        ],
+				        \\"n/no-missing-import\\": [\\"error\\", { allowModules: [\\"test-repository\\"] }],
 				      },
 				    },
 				    {

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -82,7 +82,7 @@ module.exports = {
 			rules: {
 				"n/no-missing-import": [
 					"error",
-					{ allowModules: ["create-typescript-app"] },
+					{ allowModules: ["${options.repository}"] },
 				],
 			},
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #923
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Instead of hardcoding the one allowed module name to `create-typescript-app`, uses `options.repository`.