### PR TITLE
Updated contributors. workflow

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,18 +1,20 @@
-jobs:
-  contributors:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/prepare
-      - env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        uses: JoshuaKGoldberg/all-contributors-auto-action@v0.3.2
-
-name: Contributors
+name: Contributors Comment
 
 on:
-  push:
-    branches:
-      - main
+  issue_comment:
+    types: [created]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Comment on contribution
+        uses: JoshuaKGoldberg/all-contributors-auto-action@v0.3.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          args: comment
+          context: github-actions  
+


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #928 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Certainly, changing the attribution name for the comments made by the GitHub Actions workflow is indeed a good idea, especially if you want to distinguish them from comments made by human users. To do this, you will need to modify the workflow configuration file (.github/workflows/contributors.yml) and change the context field for the comment event.
