### PR TITLE
feat: add --bin option

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -53,6 +53,7 @@ The setup scripts also allow for optional overrides of the following inputs whos
 
 - `--access` _(`"public" | "restricted"`)_: Which [`npm publish --access`](https://docs.npmjs.com/cli/commands/npm-publish#access) to release npm packages with (by default, `"public"`)
 - `--author` _(`string`)_: Username on npm to publish packages under (by default, an existing npm author, or the currently logged in npm user, or `owner.toLowerCase()`)
+- `--bin` _(`string`)_: `package.json` bin value to include for npx-style running.
 - `--directory` _(`string`)_: Directory to create the repository in (by default, the same name as the repository)
 - `--email` _(`string`)_: Email address to be listed as the point of contact in docs and packages (e.g. `example@joshuakgoldberg.com`)
   - Optionally, `--email-github` _(`string`)_ and/or `--email-npm` _(`string`)_ may be provided to use different emails in `.md` files and `package.json`, respectively

--- a/src/bin/help.test.ts
+++ b/src/bin/help.test.ts
@@ -122,6 +122,10 @@ describe("logHelpText", () => {
 			  ],
 			  [
 			    "
+			  --bin (string): package.json bin value to include for npx-style running.",
+			  ],
+			  [
+			    "
 			  --directory (string): Directory to create the repository in (by default, the same 
 			  name as the repository)",
 			  ],

--- a/src/shared/options/args.ts
+++ b/src/shared/options/args.ts
@@ -31,6 +31,11 @@ export const allArgOptions = {
 		docsSection: "core",
 		type: "string",
 	},
+	bin: {
+		description: `package.json bin value to include for npx-style running.`,
+		docsSection: "optional",
+		type: "string",
+	},
 	"create-repository": {
 		description: `Whether to create a corresponding repository on github.com 
   (if it doesn't yet exist)`,

--- a/src/shared/options/createOptionDefaults/index.test.ts
+++ b/src/shared/options/createOptionDefaults/index.test.ts
@@ -35,6 +35,26 @@ vi.mock("../../packages.js", () => ({
 }));
 
 describe("createOptionDefaults", () => {
+	describe("bin", () => {
+		it("returns undefined when package data does not have a bin", async () => {
+			mockReadPackageData.mockResolvedValue({});
+
+			const actual = await createOptionDefaults().bin();
+
+			expect(actual).toBeUndefined();
+		});
+
+		it("returns the bin when package data has a bin", async () => {
+			const bin = "./lib/index.js";
+
+			mockReadPackageData.mockResolvedValue({ bin });
+
+			const actual = await createOptionDefaults().bin();
+
+			expect(actual).toBe(bin);
+		});
+	});
+
 	describe("email", () => {
 		it("returns the npm whoami email from npm when only an npm exists", async () => {
 			mock$.mockImplementation(([command]: string[]) =>

--- a/src/shared/options/createOptionDefaults/index.ts
+++ b/src/shared/options/createOptionDefaults/index.ts
@@ -30,6 +30,7 @@ export function createOptionDefaults(promptedOptions?: PromptedOptions) {
 
 	return {
 		author: async () => (await packageAuthor()).author ?? npmDefaults.name,
+		bin: async () => (await packageData()).bin,
 		description: async () => (await packageData()).description,
 		email: async () => {
 			const gitEmail = await tryCatchAsync(

--- a/src/shared/options/optionsSchema.ts
+++ b/src/shared/options/optionsSchema.ts
@@ -12,6 +12,7 @@ export const optionsSchemaShape = {
 			z.literal("prompt"),
 		])
 		.optional(),
+	bin: z.string().optional(),
 	description: z.string().optional(),
 	directory: z.string().optional(),
 	email: z

--- a/src/shared/options/readOptions.test.ts
+++ b/src/shared/options/readOptions.test.ts
@@ -10,6 +10,7 @@ const emptyOptions = {
 	author: undefined,
 	auto: false,
 	base: undefined,
+	bin: undefined,
 	description: undefined,
 	directory: undefined,
 	email: undefined,

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -55,6 +55,7 @@ export async function readOptions(
 		author: values.author,
 		auto: !!values.auto,
 		base: values.base,
+		bin: values.bin,
 		description: values.description,
 		directory: values.directory,
 		email:

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -13,6 +13,7 @@ export interface AllContributorsData {
 
 export interface PartialPackageData {
 	author?: { email: string; name: string } | string;
+	bin?: string;
 	dependencies?: Record<string, string>;
 	description?: string;
 	devDependencies?: Record<string, string>;
@@ -48,6 +49,7 @@ export interface Options {
 	access: OptionsAccess;
 	author?: string;
 	base?: OptionsBase;
+	bin?: string;
 	description: string;
 	directory: string;
 	email: OptionsEmail;

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -41,6 +41,7 @@ export async function writePackageJson(options: Options) {
 		...existingPackageJson,
 
 		author: { email: options.email.npm, name: options.author },
+		bin: options.bin,
 		description: options.description,
 		keywords: options.keywords?.length
 			? options.keywords.flatMap((keyword) => keyword.split(/ /))


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #938
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the `--bin` option with auto-detection from existing `package.json` contents.

Doesn't do anything about investigating whether to adjust `pnpm build` before `pnpm lint` & similar. That can be a followup.