### PR TITLE
fix: prompt for values when auto is off, regardless of a default value

### DIFF
--- a/src/shared/options/getPrefillOrPromptedOption.test.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.test.ts
@@ -13,7 +13,21 @@ vi.mock("@clack/prompts", () => ({
 }));
 
 describe("getPrefillOrPromptedValue", () => {
-	it("returns the placeholder when auto is true and it exists", async () => {
+	it("returns the provided when it exists", async () => {
+		const value = "Test Value";
+
+		const actual = await getPrefillOrPromptedOption({
+			auto: true,
+			getDefaultValue: vi.fn().mockResolvedValue("default value"),
+			message: "Input message.",
+			name: "field",
+			provided: value,
+		});
+
+		expect(actual).toEqual({ error: undefined, value });
+	});
+
+	it("returns the default value when auto is true and it exists", async () => {
 		const value = "Test Value";
 
 		const actual = await getPrefillOrPromptedOption({
@@ -26,7 +40,7 @@ describe("getPrefillOrPromptedValue", () => {
 		expect(actual).toEqual({ error: undefined, value });
 	});
 
-	it("returns an error when auto is true and no placeholder exists", async () => {
+	it("returns an error when auto is true and no default value exists", async () => {
 		const actual = await getPrefillOrPromptedOption({
 			auto: true,
 			getDefaultValue: vi.fn().mockResolvedValue(undefined),
@@ -52,22 +66,22 @@ describe("getPrefillOrPromptedValue", () => {
 		});
 	});
 
-	it("provides the placeholder's awaited return when a placeholder function is provided and auto is false", async () => {
+	it("prompts with the default value as a placeholder when a placeholder function is provided and auto is false", async () => {
 		const message = "Test message";
 		const placeholder = "Test placeholder";
 
-		const actual = await getPrefillOrPromptedOption({
+		await getPrefillOrPromptedOption({
 			auto: false,
 			getDefaultValue: vi.fn().mockResolvedValue(placeholder),
 			message,
 			name: "field",
 		});
 
-		expect(actual).toEqual({
-			error: undefined,
-			value: placeholder,
+		expect(mockText).toHaveBeenCalledWith({
+			message,
+			placeholder,
+			validate: expect.any(Function),
 		});
-		expect(mockText).not.toHaveBeenCalled();
 	});
 
 	it("validates entered text when it's not  blank and auto is false", async () => {

--- a/src/shared/options/getPrefillOrPromptedOption.ts
+++ b/src/shared/options/getPrefillOrPromptedOption.ts
@@ -7,6 +7,7 @@ export interface GetPrefillOrPromptedOptionOptions {
 	getDefaultValue?: () => Promise<string | undefined>;
 	message: string;
 	name: string;
+	provided?: string | undefined;
 }
 
 export async function getPrefillOrPromptedOption({
@@ -14,10 +15,15 @@ export async function getPrefillOrPromptedOption({
 	getDefaultValue,
 	message,
 	name,
+	provided,
 }: GetPrefillOrPromptedOptionOptions) {
+	if (provided) {
+		return { value: provided };
+	}
+
 	const defaultValue = await getDefaultValue?.();
 
-	if (auto || defaultValue) {
+	if (auto) {
 		return {
 			error: defaultValue
 				? undefined

--- a/src/shared/options/readOptions.ts
+++ b/src/shared/options/readOptions.ts
@@ -124,9 +124,10 @@ export async function readOptions(
 
 	const ownerOption = await getPrefillOrPromptedOption({
 		auto: !!mappedOptions.auto,
-		getDefaultValue: async () => options.owner ?? (await defaults.owner()),
+		getDefaultValue: defaults.owner,
 		message: "What organization or user will the repository be under?",
 		name: "owner",
+		provided: options.owner,
 	});
 
 	options.owner ??= ownerOption.value;
@@ -141,10 +142,10 @@ export async function readOptions(
 
 	const repositoryOption = await getPrefillOrPromptedOption({
 		auto: !!mappedOptions.auto,
-		getDefaultValue: async () =>
-			options.repository ?? (await defaults.repository()),
+		getDefaultValue: defaults.repository,
 		message: "What will the kebab-case name of the repository be?",
 		name: "repository",
+		provided: options.repository,
 	});
 
 	options.repository ??= repositoryOption.value;
@@ -175,11 +176,10 @@ export async function readOptions(
 	const descriptionOption = await getPrefillOrPromptedOption({
 		auto: !!mappedOptions.auto,
 		getDefaultValue: async () =>
-			options.description ??
-			(await defaults.description()) ??
-			"A very lovely package. Hooray!",
+			(await defaults.description()) ?? "A very lovely package. Hooray!",
 		message: "How would you describe the new package?",
 		name: "description",
+		provided: options.description,
 	});
 
 	options.description ??= descriptionOption.value;
@@ -191,11 +191,10 @@ export async function readOptions(
 	const titleOption = await getPrefillOrPromptedOption({
 		auto: !!mappedOptions.auto,
 		getDefaultValue: async () =>
-			options.title ??
-			(await defaults.title()) ??
-			titleCase(repository).replaceAll("-", " "),
+			(await defaults.title()) ?? titleCase(repository).replaceAll("-", " "),
 		message: "What will the Title Case title of the repository be?",
 		name: "title",
+		provided: options.title,
 	});
 
 	options.title ??= titleOption.value;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1106
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

A default value being present for `getPrefillOrPromptedValue` doesn't mean it should be used. Only a _provided_ value does. This adds an explicit `provided?: string` to the function's options.