### PR TITLE
feat: enabled prev: multiline-expression for padding-line-between-statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -162,7 +162,11 @@ module.exports = {
 		// Stylistic concerns that don't interfere with Prettier
 		"@typescript-eslint/padding-line-between-statements": [
 			"error",
-			{ blankLine: "always", next: "*", prev: "block-like" },
+			{
+				blankLine: "always",
+				next: "*",
+				prev: ["block-like", "multiline-expression"],
+			},
 		],
 		"no-useless-rename": "error",
 		"object-shorthand": "error",

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -57,6 +57,7 @@ if (unstagedModifiedFiles.length) {
 			(await execaCommand(gitDiffCommand)).stdout
 		}`,
 	);
+
 	console.error(
 		[
 			"",
@@ -72,5 +73,6 @@ if (unstagedModifiedFiles.length) {
 			.map((line) => chalk.red(line))
 			.join("\n"),
 	);
+
 	process.exitCode = 1;
 }

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -73,6 +73,7 @@ describe("bin", () => {
 		expect(mockOutro).toHaveBeenCalledWith(
 			chalk.red("Operation cancelled. Exiting - maybe another time? 👋"),
 		);
+
 		expect(result).toBe(1);
 	});
 
@@ -119,6 +120,7 @@ describe("bin", () => {
 		expect(mockCancel).toHaveBeenCalledWith(
 			`Operation cancelled. Exiting - maybe another time? 👋`,
 		);
+
 		expect(result).toEqual(code);
 	});
 
@@ -142,6 +144,7 @@ describe("bin", () => {
 		expect(mockCancel).toHaveBeenCalledWith(
 			`Operation cancelled. Exiting - maybe another time? 👋`,
 		);
+
 		expect(result).toEqual(code);
 	});
 
@@ -167,9 +170,11 @@ describe("bin", () => {
 		expect(mockLogLine).toHaveBeenCalledWith(
 			chalk.red('Validation error: Invalid email at "email"'),
 		);
+
 		expect(mockCancel).toHaveBeenCalledWith(
 			`Operation cancelled. Exiting - maybe another time? 👋`,
 		);
+
 		expect(result).toEqual(code);
 	});
 
@@ -188,6 +193,7 @@ describe("bin", () => {
 		expect(mockCancel).toHaveBeenCalledWith(
 			`Operation failed. Exiting - maybe another time? 👋`,
 		);
+
 		expect(result).toEqual(code);
 	});
 });

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -31,6 +31,7 @@ export async function bin(args: string[]) {
 			"⚠️ This template is early stage, opinionated, and not endorsed by the TypeScript team. ⚠️",
 		),
 	);
+
 	logLine(
 		chalk.yellow(
 			"⚠️ If any tooling it sets displeases you, you can always remove that portion manually. ⚠️",
@@ -68,6 +69,7 @@ export async function bin(args: string[]) {
 			logLine(
 				chalk.red(typeof error === "string" ? error : fromZodError(error)),
 			);
+
 			logLine();
 		}
 

--- a/src/bin/promptForMode.test.ts
+++ b/src/bin/promptForMode.test.ts
@@ -35,6 +35,7 @@ vi.mock("../shared/cli/lines.js", () => ({
 		return mockLogLine;
 	},
 }));
+
 describe("promptForMode", () => {
 	it("returns an error when the input exists and is not a mode", async () => {
 		const mode = await promptForMode("other");
@@ -69,6 +70,7 @@ describe("promptForMode", () => {
 			mode: "create",
 			options: { directory: ".", repository: directory },
 		});
+
 		expect(mockLogLine).not.toHaveBeenCalled();
 	});
 
@@ -84,6 +86,7 @@ describe("promptForMode", () => {
 		expect(actual).toEqual({
 			mode: "create",
 		});
+
 		expect(mockLogLine).not.toHaveBeenCalled();
 	});
 

--- a/src/create/index.test.ts
+++ b/src/create/index.test.ts
@@ -63,6 +63,7 @@ describe("create", () => {
 			code: StatusCodes.Failure,
 			options: optionsBase,
 		});
+
 		expect(mockOutro).toHaveBeenCalledWith(
 			chalk.red(
 				"The TestDirectory directory already exists and is not empty. Please clear the directory, run with --mode initialize, or try a different directory.",

--- a/src/create/index.ts
+++ b/src/create/index.ts
@@ -27,6 +27,7 @@ export const create: ModeRunner = async (args, promptedOptions) => {
 				`The ${inputs.options.directory} directory already exists and is not empty. Please clear the directory, run with --mode initialize, or try a different directory.`,
 			),
 		);
+
 		return { code: StatusCodes.Failure, options: inputs.options };
 	}
 

--- a/src/shared/doesRepositoryExist.ts
+++ b/src/shared/doesRepositoryExist.ts
@@ -16,6 +16,7 @@ export async function doesRepositoryExist(
 			owner: options.owner,
 			repo: options.repository,
 		});
+
 		return true;
 	} catch (error) {
 		if ((error as RequestError).status !== 404) {

--- a/src/shared/getGitHubUserAsAllContributor.test.ts
+++ b/src/shared/getGitHubUserAsAllContributor.test.ts
@@ -76,6 +76,7 @@ describe("getGitHubUserAsAllContributor", () => {
 				`Couldn't authenticate GitHub user, falling back to the provided owner name '${owner}'.`,
 			),
 		);
+
 		expect(mock$.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [

--- a/src/shared/getGitHubUserAsAllContributor.ts
+++ b/src/shared/getGitHubUserAsAllContributor.ts
@@ -16,6 +16,7 @@ export async function getGitHubUserAsAllContributor(
 				`Skipping populating all-contributors contributions for ${options.owner} because in --offline mode.`,
 			),
 		);
+
 		return options.owner;
 	}
 
@@ -29,6 +30,7 @@ export async function getGitHubUserAsAllContributor(
 				`Couldn't authenticate GitHub user, falling back to the provided owner name '${options.owner}'.`,
 			),
 		);
+
 		user = options.owner;
 	}
 

--- a/src/shared/options/createOptionDefaults/index.test.ts
+++ b/src/shared/options/createOptionDefaults/index.test.ts
@@ -40,6 +40,7 @@ describe("createOptionDefaults", () => {
 			mock$.mockImplementation(([command]: string[]) =>
 				command === "npm whoami" ? { stdout: "npm-username" } : undefined,
 			);
+
 			mockNpmUser.mockImplementation((username: string) => ({
 				email: `test@${username}.com`,
 			}));
@@ -74,6 +75,7 @@ describe("createOptionDefaults", () => {
 					? { stdout: "test@git.com" }
 					: undefined,
 			);
+
 			mockReadPackageData.mockResolvedValue({});
 
 			const actual = await createOptionDefaults().email();
@@ -91,6 +93,7 @@ describe("createOptionDefaults", () => {
 						? "test@git.com"
 						: "npm-username",
 			}));
+
 			mockReadPackageData.mockResolvedValue({});
 
 			const actual = await createOptionDefaults().email();

--- a/src/shared/options/createRepositoryWithApi.test.ts
+++ b/src/shared/options/createRepositoryWithApi.test.ts
@@ -47,11 +47,13 @@ describe("createRepositoryWithApi", () => {
 				login: options.owner,
 			},
 		});
+
 		await createRepositoryWithApi(createMockOctokit(), options);
 
 		expect(mockCreateForAuthenticatedUser).toHaveBeenCalledWith({
 			name: options.repository,
 		});
+
 		expect(mockCreateInOrg).not.toHaveBeenCalled();
 		expect(mockCreateUsingTemplate).not.toHaveBeenCalled();
 	});
@@ -66,6 +68,7 @@ describe("createRepositoryWithApi", () => {
 			name: options.repository,
 			org: options.owner,
 		});
+
 		expect(mockCreateUsingTemplate).not.toHaveBeenCalled();
 	});
 });

--- a/src/shared/options/createRepositoryWithApi.ts
+++ b/src/shared/options/createRepositoryWithApi.ts
@@ -17,6 +17,7 @@ export async function createRepositoryWithApi(
 			template_owner: "JoshuaKGoldberg",
 			template_repo: "create-typescript-app",
 		});
+
 		return;
 	}
 

--- a/src/shared/options/ensureRepositoryExists.test.ts
+++ b/src/shared/options/ensureRepositoryExists.test.ts
@@ -101,6 +101,7 @@ describe("ensureRepositoryExists", () => {
 			preserveGeneratedFrom: undefined,
 			repository,
 		});
+
 		expect(mockSelect).not.toHaveBeenCalled();
 	});
 
@@ -111,6 +112,7 @@ describe("ensureRepositoryExists", () => {
 		mockDoesRepositoryExist
 			.mockResolvedValueOnce(false)
 			.mockResolvedValueOnce(true);
+
 		mockSelect.mockResolvedValueOnce("different");
 		mockText.mockResolvedValue(newRepository);
 
@@ -123,6 +125,7 @@ describe("ensureRepositoryExists", () => {
 			github: { auth, octokit },
 			repository: newRepository,
 		});
+
 		expect(mockCreateRepositoryWithApi).not.toHaveBeenCalled();
 	});
 
@@ -134,6 +137,7 @@ describe("ensureRepositoryExists", () => {
 		mockSelect
 			.mockResolvedValueOnce("different")
 			.mockResolvedValueOnce("create");
+
 		mockText.mockResolvedValue(newRepository);
 
 		const actual = await ensureRepositoryExists(
@@ -145,6 +149,7 @@ describe("ensureRepositoryExists", () => {
 			github: { auth, octokit },
 			repository: newRepository,
 		});
+
 		expect(mockCreateRepositoryWithApi).toHaveBeenCalledWith(octokit, {
 			owner,
 			preserveGeneratedFrom: undefined,

--- a/src/shared/options/ensureRepositoryExists.ts
+++ b/src/shared/options/ensureRepositoryExists.ts
@@ -64,6 +64,7 @@ export async function ensureRepositoryExists(
 					preserveGeneratedFrom: options.preserveGeneratedFrom,
 					repository,
 				});
+
 				return { github, repository };
 
 			case "different":

--- a/src/shared/options/getBase.test.ts
+++ b/src/shared/options/getBase.test.ts
@@ -23,6 +23,7 @@ describe("getBase", () => {
 
 		expect(await getBase()).toBe("minimum");
 	});
+
 	it("should return common with common scripts", async () => {
 		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({
@@ -37,6 +38,7 @@ describe("getBase", () => {
 
 		expect(await getBase()).toBe("common");
 	});
+
 	it("should return everything with everything scripts", async () => {
 		mockReadPackageData.mockImplementationOnce(() =>
 			Promise.resolve({

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -180,6 +180,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({});
 
 		expect(await readOptions([], "create")).toStrictEqual({
@@ -198,6 +199,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockOwner")
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -220,6 +222,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -244,6 +247,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementationOnce(() => "Mock Title")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -272,6 +276,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementationOnce(() => "Mock Title")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -299,6 +304,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "MockRepository")
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -324,6 +330,7 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementationOnce(() => "Mock title.")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
@@ -349,10 +356,12 @@ describe("readOptions", () => {
 			.mockImplementationOnce(() => "Mock description.")
 			.mockImplementationOnce(() => "Mock title.")
 			.mockImplementation(() => undefined);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
 		});
+
 		mockAugmentOptionsWithExcludes.mockResolvedValue(undefined);
 
 		expect(await readOptions([], "create")).toStrictEqual({
@@ -372,6 +381,7 @@ describe("readOptions", () => {
 			...emptyOptions,
 			...mockOptions,
 		});
+
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
@@ -395,6 +405,7 @@ describe("readOptions", () => {
 			...emptyOptions,
 			...mockOptions,
 		});
+
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
@@ -449,10 +460,12 @@ describe("readOptions", () => {
 				...mockOptions,
 			}),
 		);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
 		});
+
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 
 		expect(
@@ -473,10 +486,12 @@ describe("readOptions", () => {
 				...mockOptions,
 			}),
 		);
+
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
 			repository: mockOptions.repository,
 		});
+
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 
 		expect(
@@ -499,6 +514,7 @@ describe("readOptions", () => {
 			...mockOptions,
 			...options,
 		}));
+
 		mockGetPrefillOrPromptedOption.mockImplementation(() => "mock");
 		mockEnsureRepositoryExists.mockResolvedValue({
 			github: mockOptions.github,
@@ -542,6 +558,7 @@ describe("readOptions", () => {
 				},
 			}),
 		);
+
 		expect(await readOptions(["--offline"], "migrate")).toStrictEqual({
 			cancelled: false,
 			github: mockOptions.github,

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -123,6 +123,7 @@ export async function readOptions(
 		"What organization or user will the repository be under?",
 		defaults.owner,
 	);
+
 	if (!options.owner) {
 		return {
 			cancelled: true,
@@ -134,6 +135,7 @@ export async function readOptions(
 		"What will the kebab-case name of the repository be?",
 		defaults.repository,
 	);
+
 	if (!options.repository) {
 		return {
 			cancelled: true,
@@ -160,6 +162,7 @@ export async function readOptions(
 		async () =>
 			(await defaults.description()) ?? "A very lovely package. Hooray!",
 	);
+
 	if (!options.description) {
 		return { cancelled: true, options };
 	}
@@ -169,6 +172,7 @@ export async function readOptions(
 		async () =>
 			(await defaults.title()) ?? titleCase(repository).replaceAll("-", " "),
 	);
+
 	if (!options.title) {
 		return { cancelled: true, options };
 	}

--- a/src/shared/runOrRestore.test.ts
+++ b/src/shared/runOrRestore.test.ts
@@ -56,6 +56,7 @@ describe("runOrRestore", () => {
 				skipRestore: false,
 			},
 		});
+
 		mockConfirm.mockResolvedValue(false);
 
 		const actual = await runOrRestore({
@@ -74,6 +75,7 @@ describe("runOrRestore", () => {
 				skipRestore: false,
 			},
 		});
+
 		mockConfirm.mockResolvedValue(true);
 
 		const actual = await runOrRestore({

--- a/src/shared/runOrRestore.ts
+++ b/src/shared/runOrRestore.ts
@@ -33,6 +33,7 @@ export async function runOrRestore({ run, skipRestore }: RunOrRestoreOptions) {
 						chalk.reset`git restore .`,
 					].join(" "),
 				);
+
 				await $`git restore .`;
 			}
 		}

--- a/src/steps/addOwnerAsAllContributor.test.ts
+++ b/src/steps/addOwnerAsAllContributor.test.ts
@@ -42,6 +42,7 @@ describe("addOwnerAsAllContributor", () => {
 		mock$.mockResolvedValueOnce({
 			stdout: JSON.stringify({ login: "user" }),
 		});
+
 		mockReadFileAsJson.mockResolvedValue("invalid");
 
 		await expect(async () => {
@@ -55,6 +56,7 @@ describe("addOwnerAsAllContributor", () => {
 		mock$.mockResolvedValueOnce({
 			stdout: JSON.stringify({ login: "user" }),
 		});
+
 		mockReadFileAsJson.mockResolvedValue({});
 
 		await expect(async () => {
@@ -68,6 +70,7 @@ describe("addOwnerAsAllContributor", () => {
 		mock$.mockResolvedValueOnce({
 			stdout: JSON.stringify({ login: mockOwner }),
 		});
+
 		mockReadFileAsJson.mockResolvedValue({
 			contributors: [],
 		});
@@ -89,6 +92,7 @@ describe("addOwnerAsAllContributor", () => {
 		mock$.mockResolvedValueOnce({
 			stdout: JSON.stringify({ login: mockOwner }),
 		});
+
 		mockReadFileAsJson.mockResolvedValue({
 			contributors: [
 				{ contributions: ["bug", "fix"], login: mockOwner },

--- a/src/steps/runCommands.test.ts
+++ b/src/steps/runCommands.test.ts
@@ -60,6 +60,7 @@ describe("runCommands", () => {
 				chalk.yellow(`\` failed. You should run it and fix its complaints.`),
 			].join(""),
 		);
+
 		expect(mockLogLine).toHaveBeenCalledWith(
 			[
 				chalk.yellow(`🟡 Running \``),

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -366,12 +366,14 @@ describe("updateLocalFiles", () => {
 			to: options.description,
 		});
 	});
+
 	it("replaces an existing description when it exists", async () => {
 		const existingDescription = "Existing description.";
 
 		mockReadFileSafeAsJson.mockResolvedValue({
 			description: existingDescription,
 		});
+
 		mockReplaceInFile.mockResolvedValue([]);
 
 		await updateLocalFiles({ ...options, mode: "initialize" });
@@ -387,6 +389,7 @@ describe("updateLocalFiles", () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
 			version: "1.2.3",
 		});
+
 		mockReplaceInFile.mockResolvedValue([]);
 
 		await updateLocalFiles({ ...options, mode: "initialize" });
@@ -402,6 +405,7 @@ describe("updateLocalFiles", () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
 			version: "1.2.3",
 		});
+
 		mockReplaceInFile.mockResolvedValue([]);
 
 		await updateLocalFiles({ ...options, mode: "migrate" });
@@ -417,6 +421,7 @@ describe("updateLocalFiles", () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
 			version: "1.2.3",
 		});
+
 		mockReplaceInFile.mockResolvedValue([]);
 
 		await updateLocalFiles({ ...options, mode: "initialize" });
@@ -432,6 +437,7 @@ describe("updateLocalFiles", () => {
 		mockReadFileSafeAsJson.mockResolvedValue({
 			version: "1.2.3",
 		});
+
 		mockReplaceInFile.mockResolvedValue([]);
 
 		await updateLocalFiles({ ...options, mode: "migrate" });

--- a/src/steps/writeReadme/index.ts
+++ b/src/steps/writeReadme/index.ts
@@ -46,6 +46,7 @@ export async function writeReadme(options: Options) {
 				.filter(Boolean)
 				.join("\n\n"),
 		);
+
 		return;
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1001
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Hmm. Not as pretty as I'd been hoping. Maybe there's more configuration I can do... will investigate eventually.