### PR TITLE
fix: improve migration owner replacements

### DIFF
--- a/script/initialize-test-e2e.js
+++ b/script/initialize-test-e2e.js
@@ -30,7 +30,7 @@ for (const search of [`/JoshuaKGoldberg/`, "create-typescript-app"]) {
 	const { stdout } = await $`grep -i ${search} ${files}`;
 	assert.equal(
 		stdout,
-		`README.md:> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
+		`README.md:> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
 	);
 }
 

--- a/src/initialize/initializeWithOptions.ts
+++ b/src/initialize/initializeWithOptions.ts
@@ -22,7 +22,12 @@ export async function initializeWithOptions({
 				await updateLocalFiles(options);
 			},
 		],
-		["Updating README.md", updateReadme],
+		[
+			"Updating README.md",
+			async () => {
+				await updateReadme(options);
+			},
+		],
 		["Clearing changelog", clearChangelog],
 		[
 			"Updating all-contributors table",

--- a/src/steps/createJoshuaKGoldbergReplacement.test.ts
+++ b/src/steps/createJoshuaKGoldbergReplacement.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+
+import { createJoshuaKGoldbergReplacement } from "./createJoshuaKGoldbergReplacement.js";
+
+const options = {
+	owner: "NewOwner",
+	repository: "new-repository",
+};
+
+describe("createJoshuaKGoldbergReplacement", () => {
+	test.each([
+		[`JoshuaKGoldberg`, options.owner],
+		[
+			`JoshuaKGoldberg/${options.repository}`,
+			`${options.owner}/${options.repository}`,
+		],
+		[`JoshuaKGoldberg/other-repository`, `JoshuaKGoldberg/other-repository`],
+	])("%s", (before, expected) => {
+		const [matcher, replacer] = createJoshuaKGoldbergReplacement(options);
+
+		const actual = replacer(before, matcher.exec(before)?.[1]);
+
+		expect(actual).toBe(expected);
+	});
+});

--- a/src/steps/createJoshuaKGoldbergReplacement.ts
+++ b/src/steps/createJoshuaKGoldbergReplacement.ts
@@ -1,0 +1,18 @@
+import { Options } from "../shared/types.js";
+
+export const createJoshuaKGoldbergReplacement = (
+	options: Pick<Options, "owner" | "repository">,
+) =>
+	[
+		/JoshuaKGoldberg(?:\/(.+))?/g,
+		(full: string, capture: string | undefined) =>
+			capture
+				? // If this was a "JoshuaKGoldberg/..." repository link,
+				  // swap the owner if it's the repository being migrated.
+				  capture.startsWith(options.repository)
+					? `${options.owner}/${capture}`
+					: full
+				: // Otherwise it's just "JoshuaKGoldberg" standalone,
+				  // so swap to the new owner.
+				  options.owner,
+	] as const;

--- a/src/steps/createJoshuaKGoldbergReplacement.ts
+++ b/src/steps/createJoshuaKGoldbergReplacement.ts
@@ -1,5 +1,9 @@
 import { Options } from "../shared/types.js";
 
+/**
+ * Creates a replace-in-file replacement for JoshuaKGoldberg/... matches,
+ * keeping repository names not being migrated (e.g. for GitHub actions).
+ */
 export const createJoshuaKGoldbergReplacement = (
 	options: Pick<Options, "owner" | "repository">,
 ) =>

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -75,8 +75,8 @@ describe("updateLocalFiles", () => {
 			        "./.github/**/*",
 			        "./*.*",
 			      ],
-			      "from": /JoshuaKGoldberg\\(\\?!\\\\/console-fail-test\\)/g,
-			      "to": "StubOwner",
+			      "from": /JoshuaKGoldberg\\(\\?:\\\\/\\(\\.\\+\\)\\)\\?/g,
+			      "to": [Function],
 			    },
 			  ],
 			  [
@@ -200,8 +200,8 @@ describe("updateLocalFiles", () => {
 			    {
 			      "allowEmptyPaths": true,
 			      "files": "./README.md",
-			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
-			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
+			      "from": /> 💙 This package was templated with \\.\\+\\\\\\./g,
+			      "to": "> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).",
 			    },
 			  ],
 			]
@@ -234,8 +234,8 @@ describe("updateLocalFiles", () => {
 			        "./.github/**/*",
 			        "./*.*",
 			      ],
-			      "from": /JoshuaKGoldberg\\(\\?!\\\\/console-fail-test\\)/g,
-			      "to": "StubOwner",
+			      "from": /JoshuaKGoldberg\\(\\?:\\\\/\\(\\.\\+\\)\\)\\?/g,
+			      "to": [Function],
 			    },
 			  ],
 			  [
@@ -359,8 +359,8 @@ describe("updateLocalFiles", () => {
 			    {
 			      "allowEmptyPaths": true,
 			      "files": "./README.md",
-			      "from": "> 💙 This package is based on [@StubOwner](https://github.com/StubOwner)'s [stub-repository](https://github.com/JoshuaKGoldberg/stub-repository).",
-			      "to": "> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).",
+			      "from": /> 💙 This package was templated with \\.\\+\\\\\\./g,
+			      "to": "> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).",
 			    },
 			  ],
 			]

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -82,6 +82,14 @@ describe("updateLocalFiles", () => {
 			  [
 			    {
 			      "allowEmptyPaths": true,
+			      "files": "package.json",
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
 			      "files": [
 			        "./.github/**/*",
 			        "./*.*",
@@ -236,6 +244,14 @@ describe("updateLocalFiles", () => {
 			      ],
 			      "from": /JoshuaKGoldberg\\(\\?:\\\\/\\(\\.\\+\\)\\)\\?/g,
 			      "to": [Function],
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": "package.json",
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
 			    },
 			  ],
 			  [

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -2,6 +2,7 @@ import replaceInFile from "replace-in-file";
 
 import { readFileSafeAsJson } from "../shared/readFileSafeAsJson.js";
 import { Options } from "../shared/types.js";
+import { createJoshuaKGoldbergReplacement } from "./createJoshuaKGoldbergReplacement.js";
 import { endOfReadmeTemplateLine } from "./updateReadme.js";
 
 interface ExistingPackageData {
@@ -15,19 +16,7 @@ export async function updateLocalFiles(options: Options) {
 
 	const replacements = [
 		[/Create TypeScript App/g, options.title],
-		[
-			/JoshuaKGoldberg(?:\/(.+))?/g,
-			(full: string, capture: string | undefined) =>
-				capture
-					? // If this was a "JoshuaKGoldberg/..." repository link,
-					  // swap the owner if it's the repository being migrated.
-					  capture.startsWith(options.repository)
-						? `${options.owner}/${capture}`
-						: full
-					: // Otherwise it's just "JoshuaKGoldberg" standalone,
-					  // so swap to the new owner.
-					  options.owner,
-		],
+		createJoshuaKGoldbergReplacement(options),
 		[/create-typescript-app/g, options.repository],
 		[/\/\*\n.+\*\/\n\n/gs, ``, ".eslintrc.cjs"],
 		[/"author": ".+"/g, `"author": "${options.author}"`, "./package.json"],

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -78,8 +78,9 @@ export async function updateLocalFiles(options: Options) {
 				to,
 			});
 		} catch (error) {
+			const toString = typeof to === "function" ? "(function)" : to;
 			throw new Error(
-				`Failed to replace ${from.toString()} with ${to} in ${files.toString()}`,
+				`Failed to replace ${from.toString()} with ${toString} in ${files.toString()}`,
 				{
 					cause: error,
 				},

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -2,6 +2,7 @@ import replaceInFile from "replace-in-file";
 
 import { readFileSafeAsJson } from "../shared/readFileSafeAsJson.js";
 import { Options } from "../shared/types.js";
+import { endOfReadmeTemplateLine } from "./updateReadme.js";
 
 interface ExistingPackageData {
 	description?: string;
@@ -14,7 +15,19 @@ export async function updateLocalFiles(options: Options) {
 
 	const replacements = [
 		[/Create TypeScript App/g, options.title],
-		[/JoshuaKGoldberg(?!\/console-fail-test)/g, options.owner],
+		[
+			/JoshuaKGoldberg(?:\/(.+))?/g,
+			(full: string, capture: string | undefined) =>
+				capture
+					? // If this was a "JoshuaKGoldberg/..." repository link,
+					  // swap the owner if it's the repository being migrated.
+					  capture.startsWith(options.repository)
+						? `${options.owner}/${capture}`
+						: full
+					: // Otherwise it's just "JoshuaKGoldberg" standalone,
+					  // so swap to the new owner.
+					  options.owner,
+		],
 		[/create-typescript-app/g, options.repository],
 		[/\/\*\n.+\*\/\n\n/gs, ``, ".eslintrc.cjs"],
 		[/"author": ".+"/g, `"author": "${options.author}"`, "./package.json"],
@@ -37,8 +50,8 @@ export async function updateLocalFiles(options: Options) {
 		[`["src/**/*.ts!", "script/**/*.js"]`, `"src/**/*.ts!"`, "./knip.jsonc"],
 		// Edge case: migration scripts will rewrite README.md attribution
 		[
-			`> 💙 This package is based on [@${options.owner}](https://github.com/${options.owner})'s [${options.repository}](https://github.com/JoshuaKGoldberg/${options.repository}).`,
-			`> 💙 This package is based on [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg)'s [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
+			/> 💙 This package was templated with .+\./g,
+			endOfReadmeTemplateLine,
 			"./README.md",
 		],
 	];

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -17,6 +17,7 @@ export async function updateLocalFiles(options: Options) {
 	const replacements = [
 		[/Create TypeScript App/g, options.title],
 		createJoshuaKGoldbergReplacement(options),
+		[/JoshuaKGoldberg/g, options.owner, "package.json"],
 		[/create-typescript-app/g, options.repository],
 		[/\/\*\n.+\*\/\n\n/gs, ``, ".eslintrc.cjs"],
 		[/"author": ".+"/g, `"author": "${options.author}"`, "./package.json"],

--- a/src/steps/updateReadme.test.ts
+++ b/src/steps/updateReadme.test.ts
@@ -33,7 +33,7 @@ describe("updateReadme", () => {
 			    "
 			<!-- You can remove this notice if you don't want it 🙂 no worries! -->
 
-			> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+			> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).
 			",
 			  ],
 			]

--- a/src/steps/updateReadme.ts
+++ b/src/steps/updateReadme.ts
@@ -3,11 +3,13 @@ import { EOL } from "node:os";
 
 import { readFileSafe } from "../shared/readFileSafe.js";
 
+export const endOfReadmeTemplateLine = `> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).`;
+
 export const endOfReadmeNotice = [
 	``,
 	`<!-- You can remove this notice if you don't want it 🙂 no worries! -->`,
 	``,
-	`> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).`,
+	endOfReadmeTemplateLine,
 	``,
 ].join(EOL);
 

--- a/src/steps/updateReadme.ts
+++ b/src/steps/updateReadme.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import { EOL } from "node:os";
 
 import { readFileSafe } from "../shared/readFileSafe.js";
+import { Options } from "../shared/types.js";
 
 export const endOfReadmeTemplateLine = `> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).`;
 
@@ -16,10 +17,14 @@ export const endOfReadmeNotice = [
 export const endOfReadmeMatcher =
 	/💙.+(?:based|built|templated).+(?:from|using|on|with).+create-typescript-app/;
 
-export async function updateReadme() {
-	const contents = await readFileSafe("./README.md", "");
+export async function updateReadme(options: Pick<Options, "owner">) {
+	let contents = await readFileSafe("./README.md", "");
+
+	contents = contents.replaceAll("JoshuaKGoldberg", options.owner);
 
 	if (!endOfReadmeMatcher.test(contents)) {
-		await fs.appendFile("./README.md", endOfReadmeNotice);
+		contents += endOfReadmeNotice;
 	}
+
+	await fs.writeFile("./README.md", contents);
 }

--- a/src/steps/writeReadme/index.test.ts
+++ b/src/steps/writeReadme/index.test.ts
@@ -95,7 +95,7 @@ describe("writeReadme", () => {
 
 			<!-- You can remove this notice if you don't want it 🙂 no worries! -->
 
-			> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+			> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).
 			",
 			  ],
 			]
@@ -156,7 +156,7 @@ describe("writeReadme", () => {
 
 			<!-- You can remove this notice if you don't want it 🙂 no worries! -->
 
-			> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+			> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).
 			",
 			  ],
 			]
@@ -220,7 +220,7 @@ describe("writeReadme", () => {
 
 			<!-- You can remove this notice if you don't want it 🙂 no worries! -->
 
-			> 💙 This package was templated with [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
+			> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app).
 			",
 			  ],
 			]

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -163,8 +163,8 @@ There are two steps involved:
 
 ### Finding an Issue
 
-With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/${options.owner}/${options.repository}/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/${options.owner}/${options.repository}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
 If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
 #### Issue Claiming


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1043
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses a [`to` callback](https://github.com/adamreisnz/replace-in-file/#using-callbacks-for-to) to determine whether to swap out owner to `options.owner` in `"JoshuaKGoldberg"` _(always)_ or `"JoshuaKGoldberg/..."` (if the `...` is `options.repository`).

Also fixes some existing edge cases around owner replacements:

* Syncs up the end-of-readme attribution notice so there's only one place it's written in the templates
* Uses `options.owner` and `options.repository` in `createDotGitHubFiles` instead of hardcoding `JoshuaKGoldberg/create-typescript-app`.