### PR TITLE
feat: skip file cleanup if installation is skipped

### DIFF
--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -36,13 +36,13 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 		await withSpinner("Installing packages", async () =>
 			finalizeDependencies(options),
 		);
-	}
 
-	await runCommands("Cleaning up files", [
-		"pnpm dedupe",
-		"pnpm lint --fix",
-		"pnpm format --write",
-	]);
+		await runCommands("Cleaning up files", [
+			"pnpm dedupe",
+			"pnpm lint --fix",
+			"pnpm format --write",
+		]);
+	}
 
 	const sendToGitHub =
 		github && (await doesRepositoryExist(github.octokit, options));


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #706
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Moved the "Cleaning up files" `runCommand` call inside of the preceding conditional to only run if packages were installed.

For some reason my terminal won't let me put in emojis, so I'll use <(-.-)>
