### PR TITLE
feat: use release-it-action for release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,70 +11,10 @@ jobs:
           ref: main
       - uses: ./.github/actions/prepare
       - run: pnpm build
-      - run: git config user.name "${GITHUB_ACTOR}"
-      - run: git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-      - env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-      - name: Delete branch protection on main
-        uses: actions/github-script@v6.4.1
-        with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          script: |
-            try {
-              await github.request(
-                `DELETE /repos/JoshuaKGoldberg/create-typescript-app/branches/main/protection`,
-              );
-            } catch (error) {
-              if (!error.message?.includes?.("Branch not protected")) {
-                throw error;
-              }
-            }
       - env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          if pnpm run should-semantic-release ; then
-            pnpm release-it --verbose
-          fi
-      - if: always()
-        name: Recreate branch protection on main
-        uses: actions/github-script@v6.4.1
-        with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          script: |
-            github.request(
-              `PUT /repos/JoshuaKGoldberg/create-typescript-app/branches/main/protection`,
-              {
-                allow_deletions: false,
-                allow_force_pushes: true,
-                allow_fork_pushes: false,
-                allow_fork_syncing: true,
-                block_creations: false,
-                branch: "main",
-                enforce_admins: false,
-                owner: "JoshuaKGoldberg",
-                repo: "create-typescript-app",
-                required_conversation_resolution: true,
-                required_linear_history: false,
-                required_pull_request_reviews: null,
-                required_status_checks: {
-                  checks: [
-                    { context: "build" },
-                    { context: "compliance" },
-                    { context: "lint" },
-                    { context: "lint_knip" },
-                    { context: "lint_markdown" },
-                    { context: "lint_package_json" },
-                    { context: "lint_packages" },
-                    { context: "lint_spelling" },
-                    { context: "prettier" },
-                    { context: "test" },
-                  ],
-                  strict: false,
-                },
-                restrictions: null,
-              }
-            );
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: JoshuaKGoldberg/release-it-action@v0.2.1
 
 name: Release
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -281,70 +281,10 @@ describe("createWorkflows", () => {
 			          ref: main
 			      - uses: ./.github/actions/prepare
 			      - run: pnpm build
-			      - run: git config user.name \\"\${GITHUB_ACTOR}\\"
-			      - run: git config user.email \\"\${GITHUB_ACTOR}@users.noreply.github.com\\"
-			      - env:
-			          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
-			        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-			      - name: Delete branch protection on main
-			        uses: actions/github-script@v6.4.1
-			        with:
-			          github-token: \${{ secrets.ACCESS_TOKEN }}
-			          script: |
-			                try {
-			                  await github.request(
-			                    \`DELETE /repos/StubOwner/stub-repository/branches/main/protection\`,
-			                  );
-			                } catch (error) {
-			                  if (!error.message?.includes?.(\\"Branch not protected\\")) {
-			                    throw error;
-			                  }
-			                }
 			      - env:
 			          GITHUB_TOKEN: \${{ secrets.ACCESS_TOKEN }}
-			        run: |
-			            if pnpm run should-semantic-release ; then
-			              pnpm release-it --verbose
-			            fi
-			      - if: always()
-			        name: Recreate branch protection on main
-			        uses: actions/github-script@v6.4.1
-			        with:
-			          github-token: \${{ secrets.ACCESS_TOKEN }}
-			          script: |
-			              github.request(
-			                \`PUT /repos/StubOwner/stub-repository/branches/main/protection\`,
-			                {
-			                  allow_deletions: false,
-			                  allow_force_pushes: true,
-			                  allow_fork_pushes: false,
-			                  allow_fork_syncing: true,
-			                  block_creations: false,
-			                  branch: \\"main\\",
-			                  enforce_admins: false,
-			                  owner: \\"StubOwner\\",
-			                  repo: \\"stub-repository\\",
-			                  required_conversation_resolution: true,
-			                  required_linear_history: false,
-			                  required_pull_request_reviews: null,
-			                  required_status_checks: {
-			                    checks: [
-			                      { context: \\"build\\" },
-			                      { context: \\"compliance\\" },
-			                      { context: \\"lint\\" },
-			                      { context: \\"lint_knip\\" },
-			                      { context: \\"lint_markdown\\" },
-			                      { context: \\"lint_package_json\\" },
-			                      { context: \\"lint_packages\\" },
-			                      { context: \\"lint_spelling\\" },
-			                      { context: \\"prettier\\" },
-			                      { context: \\"test\\" },
-			                    ],
-			                    strict: false,
-			                  },
-			                  restrictions: null,
-			                }
-			              );
+			          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
+			        uses: JoshuaKGoldberg/release-it-action@v0.2.1
 
 			name: Release
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -183,85 +183,11 @@ export function createWorkflows(options: Options) {
 						run: "pnpm build",
 					},
 					{
-						run: 'git config user.name "${GITHUB_ACTOR}"',
-					},
-					{
-						run: 'git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"',
-					},
-					{
-						env: {
-							NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
-						},
-						run: "npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN",
-					},
-					{
-						name: "Delete branch protection on main",
-						uses: "actions/github-script@v6.4.1",
-						with: {
-							"github-token": "${{ secrets.ACCESS_TOKEN }}",
-							script: `
-								try {
-									await github.request(
-									  \`DELETE /repos/${options.owner}/${options.repository}/branches/main/protection\`,
-									);
-								} catch (error) {
-									if (!error.message?.includes?.("Branch not protected")) {
-										throw error;
-									}
-								}`,
-						},
-					},
-					{
 						env: {
 							GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}",
+							NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
 						},
-						run: `
-						if pnpm run should-semantic-release ; then
-							pnpm release-it --verbose
-						fi`,
-					},
-					{
-						if: "always()",
-						name: "Recreate branch protection on main",
-						uses: "actions/github-script@v6.4.1",
-						with: {
-							"github-token": "${{ secrets.ACCESS_TOKEN }}",
-							script: `
-							github.request(
-							  \`PUT /repos/${options.owner}/${options.repository}/branches/main/protection\`,
-							  {
-							    allow_deletions: false,
-							    allow_force_pushes: true,
-							    allow_fork_pushes: false,
-							    allow_fork_syncing: true,
-							    block_creations: false,
-							    branch: "main",
-							    enforce_admins: false,
-							    owner: "${options.owner}",
-							    repo: "${options.repository}",
-							    required_conversation_resolution: true,
-							    required_linear_history: false,
-							    required_pull_request_reviews: null,
-							    required_status_checks: {
-							      checks: [
-							        { context: "build" },
-							        { context: "compliance" },
-							        { context: "lint" },
-							        { context: "lint_knip" },
-							        { context: "lint_markdown" },
-							        { context: "lint_package_json" },
-							        { context: "lint_packages" },
-							        { context: "lint_spelling" },
-							        { context: "prettier" },
-							        { context: "test" },
-							      ],
-							      strict: false,
-							    },
-							    restrictions: null,
-							  }
-							);
-						`,
-						},
+						uses: "JoshuaKGoldberg/release-it-action@v0.2.1",
 					},
 				],
 			}),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #145
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses my new https://github.com/JoshuaKGoldberg/release-it-action that contains much of the same logic as the previous `release.yml` contents. I stuck with the "delete and recreate branch protections" approach because (a) it's worked well and (b) other approaches had other limitations. 

I can't be 100% sure this works in this repo until it lands on `main` and tries a few release flows. But I did test it in a separate repo and it worked well there.