### PR TITLE
feat(lint): add `no-useless-rename` and `object-shorthand`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -164,6 +164,8 @@ module.exports = {
 			"error",
 			{ blankLine: "always", next: "*", prev: "block-like" },
 		],
+		"no-useless-rename": "error",
+		"object-shorthand": "error",
 		"perfectionist/sort-objects": [
 			"error",
 			{

--- a/src/shared/options/ensureRepositoryExists.ts
+++ b/src/shared/options/ensureRepositoryExists.ts
@@ -86,5 +86,5 @@ export async function ensureRepositoryExists(
 		}
 	}
 
-	return { github: github, repository };
+	return { github, repository };
 }

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -252,6 +252,8 @@ describe("createESLintRC", () => {
 				      \\"error\\",
 				      { blankLine: \\"always\\", next: \\"*\\", prev: \\"block-like\\" },
 				    ],
+				    \\"no-useless-rename\\": \\"error\\",
+				    \\"object-shorthand\\": \\"error\\",
 				    \\"perfectionist/sort-objects\\": [
 				      \\"error\\",
 				      {

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -212,6 +212,8 @@ module.exports = {
 			"error",
 			{ blankLine: "always", next: "*", prev: "block-like" },
 		],
+		"no-useless-rename": "error",
+		"object-shorthand": "error",
 		`
 		}${
 			options.excludeLintPerfectionist


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [X] Addresses an existing open issue: fixes #939 
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR adds the following rules to the ESLint config:
- [no-useless-rename](https://eslint.org/docs/latest/rules/no-useless-rename)
- [object-shorthand](https://eslint.org/docs/latest/rules/object-shorthand) 

The rules have also been added to the created `.eslintrc` files and the test has been updated. Lint errors have been solved.
