### PR TITLE
chore: keep coverage directories in-place for test-initialize and test-migrate

### DIFF
--- a/.github/workflows/test-initialize.yml
+++ b/.github/workflows/test-initialize.yml
@@ -6,6 +6,10 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build
       - run: pnpm run test:initialize
+      # The template's .eslintignore only ignores coverage, not coverage-*
+      # https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1131
+      - if: always()
+        run: mv coverage coverage-initialize
       - if: always()
         name: Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-migrate.yml
+++ b/.github/workflows/test-migrate.yml
@@ -6,6 +6,10 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build
       - run: pnpm run test:migrate
+      # The template's .eslintignore only ignores coverage, not coverage-*
+      # https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1131
+      - if: always()
+        run: mv coverage coverage-migrate
       - if: always()
         name: Codecov
         uses: codecov/codecov-action@v3

--- a/script/initialize-test-e2e.js
+++ b/script/initialize-test-e2e.js
@@ -49,4 +49,4 @@ await $`pnpm i`;
 await $`pnpm run build`;
 await $({
 	stdio: "inherit",
-})`c8 -o ./coverage-initialize -r html -r lcov --src src node ./bin/index.js --base everything --description ${description} --mode initialize --owner ${owner} --title ${title} --repository ${repository} --skip-all-contributors-api --skip-github-api --skip-removal --skip-restore`;
+})`c8 -o ./coverage -r html -r lcov --src src node ./bin/index.js --base everything --description ${description} --mode initialize --owner ${owner} --title ${title} --repository ${repository} --skip-all-contributors-api --skip-github-api --skip-removal --skip-restore`;

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -11,7 +11,7 @@ const title = "Create TypeScript App";
 
 await $({
 	stdio: "inherit",
-})`c8 -o ./coverage-migrate -r html -r lcov --src src node ./bin/index.js --base everything --mode migrate --description ${description} --email-github ${emailGithub} --email-npm ${emailNpm} --owner ${owner} --title ${title} --repository ${repository} --skip-all-contributors-api --skip-github-api --skip-install`;
+})`c8 -o ./coverage -r html -r lcov --src src node ./bin/index.js --base everything --mode migrate --description ${description} --email-github ${emailGithub} --email-npm ${emailNpm} --owner ${owner} --title ${title} --repository ${repository} --skip-all-contributors-api --skip-github-api --skip-install`;
 
 const { stdout: gitStatus } = await $`git status`;
 console.log(`Stdout from running \`git status\`:\n${gitStatus}`);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1131
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Keeps them running on `./coverage`, then swaps that to `./coverage-*` later in the workflow.

Comparing the performance of the two end-to-end test types from `main` (c06c62c):

| Test         | Baseline | Update   | Δ                      |
| ------------ | -------- | -------- | ---------------------- |
| `initialize` | `1m 25s` | `1m 21s` | ~0% (near zero change) |
| `migrate`    | `2m 45s` | `30s`    | 81% faster             |

Seems like this mostly improves migration. I guess initialization didn't have this bottleneck as badlly, and still runs the initialize script twice.