### PR TITLE
chore: remove unnecessary if in a11y-alt-bot

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -2,8 +2,7 @@ jobs:
   accessibility_alt_text_bot:
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ github.event.issue || github.event.pull_request }}
-        uses: github/accessibility-alt-text-bot@v1.4.0
+      - uses: github/accessibility-alt-text-bot@v1.4.0
 
 name: Accessibility Alt Text Bot
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -45,8 +45,7 @@ describe("createWorkflows", () => {
 			  accessibility_alt_text_bot:
 			    runs-on: ubuntu-latest
 			    steps:
-			      - if: \${{ github.event.issue || github.event.pull_request }}
-			        uses: github/accessibility-alt-text-bot@v1.4.0
+			      - uses: github/accessibility-alt-text-bot@v1.4.0
 
 			name: Accessibility Alt Text Bot
 
@@ -372,8 +371,7 @@ describe("createWorkflows", () => {
 			  accessibility_alt_text_bot:
 			    runs-on: ubuntu-latest
 			    steps:
-			      - if: \${{ github.event.issue || github.event.pull_request }}
-			        uses: github/accessibility-alt-text-bot@v1.4.0
+			      - uses: github/accessibility-alt-text-bot@v1.4.0
 
 			name: Accessibility Alt Text Bot
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -108,7 +108,6 @@ export function createWorkflows(options: Options) {
 			},
 			steps: [
 				{
-					if: "${{ github.event.issue || github.event.pull_request }}",
 					uses: "github/accessibility-alt-text-bot@v1.4.0",
 				},
 			],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [X] Addresses an existing open issue: fixes #997
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR is hopefully the last one in the series of getting the `accessibility-alt-text-bot` correct by removing the unnecessary `if` statement in the `yml` job
