### PR TITLE
fix: typo in a11y bot creation

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -14,12 +14,12 @@ on:
       - edited
   issues:
     types:
-      - opened
       - edited
+      - opened
   pull_request:
     types:
-      - opened
       - edited
+      - opened
 
 permissions:
   issues: write

--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -8,17 +8,17 @@ jobs:
 name: Accessibility Alt Text Bot
 
 on:
-  issue:
-    types:
-      - created
-      - edited
   issue_comment:
     types:
       - created
       - edited
+  issues:
+    types:
+      - opened
+      - edited
   pull_request:
     types:
-      - created
+      - opened
       - edited
 
 permissions:

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -6,10 +6,10 @@ interface WorkflowFileConcurrency {
 }
 
 interface WorkflowFileOn {
-	issue?: {
+	issue_comment?: {
 		types?: string[];
 	};
-	issue_comment?: {
+	issues?: {
 		types?: string[];
 	};
 	pull_request?:

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -51,17 +51,17 @@ describe("createWorkflows", () => {
 			name: Accessibility Alt Text Bot
 
 			on:
-			  issue:
-			    types:
-			      - created
-			      - edited
 			  issue_comment:
 			    types:
 			      - created
 			      - edited
+			  issues:
+			    types:
+			      - opened
+			      - edited
 			  pull_request:
 			    types:
-			      - created
+			      - opened
 			      - edited
 
 			permissions:
@@ -378,17 +378,17 @@ describe("createWorkflows", () => {
 			name: Accessibility Alt Text Bot
 
 			on:
-			  issue:
-			    types:
-			      - created
-			      - edited
 			  issue_comment:
 			    types:
 			      - created
 			      - edited
+			  issues:
+			    types:
+			      - opened
+			      - edited
 			  pull_request:
 			    types:
-			      - created
+			      - opened
 			      - edited
 
 			permissions:

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -57,12 +57,12 @@ describe("createWorkflows", () => {
 			      - edited
 			  issues:
 			    types:
-			      - opened
 			      - edited
+			      - opened
 			  pull_request:
 			    types:
-			      - opened
 			      - edited
+			      - opened
 
 			permissions:
 			  issues: write
@@ -384,12 +384,12 @@ describe("createWorkflows", () => {
 			      - edited
 			  issues:
 			    types:
-			      - opened
 			      - edited
+			      - opened
 			  pull_request:
 			    types:
-			      - opened
 			      - edited
+			      - opened
 
 			permissions:
 			  issues: write

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -96,10 +96,10 @@ export function createWorkflows(options: Options) {
 					types: ["created", "edited"],
 				},
 				issues: {
-					types: ["opened", "edited"],
+					types: ["edited", "opened"],
 				},
 				pull_request: {
-					types: ["opened", "edited"],
+					types: ["edited", "opened"],
 				},
 			},
 			permissions: {

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -92,14 +92,14 @@ export function createWorkflows(options: Options) {
 		"accessibility-alt-text-bot.yml": createWorkflowFile({
 			name: "Accessibility Alt Text Bot",
 			on: {
-				issue: {
-					types: ["created", "edited"],
-				},
 				issue_comment: {
 					types: ["created", "edited"],
 				},
+				issues: {
+					types: ["opened", "edited"],
+				},
 				pull_request: {
-					types: ["created", "edited"],
+					types: ["opened", "edited"],
 				},
 			},
 			permissions: {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [X] Addresses an existing open issue: fixes #999 
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR fixes an error associated with the newly implemented `accessibility-alt-text-bot` which was introduced by writing `issue` instead of `issues`.
I also looked into the GH actions docs and noticed that `created` is not a possible option on issues and pull requests - replaced with `opened`.
