### PR TITLE
feat: always run build || exit 0 before lint in CI

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -56,6 +56,8 @@ For example, ESLint can be run with `--fix` to auto-fix some lint rule complaint
 pnpm run lint --fix
 ```
 
+Note that you'll likely need to run `pnpm build` before `pnpm lint` so that lint rules which check the file system can pick up on any built files.
+
 ## Testing
 
 [Vitest](https://vitest.dev) is used for tests.

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -35,7 +35,6 @@ const filesExpectedToBeChanged = new Set([
 	".eslintignore",
 	".eslintrc.cjs",
 	".github/DEVELOPMENT.md",
-	".github/workflows/lint.yml",
 	".github/workflows/lint-knip.yml",
 	".github/workflows/test.yml",
 	".gitignore",

--- a/src/steps/writing/creation/dotGitHub/createDevelopment.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDevelopment.test.ts
@@ -109,6 +109,8 @@ describe("createDevelopment", () => {
 			pnpm run lint --fix
 			\`\`\`
 
+			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
+
 			## Testing
 
 			[Vitest](https://vitest.dev) is used for tests.
@@ -214,6 +216,8 @@ describe("createDevelopment", () => {
 			\`\`\`shell
 			pnpm run lint --fix
 			\`\`\`
+
+			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
 
 			## Testing
 

--- a/src/steps/writing/creation/dotGitHub/createDevelopment.ts
+++ b/src/steps/writing/creation/dotGitHub/createDevelopment.ts
@@ -81,6 +81,8 @@ ESLint can be run with \`--fix\` to auto-fix some lint rule complaints:`
 pnpm run lint --fix
 \`\`\`
 
+Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
+
 ${
 	!options.excludeTests &&
 	`## Testing

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -192,6 +192,7 @@ describe("createWorkflows", () => {
 			    steps:
 			      - uses: actions/checkout@v4
 			      - uses: ./.github/actions/prepare
+			      - run: pnpm build || true
 			      - run: pnpm lint
 
 			name: Lint
@@ -363,6 +364,7 @@ describe("createWorkflows", () => {
 			    steps:
 			      - uses: actions/checkout@v4
 			      - uses: ./.github/actions/prepare
+			      - run: pnpm build || true
 			      - run: pnpm lint
 
 			name: Lint

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -91,7 +91,7 @@ export function createWorkflows(options: Options) {
 		}),
 		"lint.yml": createWorkflowFile({
 			name: "Lint",
-			runs: ["pnpm lint"],
+			runs: ["pnpm build || true", "pnpm lint"],
 		}),
 		...(!options.excludeLintKnip && {
 			"lint-knip.yml": createWorkflowFile({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #935
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds `pnpm build || true` before `pnpm lint` in the templated `lint.yml`. That's what this repo already does, so this essentially makes templated repos more like this one.