### PR TITLE
chore: transform noisy files in e2e migration test

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -1,410 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`verify .all-contributorsrc 1`] = `
-"--- a/.all-contributorsrc
-+++ b/.all-contributorsrc
-@@ -25,359 +25,271 @@
-       "name": "Jeff Wen",
-       "avatar_url": "https://avatars.githubusercontent.com/u/3297859?v=4",
-       "profile": "https://sinchang.me",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "Pinjasaur",
-       "name": "Paul Esch-Laurent",
-       "avatar_url": "https://avatars.githubusercontent.com/u/6335792?v=4",
-       "profile": "https://paulisaweso.me/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "NazCodeland",
-       "name": "NazCodeland",
-       "avatar_url": "https://avatars.githubusercontent.com/u/113494366?v=4",
-       "profile": "https://github.com/NazCodeland",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "johnnyreilly",
-       "name": "John Reilly",
-       "avatar_url": "https://avatars.githubusercontent.com/u/1010525?v=4",
-       "profile": "https://blog.johnnyreilly.com/",
--      "contributions": [
--        "code",
--        "ideas"
--      ]
-+      "contributions": ["code", "ideas"]
-     },
-     {
-       "login": "webpro",
-       "name": "Lars Kappert",
-       "avatar_url": "https://avatars.githubusercontent.com/u/456426?v=4",
-       "profile": "https://webpro.nl",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "RebeccaStevens",
-       "name": "Rebecca Stevens",
-       "avatar_url": "https://avatars.githubusercontent.com/u/7224206?v=4",
-       "profile": "https://github.com/RebeccaStevens",
--      "contributions": [
--        "code",
--        "infra"
--      ]
-+      "contributions": ["code", "infra"]
-     },
-     {
-       "login": "ronthetech",
-       "name": "Ron Jean-Francois",
-       "avatar_url": "https://avatars.githubusercontent.com/u/105710107?v=4",
-       "profile": "http://ronjeanfrancois.com",
--      "contributions": [
--        "code",
--        "infra"
--      ]
-+      "contributions": ["code", "infra"]
-     },
-     {
-       "login": "nowyDEV",
-       "name": "Dominik Nowik",
-       "avatar_url": "https://avatars.githubusercontent.com/u/12304307?v=4",
-       "profile": "https://github.com/nowyDEV",
--      "contributions": [
--        "tool",
--        "code"
--      ]
-+      "contributions": ["tool", "code"]
-     },
-     {
-       "login": "TAKANOME-DEV",
-       "name": "takanomedev",
-       "avatar_url": "https://avatars.githubusercontent.com/u/79809121?v=4",
-       "profile": "https://github.com/TAKANOME-DEV",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "emday4prez",
-       "name": "Emerson",
-       "avatar_url": "https://avatars.githubusercontent.com/u/35363144?v=4",
-       "profile": "https://github.com/emday4prez",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "jsjoeio",
-       "name": "Joe Previte",
-       "avatar_url": "https://avatars.githubusercontent.com/u/3806031?v=4",
-       "profile": "https://typescriptcourse.com/tutorials",
--      "contributions": [
--        "bug",
--        "code"
--      ]
-+      "contributions": ["bug", "code"]
-     },
-     {
-       "login": "navin-moorthy",
-       "name": "Navin Moorthy",
-       "avatar_url": "https://avatars.githubusercontent.com/u/39694575?v=4",
-       "profile": "https://navinmoorthy.me/",
--      "contributions": [
--        "bug",
--        "code"
--      ]
-+      "contributions": ["bug", "code"]
-     },
-     {
-       "login": "garuna-m6",
-       "name": "Anurag",
-       "avatar_url": "https://avatars.githubusercontent.com/u/23234342?v=4",
-       "profile": "https://github.com/garuna-m6",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "danielroe",
-       "name": "Daniel Roe",
-       "avatar_url": "https://avatars.githubusercontent.com/u/28706372?v=4",
-       "profile": "https://roe.dev/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "the-lazy-learner",
-       "name": "Sudhansu",
-       "avatar_url": "https://avatars.githubusercontent.com/u/13695177?v=4",
-       "profile": "https://github.com/the-lazy-learner",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "RNR1",
-       "name": "Ron Braha",
-       "avatar_url": "https://avatars.githubusercontent.com/u/45559220?v=4",
-       "profile": "https://linktr.ee/ronbraha",
--      "contributions": [
--        "code",
--        "design",
--        "test"
--      ]
-+      "contributions": ["code", "design", "test"]
-     },
-     {
-       "login": "tungbq",
-       "name": "Tung Bui (Leo)",
-       "avatar_url": "https://avatars.githubusercontent.com/u/85242618?v=4",
-       "profile": "https://github.com/tungbq",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "orta",
-       "name": "Orta Therox",
-       "avatar_url": "https://avatars.githubusercontent.com/u/49038?v=4",
-       "profile": "https://orta.io",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "promise-dash",
-       "name": "Promise Dash",
-       "avatar_url": "https://avatars.githubusercontent.com/u/86062880?v=4",
-       "profile": "https://github.com/promise-dash",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "jolg42",
-       "name": "Joël Galeran",
-       "avatar_url": "https://avatars.githubusercontent.com/u/1328733?v=4",
-       "profile": "https://twitter.com/Jolg42",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "kristo-baricevic",
-       "name": "Kristo Baricevic",
-       "avatar_url": "https://avatars.githubusercontent.com/u/108290619?v=4",
-       "profile": "https://kristo-baricevic.github.io/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "ryota-murakami",
-       "name": "Ryota Murakami",
-       "avatar_url": "https://avatars.githubusercontent.com/u/5501268?v=4",
-       "profile": "https://ryota-murakami.github.io/",
--      "contributions": [
--        "code",
--        "bug"
--      ]
-+      "contributions": ["code", "bug"]
-     },
-     {
-       "login": "ruthwikreddy09",
-       "name": "Ruthwik",
-       "avatar_url": "https://avatars.githubusercontent.com/u/126862059?v=4",
-       "profile": "https://github.com/RuthwikReddy09",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "jdwilkin4",
-       "name": "Jessica Wilkins ",
-       "avatar_url": "https://avatars.githubusercontent.com/u/67210629?v=4",
-       "profile": "https://jessicawilkins.dev/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "vasanth9",
-       "name": "Vasanth Kumar Cheepurupalli",
-       "avatar_url": "https://avatars.githubusercontent.com/u/42891954?v=4",
-       "profile": "https://github.com/vasanth9",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "conrmahr",
-       "name": "Conor Meagher",
-       "avatar_url": "https://avatars.githubusercontent.com/u/363781?v=4",
-       "profile": "https://conormeagher.com/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "DanexQ",
-       "name": "Daniel",
-       "avatar_url": "https://avatars.githubusercontent.com/u/72567464?v=4",
-       "profile": "https://github.com/DanexQ",
--      "contributions": [
--        "infra"
--      ]
-+      "contributions": ["infra"]
-     },
-     {
-       "login": "jaas666",
-       "name": "Juan A.",
-       "avatar_url": "https://avatars.githubusercontent.com/u/30204147?v=4",
-       "profile": "https://github.com/jaas666",
--      "contributions": [
--        "code",
--        "doc"
--      ]
-+      "contributions": ["code", "doc"]
-     },
-     {
-       "login": "katt",
-       "name": "Alex / KATT",
-       "avatar_url": "https://avatars.githubusercontent.com/u/459267?v=4",
-       "profile": "https://katt.dev",
--      "contributions": [
--        "bug"
--      ]
-+      "contributions": ["bug"]
-     },
-     {
-       "login": "dertimonius",
-       "name": "Timon Jurschitsch",
-       "avatar_url": "https://avatars.githubusercontent.com/u/103483059?v=4",
-       "profile": "https://www.linkedin.com/in/timonjurschitsch/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "biplobsd",
-       "name": "Biplob Sutradhar",
-       "avatar_url": "https://avatars.githubusercontent.com/u/43641536?v=4",
-       "profile": "http://biplobsd.me",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "mrswastik-robot",
-       "name": "Swastik Patel",
-       "avatar_url": "https://avatars.githubusercontent.com/u/107865087?v=4",
-       "profile": "https://github.com/mrswastik-robot",
--      "contributions": [
--        "doc"
--      ]
-+      "contributions": ["doc"]
-     },
-     {
-       "login": "gv14982",
-       "name": "Graham Vasquez",
-       "avatar_url": "https://avatars.githubusercontent.com/u/7041175?v=4",
-       "profile": "https://gvasquez.dev",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "dominicduffin1",
-       "name": "Dominic Duffin",
-       "avatar_url": "https://avatars.githubusercontent.com/u/26224873?v=4",
-       "profile": "https://dominicduffin.uk",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "5hraddha",
-       "name": "Shraddha",
-       "avatar_url": "https://avatars.githubusercontent.com/u/27571141?v=4",
-       "profile": "https://www.shraddha.tech",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "xl4624",
-       "name": "Xiaomin Liu",
-       "avatar_url": "https://avatars.githubusercontent.com/u/116298054?v=4",
-       "profile": "https://github.com/xl4624",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     },
-     {
-       "login": "jamiemagee",
-       "name": "Jamie Magee",
-       "avatar_url": "https://avatars.githubusercontent.com/u/1358764?v=4",
-       "profile": "https://jamiemagee.co.uk",
--      "contributions": [
--        "ideas"
--      ]
-+      "contributions": ["ideas"]
-     },
-     {
-       "login": "praveenshinde3",
-       "name": "Praveen Shinde",
-       "avatar_url": "https://avatars.githubusercontent.com/u/107350270?v=4",
-       "profile": "https://praveenshinde.vercel.app/",
--      "contributions": [
--        "code"
--      ]
-+      "contributions": ["code"]
-     }
-   ],
-   "contributorsPerLine": 7,
-   "contributorsSortAlphabetically": true,
--  "files": [
--    "README.md"
--  ],
-+  "files": ["README.md"],
-   "imageSize": 100,
-   "projectName": "create-typescript-app",
-   "projectOwner": "JoshuaKGoldberg","
-`;
-
-exports[`verify .eslintignore 1`] = `
+exports[`expected file changes > .eslintignore 1`] = `
 "--- a/.eslintignore
 +++ b/.eslintignore
 @@ -1,5 +1,5 @@
@@ -416,7 +12,7 @@ exports[`verify .eslintignore 1`] = `
  pnpm-lock.yaml"
 `;
 
-exports[`verify .eslintrc.cjs 1`] = `
+exports[`expected file changes > .eslintrc.cjs 1`] = `
 "--- a/.eslintrc.cjs
 +++ b/.eslintrc.cjs
 @@ -1,13 +1,3 @@
@@ -454,7 +50,7 @@ exports[`verify .eslintrc.cjs 1`] = `
  		{"
 `;
 
-exports[`verify .github/DEVELOPMENT.md 1`] = `
+exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
 "--- a/.github/DEVELOPMENT.md
 +++ b/.github/DEVELOPMENT.md
 @@ -99,116 +99,3 @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
@@ -576,7 +172,7 @@ exports[`verify .github/DEVELOPMENT.md 1`] = `
 -> You can also try running the test script locally."
 `;
 
-exports[`verify .github/workflows/lint-knip.yml 1`] = `
+exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
 "--- a/.github/workflows/lint-knip.yml
 +++ b/.github/workflows/lint-knip.yml
 @@ -4,7 +4,6 @@ jobs:
@@ -589,7 +185,7 @@ exports[`verify .github/workflows/lint-knip.yml 1`] = `
  name: Lint Knip"
 `;
 
-exports[`verify .github/workflows/test.yml 1`] = `
+exports[`expected file changes > .github/workflows/test.yml 1`] = `
 "--- a/.github/workflows/test.yml
 +++ b/.github/workflows/test.yml
 @@ -7,14 +7,6 @@ jobs:
@@ -609,7 +205,7 @@ exports[`verify .github/workflows/test.yml 1`] = `
  "
 `;
 
-exports[`verify .gitignore 1`] = `
+exports[`expected file changes > .gitignore 1`] = `
 "--- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,3 @@
@@ -619,7 +215,7 @@ exports[`verify .gitignore 1`] = `
  node_modules/"
 `;
 
-exports[`verify .prettierignore 1`] = `
+exports[`expected file changes > .prettierignore 1`] = `
 "--- a/.prettierignore
 +++ b/.prettierignore
 @@ -1,4 +1,4 @@
@@ -630,7 +226,7 @@ exports[`verify .prettierignore 1`] = `
  pnpm-lock.yaml"
 `;
 
-exports[`verify README.md 1`] = `
+exports[`expected file changes > README.md 1`] = `
 "--- a/README.md
 +++ b/README.md
 @@ -5,57 +5,20 @@
@@ -709,9 +305,7 @@ exports[`verify README.md 1`] = `
 +> 💙 This package was templated with [\`create-typescript-app\`](https://github.com/JoshuaKGoldberg/create-typescript-app)."
 `;
 
-exports[`verify bin/index.js 1`] = `""`;
-
-exports[`verify cspell.json 1`] = `
+exports[`expected file changes > cspell.json 1`] = `
 "--- a/cspell.json
 +++ b/cspell.json
 @@ -1,40 +1,27 @@
@@ -759,7 +353,7 @@ exports[`verify cspell.json 1`] = `
  }"
 `;
 
-exports[`verify knip.jsonc 1`] = `
+exports[`expected file changes > knip.jsonc 1`] = `
 "--- a/knip.jsonc
 +++ b/knip.jsonc
 @@ -1,17 +1,6 @@
@@ -785,7 +379,7 @@ exports[`verify knip.jsonc 1`] = `
  }"
 `;
 
-exports[`verify package.json 1`] = `
+exports[`expected file changes > package.json 1`] = `
 "--- a/package.json
 +++ b/package.json
 @@ -15,7 +15,6 @@

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -1,7 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`expected file changes > .eslintignore 1`] = `
-" !.*
+"--- a/.eslintignore
++++ b/.eslintignore
+@@ -1,5 +1,5 @@
+ !.*
 -coverage*
 +coverage
  lib
@@ -10,7 +13,10 @@ exports[`expected file changes > .eslintignore 1`] = `
 `;
 
 exports[`expected file changes > .eslintrc.cjs 1`] = `
-"-/*
+"--- a/.eslintrc.cjs
++++ b/.eslintrc.cjs
+@@ -1,13 +1,3 @@
+-/*
 -👋 Hi! This ESLint configuration contains a lot more stuff than many repos'!
 -You can read from it to see all sorts of linting goodness, but don't worry -
 -it's not something you need to exhaustively understand immediately. 💙
@@ -44,21 +50,67 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
  		{"
 `;
 
-exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `undefined`;
+exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
+"--- a/.github/DEVELOPMENT.md
++++ b/.github/DEVELOPMENT.md
+@@ -99,7 +99,6 @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
+ \`\`\`shell
+ pnpm tsc --watch
+ \`\`\`
+-
+ ## Setup Scripts
+ 
+ As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository."
+`;
 
-exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `undefined`;
+exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
+"--- a/.github/workflows/lint-knip.yml
++++ b/.github/workflows/lint-knip.yml
+@@ -4,7 +4,6 @@ jobs:
+     steps:
+       - uses: actions/checkout@v4
+       - uses: ./.github/actions/prepare
+-      - run: pnpm build || true
+       - run: pnpm lint:knip
+ 
+ name: Lint Knip"
+`;
 
-exports[`expected file changes > .github/workflows/test.yml 1`] = `undefined`;
+exports[`expected file changes > .github/workflows/test.yml 1`] = `
+"--- a/.github/workflows/test.yml
++++ b/.github/workflows/test.yml
+@@ -7,14 +7,6 @@ jobs:
+       - run: pnpm run test --coverage
+       - name: Codecov
+         uses: codecov/codecov-action@v3
+-        with:
+-          flags: unit
+-      - if: always()
+-        name: Archive code coverage results
+-        uses: actions/upload-artifact@v4
+-        with:
+-          name: code-coverage-report
+-          path: coverage
+ 
+ name: Test
+ "
+`;
 
 exports[`expected file changes > .gitignore 1`] = `
-"-coverage*/
+"--- a/.gitignore
++++ b/.gitignore
+@@ -1,3 +1,3 @@
+-coverage*/
 +coverage/
  lib/
  node_modules/"
 `;
 
 exports[`expected file changes > .prettierignore 1`] = `
-" .all-contributorsrc
+"--- a/.prettierignore
++++ b/.prettierignore
+@@ -1,4 +1,4 @@
+ .all-contributorsrc
 -coverage*/
 +coverage/
  lib/
@@ -66,7 +118,10 @@ exports[`expected file changes > .prettierignore 1`] = `
 `;
 
 exports[`expected file changes > README.md 1`] = `
-" <p align="center">
+"--- a/README.md
++++ b/README.md
+@@ -5,57 +5,20 @@
+ <p align="center">
  	<!-- prettier-ignore-start -->
  	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 -  <a href="#contributors" target="_blank"><img alt="All Contributors: 39 👪" src="https://img.shields.io/badge/all_contributors-39_👪-21bb42.svg" /></a>
@@ -142,7 +197,10 @@ exports[`expected file changes > README.md 1`] = `
 `;
 
 exports[`expected file changes > cspell.json 1`] = `
-" {
+"--- a/cspell.json
++++ b/cspell.json
+@@ -1,40 +1,27 @@
+ {
  	"dictionaries": ["typescript"],
  	"ignorePaths": [
 -		"./coverage*",
@@ -187,7 +245,10 @@ exports[`expected file changes > cspell.json 1`] = `
 `;
 
 exports[`expected file changes > knip.jsonc 1`] = `
-" {
+"--- a/knip.jsonc
++++ b/knip.jsonc
+@@ -1,17 +1,6 @@
+ {
  	"$schema": "https://unpkg.com/knip@latest/schema.json",
 -	"entry": [
 -		"src/index.ts!",
@@ -210,12 +271,41 @@ exports[`expected file changes > knip.jsonc 1`] = `
 `;
 
 exports[`expected file changes > package.json 1`] = `
-" 	"main": "./lib/index.js",
+"--- a/package.json
++++ b/package.json
+@@ -15,7 +15,6 @@
+ 	"main": "./lib/index.js",
  	"bin": "./bin/index.js",
  	"files": [
 -		"bin/",
  		"lib/",
  		"package.json",
  		"LICENSE.md",
-@@ -24,7 +23,6 "
+@@ -24,7 +23,6 @@
+ 	"scripts": {
+ 		"build": "tsup",
+ 		"format": "prettier \\"**/*\\" --ignore-unknown",
+-		"initialize": "tsx ./src/bin/index.js --mode initialize",
+ 		"lint": "eslint . .*js --max-warnings 0",
+ 		"lint:knip": "knip",
+ 		"lint:md": "markdownlint \\"**/*.md\\" \\".github/**/*.md\\" --rules sentences-per-line",
+@@ -34,9 +32,6 @@
+ 		"prepare": "husky install",
+ 		"should-semantic-release": "should-semantic-release --verbose",
+ 		"test": "vitest",
+-		"test:create": "node script/create-test-e2e.js",
+-		"test:initialize": "node script/initialize-test-e2e.js",
+-		"test:migrate": "vitest run -r script/",
+ 		"tsc": "tsc"
+ 	},
+ 	"lint-staged": {
+@@ -107,7 +102,7 @@
+ 		"vitest": "^1.0.2",
+ 		"yaml-eslint-parser": "^1.2.2"
+ 	},
+-	"packageManager": "pnpm@8.13.1",
++	"packageManager": "pnpm@8.7.0",
+ 	"engines": {
+ 		"node": ">=18"
+ 	},"
 `;

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -1,10 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`expected file changes > .eslintignore 1`] = `
-"--- a/.eslintignore
-+++ b/.eslintignore
-@@ -1,5 +1,5 @@
- !.*
+" !.*
 -coverage*
 +coverage
  lib
@@ -13,10 +10,7 @@ exports[`expected file changes > .eslintignore 1`] = `
 `;
 
 exports[`expected file changes > .eslintrc.cjs 1`] = `
-"--- a/.eslintrc.cjs
-+++ b/.eslintrc.cjs
-@@ -1,13 +1,3 @@
--/*
+"-/*
 -👋 Hi! This ESLint configuration contains a lot more stuff than many repos'!
 -You can read from it to see all sorts of linting goodness, but don't worry -
 -it's not something you need to exhaustively understand immediately. 💙
@@ -50,176 +44,21 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
  		{"
 `;
 
-exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
-"--- a/.github/DEVELOPMENT.md
-+++ b/.github/DEVELOPMENT.md
-@@ -99,116 +99,3 @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
- \`\`\`shell
- pnpm tsc --watch
- \`\`\`
--
--## Setup Scripts
--
--As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository.
--
--Each follows roughly the same general flow:
--
--1. \`bin/index.ts\` uses \`bin/mode.ts\` to determine which of the three setup scripts to run
--2. \`readOptions\` parses in options from local files, Git commands, npm APIs, and/or files on disk
--3. \`runOrRestore\` wraps the setup script's main logic in a friendly prompt wrapper
--4. The setup script wraps each portion of its main logic with \`withSpinner\`
--   - Each step of setup logic is generally imported from within \`src/steps\`
--5. A call to \`outro\` summarizes the results for the user
--
--> **Warning**
--> Each setup script overrides many files in the directory they're run in.
--> Make sure to save any changes you want to preserve before running them.
--
--### The Creation Script
--
--This template's "creation" script is located in \`src/create/\`.
--You can run it locally with \`node bin/index.js --mode create\`.
--Note that files need to be built with \`pnpm run build\` beforehand.
--
--#### Testing the Creation Script
--
--You can run the end-to-end test for creation locally on the command-line.
--Note that the files need to be built with \`pnpm run build\` beforehand.
--
--\`\`\`shell
--pnpm run test:create
--\`\`\`
--
--That end-to-end test executes \`script/create-test-e2e.js\`, which:
--
--1. Runs the creation script to create a new \`test-repository\` child directory and repository, capturing code coverage
--2. Asserts that commands such as \`build\` and \`lint\` each pass
--
--The \`pnpm run test:create\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
--See \`.github/workflows/test-create.yml\`.
--
--### The Initialization Script
--
--This template's "initialization" script is located in \`src/initialize/\`.
--You can run it locally with \`pnpm run initialize\`.
--It uses [\`tsx\`](https://github.com/esbuild-kit/tsx) so you don't need to build files before running.
--
--\`\`\`shell
--pnpm run initialize
--\`\`\`
--
--#### Testing the Initialization Script
--
--You can run the end-to-end test for initializing locally on the command-line.
--Note that files need to be built with \`pnpm run build\` beforehand.
--
--\`\`\`shell
--pnpm run test:initialize
--\`\`\`
--
--That end-to-end test executes \`script/initialize-test-e2e.js\`, which:
--
--1. Runs the initialization script using \`--skip-github-api\` and other skip flags
--2. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
--3. Runs \`pnpm run lint:knip\` to make sure no excess dependencies or files were left over
--4. Resets everything
--5. Runs initialization a second time, capturing test coverage
--
--The \`pnpm run test:initialize\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
--See \`.github/workflows/test-initialize.yml\`.
--
--### The Migration Script
--
--This template's "migration" script is located in \`src/migrate/\`.
--Note that files need to be built with \`pnpm run build\` beforehand.
--
--To test out the script locally, run it from a different repository's directory:
--
--\`\`\`shell
--cd ../other-repo
--node ../create-typescript-app/bin/migrate.js
--\`\`\`
--
--The migration script will work on any directory.
--You can try it out in a blank directory with scripts like:
--
--\`\`\`shell
--cd ..
--mkdir temp
--cd temp
--node ../create-typescript-app/bin/migrate.js
--\`\`\`
--
--#### Testing the Migration Script
--
--You can run the end-to-end test for migrating locally on the command-line:
--
--\`\`\`shell
--pnpm run test:migrate
--\`\`\`
--
--That end-to-end test executes \`script/migrate-test-e2e.js\`, which:
--
--1. Runs the migration script using \`--skip-github-api\` and other skip flags, capturing code coverage
--2. Checks that only a small list of allowed files were changed
--3. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
--
--The \`pnpm run test:migrate\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
--See \`.github/workflows/test-migrate.yml\`.
--
--> Tip: if the migration test is failing in CI and you don't see any errors, try [downloading the full logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
--> There'll likely be a list of changed files under a message like _\`Oh no! Running the migrate script modified some files:\`_.
--> You can also try running the test script locally."
-`;
+exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `undefined`;
 
-exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
-"--- a/.github/workflows/lint-knip.yml
-+++ b/.github/workflows/lint-knip.yml
-@@ -4,7 +4,6 @@ jobs:
-     steps:
-       - uses: actions/checkout@v4
-       - uses: ./.github/actions/prepare
--      - run: pnpm build || true
-       - run: pnpm lint:knip
- 
- name: Lint Knip"
-`;
+exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `undefined`;
 
-exports[`expected file changes > .github/workflows/test.yml 1`] = `
-"--- a/.github/workflows/test.yml
-+++ b/.github/workflows/test.yml
-@@ -7,14 +7,6 @@ jobs:
-       - run: pnpm run test --coverage
-       - name: Codecov
-         uses: codecov/codecov-action@v3
--        with:
--          flags: unit
--      - if: always()
--        name: Archive code coverage results
--        uses: actions/upload-artifact@v4
--        with:
--          name: code-coverage-report
--          path: coverage
- 
- name: Test
- "
-`;
+exports[`expected file changes > .github/workflows/test.yml 1`] = `undefined`;
 
 exports[`expected file changes > .gitignore 1`] = `
-"--- a/.gitignore
-+++ b/.gitignore
-@@ -1,3 +1,3 @@
--coverage*/
+"-coverage*/
 +coverage/
  lib/
  node_modules/"
 `;
 
 exports[`expected file changes > .prettierignore 1`] = `
-"--- a/.prettierignore
-+++ b/.prettierignore
-@@ -1,4 +1,4 @@
- .all-contributorsrc
+" .all-contributorsrc
 -coverage*/
 +coverage/
  lib/
@@ -227,10 +66,7 @@ exports[`expected file changes > .prettierignore 1`] = `
 `;
 
 exports[`expected file changes > README.md 1`] = `
-"--- a/README.md
-+++ b/README.md
-@@ -5,57 +5,20 @@
- <p align="center">
+" <p align="center">
  	<!-- prettier-ignore-start -->
  	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 -  <a href="#contributors" target="_blank"><img alt="All Contributors: 39 👪" src="https://img.shields.io/badge/all_contributors-39_👪-21bb42.svg" /></a>
@@ -306,10 +142,7 @@ exports[`expected file changes > README.md 1`] = `
 `;
 
 exports[`expected file changes > cspell.json 1`] = `
-"--- a/cspell.json
-+++ b/cspell.json
-@@ -1,40 +1,27 @@
- {
+" {
  	"dictionaries": ["typescript"],
  	"ignorePaths": [
 -		"./coverage*",
@@ -354,10 +187,7 @@ exports[`expected file changes > cspell.json 1`] = `
 `;
 
 exports[`expected file changes > knip.jsonc 1`] = `
-"--- a/knip.jsonc
-+++ b/knip.jsonc
-@@ -1,17 +1,6 @@
- {
+" {
  	"$schema": "https://unpkg.com/knip@latest/schema.json",
 -	"entry": [
 -		"src/index.ts!",
@@ -380,41 +210,12 @@ exports[`expected file changes > knip.jsonc 1`] = `
 `;
 
 exports[`expected file changes > package.json 1`] = `
-"--- a/package.json
-+++ b/package.json
-@@ -15,7 +15,6 @@
- 	"main": "./lib/index.js",
+" 	"main": "./lib/index.js",
  	"bin": "./bin/index.js",
  	"files": [
 -		"bin/",
  		"lib/",
  		"package.json",
  		"LICENSE.md",
-@@ -24,7 +23,6 @@
- 	"scripts": {
- 		"build": "tsup",
- 		"format": "prettier \\"**/*\\" --ignore-unknown",
--		"initialize": "tsx ./src/bin/index.js --mode initialize",
- 		"lint": "eslint . .*js --max-warnings 0",
- 		"lint:knip": "knip",
- 		"lint:md": "markdownlint \\"**/*.md\\" \\".github/**/*.md\\" --rules sentences-per-line",
-@@ -34,9 +32,6 @@
- 		"prepare": "husky install",
- 		"should-semantic-release": "should-semantic-release --verbose",
- 		"test": "vitest",
--		"test:create": "node script/create-test-e2e.js",
--		"test:initialize": "node script/initialize-test-e2e.js",
--		"test:migrate": "vitest run -r script/",
- 		"tsc": "tsc"
- 	},
- 	"lint-staged": {
-@@ -107,7 +102,7 @@
- 		"vitest": "^1.0.2",
- 		"yaml-eslint-parser": "^1.2.2"
- 	},
--	"packageManager": "pnpm@8.13.1",
-+	"packageManager": "pnpm@8.7.0",
- 	"engines": {
- 		"node": ">=18"
- 	},"
+@@ -24,7 +23,6 "
 `;

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -6,6 +6,7 @@ import packageData from "../package.json" assert { type: "json" };
 
 const filesExpectedToBeChanged = new Set([
 	".all-contributorsrc",
+	"bin/index.js",
 	"README.md",
 	"knip.jsonc",
 	"package.json",

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -6,7 +6,6 @@ import { assert, describe, expect, test } from "vitest";
 import packageData from "../package.json" assert { type: "json" };
 
 const filesExpectedToBeChanged = new Set([
-	"bin/index.js",
 	"README.md",
 	"knip.jsonc",
 	"package.json",

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -37,8 +37,6 @@ const originalDevelopment = (
 	await fs.readFile(".github/DEVELOPMENT.md")
 ).toString();
 
-// const originalReadme = (await fs.readFile("README.md")).toString();
-
 await $({
 	stdio: "inherit",
 })`c8 -o ./coverage -r html -r lcov --src src node ${bin} --base everything --author ${authorName} --mode migrate --bin ${bin} --description ${description} --email-github ${emailGithub} --email-npm ${emailNpm} --guide ${guide} --guide-title ${guideTitle} --owner ${owner} --title ${title} --repository ${repository} --skip-all-contributors-api --skip-github-api --skip-install`;
@@ -59,15 +57,6 @@ await fs.appendFile(
 	".github/DEVELOPMENT.md",
 	originalDevelopment.slice(originalDevelopment.indexOf("## Setup Scripts")),
 );
-
-// // The Readme docs can be ignored, too, for being unnecessary diff noise.
-// await fs.writeFile(
-// 	"README.md",
-// 	originalReadme.slice(
-// 		0,
-// 		originalReadme.indexOf("`create-typescript-app` is a one-stop"),
-// 	) + originalReadme.slice(originalReadme.indexOf("## Development")),
-// );
 
 describe("expected file changes", () => {
 	test.each([...filesExpectedToBeChanged])("%s", async (file) => {

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -55,7 +55,7 @@ await $({
 describe("expected file changes", () => {
 	test.each([...filesExpectedToBeChanged])("%s", async (file) => {
 		const { stdout } = await execaCommand(`git diff HEAD -- ${file}`);
-		const contentsAfterGitMarkers = stdout.split("\n").slice(2).join("\n");
+		const [, contentsAfterGitMarkers] = stdout.split("@@\n");
 		const contentsTransformed =
 			fileContentTransforms.get(file)?.(contentsAfterGitMarkers) ??
 			contentsAfterGitMarkers;

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -23,11 +23,17 @@ const filesExpectedToBeChanged = new Set([
 const fileContentTransforms = new Map([
 	[
 		".all-contributorsrc",
-		(original) =>
-			JSON.stringify({
-				...JSON.parse(original),
-				contributors: undefined,
-			}),
+		(original) => {
+			try {
+				return JSON.stringify({
+					...JSON.parse(original),
+					contributors: undefined,
+				});
+			} catch (error) {
+				console.warn("Original text:", original);
+				throw error;
+			}
+		},
 	],
 	[
 		".github/DEVELOPMENT.md:",
@@ -60,10 +66,11 @@ describe("expected file changes", () => {
 			fileContentTransforms.get(file)?.(contentsAfterGitMarkers) ??
 			contentsAfterGitMarkers;
 
-		assert(
-			stdout,
-			`Looks like there were no changes to ${file} from migration?`,
-		);
+		if (stdout) {
+			throw new Error(
+				`Looks like there were no changes to ${file} from migration: ${stdout}`,
+			);
+		}
 
 		expect(contentsTransformed).toMatchSnapshot();
 	});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1142
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In the migration script, after running with `--mode migrate` but before running test assertions, modifies a couple of files on disk:

1. `.all-contributorsrc`: Formats with `JSON.stringify(..., null, 2)` as it seems All Contributors isn't able to use Prettier for it
2. `.github/DEVELOPMENT.md`: Adds back in the `## The Setup Scripts` heading, as it's not part of the default template

Also wraps the `test`s in `describe` and standardizes naming just a bit. I'm very nitpicky.