### PR TITLE
fix: corrected readOptions using provided values

### DIFF
--- a/src/shared/options/getPrefillOrPromptedOption.test.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.test.ts
@@ -16,23 +16,23 @@ describe("getPrefillOrPromptedValue", () => {
 	it("returns the placeholder when auto is true and it exists", async () => {
 		const value = "Test Value";
 
-		const actual = await getPrefillOrPromptedOption(
-			"field",
-			true,
-			"Input message.",
-			vi.fn().mockResolvedValue(value),
-		);
+		const actual = await getPrefillOrPromptedOption({
+			auto: true,
+			getDefaultValue: vi.fn().mockResolvedValue(value),
+			message: "Input message.",
+			name: "field",
+		});
 
 		expect(actual).toEqual({ error: undefined, value });
 	});
 
 	it("returns an error when auto is true and no placeholder exists", async () => {
-		const actual = await getPrefillOrPromptedOption(
-			"field",
-			true,
-			"Input message.",
-			vi.fn().mockResolvedValue(undefined),
-		);
+		const actual = await getPrefillOrPromptedOption({
+			auto: true,
+			getDefaultValue: vi.fn().mockResolvedValue(undefined),
+			message: "Input message.",
+			name: "field",
+		});
 
 		expect(actual).toEqual({
 			error: "Could not infer a default value for field.",
@@ -43,7 +43,7 @@ describe("getPrefillOrPromptedValue", () => {
 	it("provides no placeholder when one is not provided and auto is false", async () => {
 		const message = "Test message";
 
-		await getPrefillOrPromptedOption("Input message.", false, message);
+		await getPrefillOrPromptedOption({ auto: false, message, name: "field" });
 
 		expect(mockText).toHaveBeenCalledWith({
 			message,
@@ -56,12 +56,12 @@ describe("getPrefillOrPromptedValue", () => {
 		const message = "Test message";
 		const placeholder = "Test placeholder";
 
-		const actual = await getPrefillOrPromptedOption(
-			"field",
-			false,
+		const actual = await getPrefillOrPromptedOption({
+			auto: false,
+			getDefaultValue: vi.fn().mockResolvedValue(placeholder),
 			message,
-			vi.fn().mockResolvedValue(placeholder),
-		);
+			name: "field",
+		});
 
 		expect(actual).toEqual({
 			error: undefined,
@@ -73,7 +73,7 @@ describe("getPrefillOrPromptedValue", () => {
 	it("validates entered text when it's not  blank and auto is false", async () => {
 		const message = "Test message";
 
-		await getPrefillOrPromptedOption("Input message.", false, message);
+		await getPrefillOrPromptedOption({ auto: false, message, name: "field" });
 
 		const { validate } = (mockText.mock.calls[0] as [Required<TextOptions>])[0];
 
@@ -83,7 +83,7 @@ describe("getPrefillOrPromptedValue", () => {
 	it("invalidates entered text when it's blank and auto is false", async () => {
 		const message = "";
 
-		await getPrefillOrPromptedOption("Input message.", false, message);
+		await getPrefillOrPromptedOption({ auto: false, message, name: "field" });
 
 		const { validate } = (mockText.mock.calls[0] as [Required<TextOptions>])[0];
 

--- a/src/shared/options/getPrefillOrPromptedOption.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.ts
@@ -2,12 +2,19 @@ import * as prompts from "@clack/prompts";
 
 import { filterPromptCancel } from "../prompts.js";
 
-export async function getPrefillOrPromptedOption(
-	name: string,
-	auto: boolean,
-	message: string,
-	getDefaultValue?: () => Promise<string | undefined>,
-) {
+export interface GetPrefillOrPromptedOptionOptions {
+	auto: boolean;
+	getDefaultValue?: () => Promise<string | undefined>;
+	message: string;
+	name: string;
+}
+
+export async function getPrefillOrPromptedOption({
+	auto,
+	getDefaultValue,
+	message,
+	name,
+}: GetPrefillOrPromptedOptionOptions) {
 	const defaultValue = await getDefaultValue?.();
 
 	if (auto || defaultValue) {

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -122,12 +122,12 @@ export async function readOptions(
 
 	const options = optionsParseResult.data;
 
-	const ownerOption = await getPrefillOrPromptedOption(
-		"owner",
-		!!mappedOptions.auto,
-		"What organization or user will the repository be under?",
-		async () => options.owner ?? (await defaults.owner()),
-	);
+	const ownerOption = await getPrefillOrPromptedOption({
+		auto: !!mappedOptions.auto,
+		getDefaultValue: async () => options.owner ?? (await defaults.owner()),
+		message: "What organization or user will the repository be under?",
+		name: "owner",
+	});
 
 	options.owner ??= ownerOption.value;
 
@@ -139,12 +139,13 @@ export async function readOptions(
 		};
 	}
 
-	const repositoryOption = await getPrefillOrPromptedOption(
-		"repository",
-		!!mappedOptions.auto,
-		"What will the kebab-case name of the repository be?",
-		async () => options.repository ?? (await defaults.repository()),
-	);
+	const repositoryOption = await getPrefillOrPromptedOption({
+		auto: !!mappedOptions.auto,
+		getDefaultValue: async () =>
+			options.repository ?? (await defaults.repository()),
+		message: "What will the kebab-case name of the repository be?",
+		name: "repository",
+	});
 
 	options.repository ??= repositoryOption.value;
 
@@ -171,15 +172,15 @@ export async function readOptions(
 		return { cancelled: true, error: repositoryOption.error, options };
 	}
 
-	const descriptionOption = await getPrefillOrPromptedOption(
-		"description",
-		!!mappedOptions.auto,
-		"How would you describe the new package?",
-		async () =>
+	const descriptionOption = await getPrefillOrPromptedOption({
+		auto: !!mappedOptions.auto,
+		getDefaultValue: async () =>
 			options.description ??
 			(await defaults.description()) ??
 			"A very lovely package. Hooray!",
-	);
+		message: "How would you describe the new package?",
+		name: "description",
+	});
 
 	options.description ??= descriptionOption.value;
 
@@ -187,15 +188,15 @@ export async function readOptions(
 		return { cancelled: true, error: descriptionOption.error, options };
 	}
 
-	const titleOption = await getPrefillOrPromptedOption(
-		"title",
-		!!mappedOptions.auto,
-		"What will the Title Case title of the repository be?",
-		async () =>
+	const titleOption = await getPrefillOrPromptedOption({
+		auto: !!mappedOptions.auto,
+		getDefaultValue: async () =>
 			options.title ??
 			(await defaults.title()) ??
 			titleCase(repository).replaceAll("-", " "),
-	);
+		message: "What will the Title Case title of the repository be?",
+		name: "title",
+	});
 
 	options.title ??= titleOption.value;
 
@@ -209,11 +210,11 @@ export async function readOptions(
 		if (options.guideTitle) {
 			guide = { href: options.guide, title: options.guideTitle };
 		} else {
-			const titleOption = await getPrefillOrPromptedOption(
-				"getPrefillOrPromptedOption",
-				!!mappedOptions.auto,
-				"What is the title text for the guide?",
-			);
+			const titleOption = await getPrefillOrPromptedOption({
+				auto: !!mappedOptions.auto,
+				message: "What is the title text for the guide?",
+				name: "getPrefillOrPromptedOption",
+			});
 
 			if (!titleOption.value) {
 				return { cancelled: true, error: titleOption.error, options };
@@ -229,11 +230,11 @@ export async function readOptions(
 		if (options.logoAlt) {
 			logo = { alt: options.logoAlt, src: options.logo };
 		} else {
-			const logoAltOption = await getPrefillOrPromptedOption(
-				"getPrefillOrPromptedOption",
-				!!mappedOptions.auto,
-				"What is the alt text (non-visual description) of the logo?",
-			);
+			const logoAltOption = await getPrefillOrPromptedOption({
+				auto: !!mappedOptions.auto,
+				message: "What is the alt text (non-visual description) of the logo?",
+				name: "getPrefillOrPromptedOption",
+			});
 
 			if (!logoAltOption.value) {
 				return { cancelled: true, error: logoAltOption.error, options };
@@ -246,11 +247,11 @@ export async function readOptions(
 	let email = options.email ?? (await defaults.email());
 
 	if (!email) {
-		const emailOption = await getPrefillOrPromptedOption(
-			"email",
-			!!mappedOptions.auto,
-			"What email should be used in package.json and .md files?",
-		);
+		const emailOption = await getPrefillOrPromptedOption({
+			auto: !!mappedOptions.auto,
+			message: "What email should be used in package.json and .md files?",
+			name: "email",
+		});
 
 		if (!emailOption.value) {
 			return { cancelled: true, error: emailOption.error, options };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1083
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Prepends `options.owner` in front of the default value getter. Same with other options values.

The unit test doesn't quite catch this specific addition but I'm annoyed at how convoluted `readOptions` has gotten...