### PR TITLE
feat: infer base from package json scripts during migration

### DIFF
--- a/src/shared/options/getBase.test.ts
+++ b/src/shared/options/getBase.test.ts
@@ -4,7 +4,9 @@ import { getBase } from "./getBase.js";
 
 const mockReadPackageData = vi.fn();
 vi.mock("../packages.js", () => ({
-	readPackageData: mockReadPackageData,
+	get readPackageData() {
+		return mockReadPackageData;
+	},
 }));
 
 describe("getBase", () => {

--- a/src/shared/options/getBase.test.ts
+++ b/src/shared/options/getBase.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it, vi } from "vitest";
 
 import { getBase } from "./getBase.js";
 
-const readPackageData = vi.hoisted(() => vi.fn());
+const mockReadPackageData = vi.fn();
 vi.mock("../packages.js", () => ({
-	readPackageData,
+	readPackageData: mockReadPackageData,
 }));
 
 describe("getBase", () => {
 	it("should return minimum with minimum scripts", async () => {
-		readPackageData.mockImplementationOnce(() =>
+		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({
 				scripts: {
 					build: "build",
@@ -22,7 +22,7 @@ describe("getBase", () => {
 		expect(await getBase()).toBe("minimum");
 	});
 	it("should return common with common scripts", async () => {
-		readPackageData.mockImplementationOnce(() =>
+		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({
 				scripts: {
 					build: "build",
@@ -36,7 +36,7 @@ describe("getBase", () => {
 		expect(await getBase()).toBe("common");
 	});
 	it("should return everything with everything scripts", async () => {
-		readPackageData.mockImplementationOnce(() =>
+		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({
 				scripts: {
 					build: "build",

--- a/src/shared/options/getBase.test.ts
+++ b/src/shared/options/getBase.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getBase } from "./getBase.js";
+
+const readPackageData = vi.hoisted(() => vi.fn());
+vi.mock("../packages.js", () => ({
+	readPackageData,
+}));
+
+describe("getBase", () => {
+	it("should return minimum with minimum scripts", async () => {
+		readPackageData.mockImplementationOnce(() =>
+			Promise.resolve({
+				scripts: {
+					build: "build",
+					lint: "lint",
+					test: "test",
+				},
+			}),
+		);
+
+		expect(await getBase()).toBe("minimum");
+	});
+	it("should return common with common scripts", async () => {
+		readPackageData.mockImplementationOnce(() =>
+			Promise.resolve({
+				scripts: {
+					build: "build",
+					lint: "lint",
+					"lint:knip": "knip",
+					test: "test",
+				},
+			}),
+		);
+
+		expect(await getBase()).toBe("common");
+	});
+	it("should return everything with everything scripts", async () => {
+		readPackageData.mockImplementationOnce(() =>
+			Promise.resolve({
+				scripts: {
+					build: "build",
+					lint: "lint",
+					"lint:knip": "knip",
+					"lint:md": "md",
+					"lint:package-json": "package-json",
+					"lint:packages": "packages",
+					test: "test",
+				},
+			}),
+		);
+
+		expect(await getBase()).toBe("everything");
+	});
+});

--- a/src/shared/options/getBase.ts
+++ b/src/shared/options/getBase.ts
@@ -1,0 +1,34 @@
+import { readPackageData } from "../packages.js";
+import { OptionsBase } from "../types.js";
+
+const commonScripts = new Set(["lint:knip", "should-semantic-release", "test"]);
+
+const everythingScripts = new Set([
+	"lint:md",
+	"lint:package-json",
+	"lint:packages",
+	"lint:spelling",
+]);
+export async function getBase(): Promise<OptionsBase> {
+	const scripts = Object.keys((await readPackageData()).scripts ?? {});
+
+	if (
+		scripts.reduce(
+			(acc, curr) => (everythingScripts.has(curr) ? acc + 1 : acc),
+			0,
+		) >= 3
+	) {
+		return "everything";
+	}
+
+	if (
+		scripts.reduce(
+			(acc, curr) => (commonScripts.has(curr) ? acc + 1 : acc),
+			0,
+		) >= 2
+	) {
+		return "common";
+	}
+
+	return "minimum";
+}

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -113,7 +113,9 @@ vi.mock("./createOptionDefaults/index.js", () => ({
 
 const mockReadPackageData = vi.fn();
 vi.mock("../packages.js", () => ({
-	readPackageData: mockReadPackageData,
+	get readPackageData() {
+		return mockReadPackageData;
+	},
 }));
 
 describe("readOptions", () => {

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -111,6 +111,11 @@ vi.mock("./createOptionDefaults/index.js", () => ({
 	},
 }));
 
+const readPackageData = vi.hoisted(() => vi.fn());
+vi.mock("../packages.js", () => ({
+	readPackageData,
+}));
+
 describe("readOptions", () => {
 	it("returns a cancellation when an arg is invalid", async () => {
 		const validationResult = z
@@ -516,6 +521,42 @@ describe("readOptions", () => {
 				guide: undefined,
 				logo: undefined,
 				mode: "create",
+				offline: true,
+				owner: "mock",
+				skipAllContributorsApi: true,
+				skipGitHubApi: true,
+				title: "mock",
+			},
+		});
+	});
+
+	it("infers base from package scripts during migration", async () => {
+		readPackageData.mockImplementationOnce(() =>
+			Promise.resolve({
+				scripts: {
+					build: "build",
+					lint: "lint",
+					test: "test",
+				},
+			}),
+		);
+		expect(await readOptions(["--offline"], "migrate")).toStrictEqual({
+			cancelled: false,
+			github: mockOptions.github,
+			options: {
+				...emptyOptions,
+				...mockOptions,
+				access: "public",
+				base: "minimum",
+				description: "mock",
+				directory: "mock",
+				email: {
+					github: "mock",
+					npm: "mock",
+				},
+				guide: undefined,
+				logo: undefined,
+				mode: "migrate",
 				offline: true,
 				owner: "mock",
 				skipAllContributorsApi: true,

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -111,9 +111,9 @@ vi.mock("./createOptionDefaults/index.js", () => ({
 	},
 }));
 
-const readPackageData = vi.hoisted(() => vi.fn());
+const mockReadPackageData = vi.fn();
 vi.mock("../packages.js", () => ({
-	readPackageData,
+	readPackageData: mockReadPackageData,
 }));
 
 describe("readOptions", () => {
@@ -531,7 +531,7 @@ describe("readOptions", () => {
 	});
 
 	it("infers base from package scripts during migration", async () => {
-		readPackageData.mockImplementationOnce(() =>
+		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({
 				scripts: {
 					build: "build",

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -3,14 +3,14 @@ import { titleCase } from "title-case";
 import { z } from "zod";
 
 import { withSpinner } from "../cli/spinners.js";
-import { readPackageData } from "../packages.js";
-import { Mode, OptionsBase, OptionsGuide, PromptedOptions } from "../types.js";
+import { Mode, OptionsGuide, PromptedOptions } from "../types.js";
 import { Options, OptionsLogo } from "../types.js";
 import { allArgOptions } from "./args.js";
 import { augmentOptionsWithExcludes } from "./augmentOptionsWithExcludes.js";
 import { createOptionDefaults } from "./createOptionDefaults/index.js";
 import { detectEmailRedundancy } from "./detectEmailRedundancy.js";
 import { ensureRepositoryExists } from "./ensureRepositoryExists.js";
+import { getBase } from "./getBase.js";
 import { GitHub, getGitHub } from "./getGitHub.js";
 import { getPrefillOrPromptedOption } from "./getPrefillOrPromptedOption.js";
 import { optionsSchema } from "./optionsSchema.js";
@@ -242,38 +242,4 @@ export async function readOptions(
 		github,
 		options: augmentedOptions,
 	};
-}
-
-async function getBase(): Promise<OptionsBase> {
-	const commonScripts = ["lint:knip", "should-semantic-release", "test"];
-	const everythingScripts = [
-		"lint:md",
-		"lint:package-json",
-		"lint:packages",
-		"lint:spelling",
-	];
-
-	const scripts = await readPackageData().then((pkg) =>
-		pkg.scripts ? Object.keys(pkg.scripts) : [],
-	);
-
-	if (
-		scripts.reduce(
-			(acc, curr) => (everythingScripts.includes(curr) ? acc + 1 : acc),
-			0,
-		) >= 3
-	) {
-		return "everything";
-	}
-
-	if (
-		scripts.reduce(
-			(acc, curr) => (commonScripts.includes(curr) ? acc + 1 : acc),
-			0,
-		) >= 2
-	) {
-		return "common";
-	}
-
-	return "minimum";
 }

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -49,7 +49,6 @@ export async function readOptions(
 		values.base = await getBase();
 	}
 
-	console.log(values.base);
 	const mappedOptions = {
 		access: values.access,
 		author: values.author,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,7 @@ export interface PartialPackageData {
 	email?: string;
 	name?: string;
 	repository?: { type: string; url: string } | string;
+	scripts?: Record<string, string>;
 }
 
 export type OptionsAccess = "public" | "restricted";


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #933
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add a naive solution for checking the existing `package.json` during migration to infer the base.

🐸
