### PR TITLE
fix: set emoji for all-contributors badge to 👪

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 	<a href="#contributors" target="_blank">
 <!-- prettier-ignore-start -->
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-<img alt="All Contributors: 30 🤝" src="https://img.shields.io/badge/all_contributors-30_🤝-21bb42.svg" />
+<img alt="All Contributors: 30 👪" src="https://img.shields.io/badge/all_contributors-30_👪-21bb42.svg" />
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- prettier-ignore-end -->
 	</a>

--- a/src/steps/writing/creation/writeAllContributorsRC.ts
+++ b/src/steps/writing/creation/writeAllContributorsRC.ts
@@ -9,7 +9,7 @@ export async function writeAllContributorsRC(options: Options) {
 
 	return await formatJson({
 		badgeTemplate:
-			'<img alt="All Contributors: <%= contributors.length %>" src="https://img.shields.io/badge/all_contributors-<%= contributors.length %>-21bb42.svg" />',
+			'<img alt="All Contributors: <%= contributors.length %> 👪" src="https://img.shields.io/badge/all_contributors-<%= contributors.length %>-21bb42.svg" />',
 		commit: false,
 		commitConvention: "angular",
 		contributors: existing?.contributors ?? [],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #929
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I realized the 🤝 emoji is already used for the code of conduct badge.