### PR TITLE
fix: use repository name in README.md npm package badge

### DIFF
--- a/src/steps/writeReadme/generateTopContent.test.ts
+++ b/src/steps/writeReadme/generateTopContent.test.ts
@@ -5,24 +5,24 @@ import { generateTopContent } from "./generateTopContent.js";
 
 const optionsBase = {
 	access: "public",
-	description: "",
+	description: "Test description",
 	directory: ".",
 	email: {
 		github: "github@email.com",
 		npm: "npm@email.com",
 	},
 	mode: "create",
-	owner: "",
-	repository: "",
-	title: "",
+	owner: "test-owner",
+	repository: "test-repository",
+	title: "Test Title",
 } satisfies Options;
 
 describe("findExistingBadges", () => {
 	it("generates full contents when there are no existing badges", () => {
 		expect(generateTopContent(optionsBase, [])).toMatchInlineSnapshot(`
-			"<h1 align="center"></h1>
+			"<h1 align="center">Test Title</h1>
 
-			<p align="center"></p>
+			<p align="center">Test description</p>
 
 			<p align="center">
 				<!-- prettier-ignore-start -->
@@ -30,21 +30,21 @@ describe("findExistingBadges", () => {
 				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh//" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh///branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com///blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com///blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license//?color=21bb42"></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 			</p>
 
 			## Usage
 
 			\`\`\`shell
-			npm i 
+			npm i test-repository
 			\`\`\`
 			\`\`\`ts
-			import { greet } from "";
+			import { greet } from "test-repository";
 
 			greet("Hello, world! 💖");
 			\`\`\`"
@@ -57,9 +57,9 @@ describe("findExistingBadges", () => {
 				`<img alt="TypeScript: Strict" src="invalid svg" />`,
 			]),
 		).toMatchInlineSnapshot(`
-			"<h1 align="center"></h1>
+			"<h1 align="center">Test Title</h1>
 
-			<p align="center"></p>
+			<p align="center">Test description</p>
 
 			<p align="center">
 				<!-- prettier-ignore-start -->
@@ -67,21 +67,21 @@ describe("findExistingBadges", () => {
 				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh//" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh///branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com///blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com///blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license//?color=21bb42"></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 			</p>
 
 			## Usage
 
 			\`\`\`shell
-			npm i 
+			npm i test-repository
 			\`\`\`
 			\`\`\`ts
-			import { greet } from "";
+			import { greet } from "test-repository";
 
 			greet("Hello, world! 💖");
 			\`\`\`"
@@ -94,9 +94,9 @@ describe("findExistingBadges", () => {
 				`<img alt="Unknown Badge" src="unknown.svg" />`,
 			]),
 		).toMatchInlineSnapshot(`
-			"<h1 align="center"></h1>
+			"<h1 align="center">Test Title</h1>
 
-			<p align="center"></p>
+			<p align="center">Test description</p>
 
 			<p align="center">
 				<!-- prettier-ignore-start -->
@@ -104,22 +104,22 @@ describe("findExistingBadges", () => {
 				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh//" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh///branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com///blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com///blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license//?color=21bb42"></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 				<img alt="Unknown Badge" src="unknown.svg" />
 			</p>
 
 			## Usage
 
 			\`\`\`shell
-			npm i 
+			npm i test-repository
 			\`\`\`
 			\`\`\`ts
-			import { greet } from "";
+			import { greet } from "test-repository";
 
 			greet("Hello, world! 💖");
 			\`\`\`"
@@ -129,9 +129,9 @@ describe("findExistingBadges", () => {
 	it("does not include a greet section when the mode is migrate", () => {
 		expect(generateTopContent({ ...optionsBase, mode: "migrate" }, []))
 			.toMatchInlineSnapshot(`
-				"<h1 align="center"></h1>
+				"<h1 align="center">Test Title</h1>
 
-				<p align="center"></p>
+				<p align="center">Test description</p>
 
 				<p align="center">
 					<!-- prettier-ignore-start -->
@@ -139,12 +139,12 @@ describe("findExistingBadges", () => {
 					<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 					<!-- ALL-CONTRIBUTORS-BADGE:END -->
 					<!-- prettier-ignore-end -->
-					<a href="https://codecov.io/gh//" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh///branch/main/graph/badge.svg"/></a>
-					<a href="https://github.com///blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-					<a href="https://github.com///blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license//?color=21bb42"></a>
+					<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
+					<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+					<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
 					<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 					<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-					<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+					<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 				</p>"
 			`);
 	});

--- a/src/steps/writeReadme/generateTopContent.ts
+++ b/src/steps/writeReadme/generateTopContent.ts
@@ -58,7 +58,7 @@ export function generateTopContent(options: Options, existingBadges: string[]) {
 			/typescript.*strict/i,
 		],
 		[
-			`<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />`,
+			`<img alt="npm package version" src="https://img.shields.io/npm/v/${options.repository}?color=21bb42" />`,
 			/npm.*v/i,
 		],
 	] as const) {

--- a/src/steps/writeReadme/index.test.ts
+++ b/src/steps/writeReadme/index.test.ts
@@ -66,7 +66,7 @@ describe("writeReadme", () => {
 				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 			</p>
 
 			## Usage
@@ -127,7 +127,7 @@ describe("writeReadme", () => {
 				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 			</p>
 
 			## Usage
@@ -191,7 +191,7 @@ describe("writeReadme", () => {
 				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 			</p>
 
 			## Usage
@@ -289,7 +289,7 @@ describe("writeReadme", () => {
 				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
 				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 			</p>
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1108
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replaces the hardcoded `create-typescript-app` name with `options.repository`. Also adds non-blank strings to unit tests so the snapshots will reflect this.