### PR TITLE
fix: allow empty paths for updating local files

### DIFF
--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -80,6 +80,7 @@ describe("updateLocalFiles", () => {
 			[
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -90,6 +91,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -100,6 +102,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -110,6 +113,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": ".eslintrc.cjs",
 			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
 			      "to": "",
@@ -117,6 +121,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"author": "\\.\\+"/g,
 			      "to": "\\"author\\": \\"undefined\\"",
@@ -124,6 +129,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"bin": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -131,6 +137,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:create": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -138,6 +145,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:initialize": "\\.\\*/g,
 			      "to": "",
@@ -145,6 +153,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"initialize": "\\.\\*/g,
 			      "to": "",
@@ -152,6 +161,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:migrate": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -159,6 +169,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./README.md",
 			      "from": /## Getting Started\\.\\*## Development/gs,
 			      "to": "## Development",
@@ -166,6 +177,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./.github/DEVELOPMENT.md",
 			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
 			      "to": "",
@@ -173,6 +185,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "		\\"src/initialize/index.ts\\",
 			",
@@ -181,6 +194,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "		\\"src/migrate/index.ts\\",
 			",
@@ -189,6 +203,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
 			      "to": "\\"src/index.ts!\\"",
@@ -196,6 +211,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
 			      "to": "\\"src/**/*.ts!\\"",
@@ -203,6 +219,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./README.md",
 			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
 			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
@@ -222,6 +239,7 @@ describe("updateLocalFiles", () => {
 			[
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -232,6 +250,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -242,6 +261,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -252,6 +272,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": ".eslintrc.cjs",
 			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
 			      "to": "",
@@ -259,6 +280,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"author": "\\.\\+"/g,
 			      "to": "\\"author\\": \\"undefined\\"",
@@ -266,6 +288,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"bin": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -273,6 +296,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:create": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -280,6 +304,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:initialize": "\\.\\*/g,
 			      "to": "",
@@ -287,6 +312,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"initialize": "\\.\\*/g,
 			      "to": "",
@@ -294,6 +320,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./package.json",
 			      "from": /"test:migrate": "\\.\\+\\\\n/g,
 			      "to": "",
@@ -301,6 +328,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./README.md",
 			      "from": /## Getting Started\\.\\*## Development/gs,
 			      "to": "## Development",
@@ -308,6 +336,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./.github/DEVELOPMENT.md",
 			      "from": /\\\\n## Setup Scripts\\.\\*\\$/gs,
 			      "to": "",
@@ -315,6 +344,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "		\\"src/initialize/index.ts\\",
 			",
@@ -323,6 +353,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "		\\"src/migrate/index.ts\\",
 			",
@@ -331,6 +362,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/index.ts!\\", \\"script/initialize*.js\\"]",
 			      "to": "\\"src/index.ts!\\"",
@@ -338,6 +370,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./knip.jsonc",
 			      "from": "[\\"src/**/*.ts!\\", \\"script/**/*.js\\"]",
 			      "to": "\\"src/**/*.ts!\\"",
@@ -345,6 +378,7 @@ describe("updateLocalFiles", () => {
 			  ],
 			  [
 			    {
+			      "allowEmptyPaths": true,
 			      "files": "./README.md",
 			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
 			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
@@ -361,6 +395,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "initialize" });
 
 		expect(mockReplaceInFile).not.toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: ["./.github/**/*", "./*.*"],
 			from: expect.anything(),
 			to: options.description,
@@ -377,6 +412,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "initialize" });
 
 		expect(mockReplaceInFile).toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: ["./.github/**/*", "./*.*"],
 			from: existingDescription,
 			to: options.description,
@@ -392,6 +428,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "initialize" });
 
 		expect(mockReplaceInFile).toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: "./package.json",
 			from: /"bin": ".+\n/g,
 			to: "",
@@ -407,6 +444,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "migrate" });
 
 		expect(mockReplaceInFile).not.toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: "./package.json",
 			from: /"bin": ".+\n/g,
 			to: "",
@@ -422,6 +460,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "initialize" });
 
 		expect(mockReplaceInFile).toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: "./package.json",
 			from: /"version": "1.2.3"/g,
 			to: '"version": "0.0.0"',
@@ -437,6 +476,7 @@ describe("updateLocalFiles", () => {
 		await updateLocalFiles({ ...options, mode: "migrate" });
 
 		expect(mockReplaceInFile).not.toHaveBeenCalledWith({
+			allowEmptyPaths: true,
 			files: "./package.json",
 			from: /"version": "1.2.3"/g,
 			to: '"version": "0.0.0"',

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -58,7 +58,12 @@ export async function updateLocalFiles(options: Options) {
 	for (const [from, to, files = ["./.github/**/*", "./*.*"]] of replacements) {
 		try {
 			// @ts-expect-error -- https://github.com/microsoft/TypeScript/issues/54342
-			await replaceInFile({ files, from, to });
+			await replaceInFile({
+				allowEmptyPaths: true,
+				files,
+				from,
+				to,
+			});
 		} catch (error) {
 			throw new Error(
 				`Failed to replace ${from.toString()} with ${to} in ${files.toString()}`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1015
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Brings in https://github.com/adamreisnz/replace-in-file/#allow-emptyinvalid-paths to avoid crashing.