### PR TITLE
fix: remove unnecessary boolean values in rerun suggestions

### DIFF
--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -46,7 +46,7 @@ describe("createRerunSuggestion", () => {
 		const actual = createRerunSuggestion(options);
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode create --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors true --exclude-compliance true --exclude-lint-jsdoc true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title "Test Title""`,
+			`"npx create-typescript-app --mode create --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -61,7 +61,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors true --exclude-compliance true --exclude-lint-jsdoc true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -76,7 +76,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors true --exclude-compliance true --exclude-lint-jsdoc true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-package-json true --exclude-lint-perfectionist true --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -90,7 +90,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors true --exclude-compliance true --exclude-lint-jsdoc true --exclude-lint-json true --exclude-lint-knip true --exclude-lint-md true --exclude-lint-package-json true --exclude-lint-perfectionist true --exclude-lint-spelling true --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api true --skip-install true --skip-removal true --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-md --exclude-lint-package-json --exclude-lint-perfectionist --exclude-lint-spelling --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 

--- a/src/create/createRerunSuggestion.ts
+++ b/src/create/createRerunSuggestion.ts
@@ -45,7 +45,7 @@ export function createRerunSuggestion(options: Partial<Options>): string {
 					undefined && !!value,
 		)
 		.map(([key, value]) => {
-			return `--${getFirstMatchingArg(key)} ${stringifyValue(value)}`;
+			return `--${getFirstMatchingArg(key)}${stringifyValue(value)}`;
 		})
 		.join(" ");
 
@@ -59,9 +59,13 @@ function stringifyValue(
 		return stringifyValue(value.join(" "));
 	}
 
+	if (typeof value === "boolean" && value) {
+		return "";
+	}
+
 	const valueStringified = `${value}`;
 
 	return valueStringified.includes(" ")
-		? `"${valueStringified}"`
-		: valueStringified;
+		? ` "${valueStringified}"`
+		: ` ${valueStringified}`;
 }


### PR DESCRIPTION
## PR Checklist

- [X] Addresses an existing open issue: fixes #1129 
- [X] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [X] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR fixes an issue in the rerun suggestions, where `true` is unnecessarily being printed. This change leads to the following:

```shell
# previous
npx create-typescript-app --mode create --skip-install true

# new
npx create-typescript-app --mode create --skip-install
```

The related tests have also been changed.
