### PR TITLE
feat: add -v flag to display version

### DIFF
--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -2,6 +2,7 @@ import chalk from "chalk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import z from "zod";
 
+import { getVersionFromPackageJson } from "./packageJson.js";
 import { bin } from "./index.js";
 
 const mockCancel = vi.fn();
@@ -63,6 +64,7 @@ vi.mock("./promptForMode.js", () => ({
 describe("bin", () => {
 	beforeEach(() => {
 		vi.spyOn(console, "clear").mockImplementation(() => undefined);
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
 	});
 
 	it("returns 1 when promptForMode returns an undefined mode", async () => {
@@ -189,5 +191,15 @@ describe("bin", () => {
 			`Operation failed. Exiting - maybe another time? 👋`,
 		);
 		expect(result).toEqual(code);
+	});
+
+	it("prints the version when the --version flag is passed", async () => {
+		const args = ["--version"];
+		const version = await getVersionFromPackageJson();
+
+		const result = await bin(args);
+
+		expect(console.log).toHaveBeenCalledWith(version);
+		expect(result).toBe(0);
 	});
 });

--- a/src/bin/index.test.ts
+++ b/src/bin/index.test.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import z from "zod";
 
-import { getVersionFromPackageJson } from "./packageJson.js";
 import { bin } from "./index.js";
+import { getVersionFromPackageJson } from "./packageJson.js";
 
 const mockCancel = vi.fn();
 const mockOutro = vi.fn();

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -44,14 +44,21 @@ export async function bin(args: string[]) {
 				type: "boolean",
 			},
 			mode: { type: "string" },
+			version: {
+				short: "v",
+				type: "boolean",
+			},
 		},
 		strict: false,
 	});
 
-	const help = values.help;
-
-	if (help) {
+	if (values.help) {
 		logHelpText([introPrompts, ...introWarnings]);
+		return 0;
+	}
+
+	if (values.version) {
+		console.log(version);
 		return 0;
 	}
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #704
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
I was browsing the list of issues labeled `good first issue` and saw that issue #704 had its attached PR closed. The version feature has basically already been implemented, but this just adds the flag to display the version.

🧢