### PR TITLE
chore: more e2e migration snapshots filters: contributors and line numbers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
 		"yaml"
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,5 @@
 		"yaml"
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"typescript.tsdk": "node_modules/typescript/lib",
-	"[javascript]": {
-		"editor.defaultFormatter": "esbenp.prettier-vscode"
-	}
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -186,7 +186,7 @@ exports[`expected file changes > README.md 1`] = `
  ## Development
  
  See [\`.github/CONTRIBUTING.md\`](./.github/CONTRIBUTING.md), then [\`.github/DEVELOPMENT.md\`](./.github/DEVELOPMENT.md).
-@@ -129,3 +92,7 @@ Thanks! 💖
+@@ -128,3 +91,7 @@ Thanks! 💖
  
  <!-- ALL-CONTRIBUTORS-LIST:END -->
  <!-- spellchecker: enable -->

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -186,7 +186,7 @@ exports[`expected file changes > README.md 1`] = `
  ## Development
  
  See [\`.github/CONTRIBUTING.md\`](./.github/CONTRIBUTING.md), then [\`.github/DEVELOPMENT.md\`](./.github/DEVELOPMENT.md).
-@@ -128,3 +91,7 @@ Thanks! 💖
+@@ -129,3 +92,7 @@ Thanks! 💖
  
  <!-- ALL-CONTRIBUTORS-LIST:END -->
  <!-- spellchecker: enable -->

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -3,7 +3,7 @@
 exports[`expected file changes > .eslintignore 1`] = `
 "--- a/.eslintignore
 +++ b/.eslintignore
-@@ -1,5 +1,5 @@
+@@ ... @@
  !.*
 -coverage*
 +coverage
@@ -15,7 +15,7 @@ exports[`expected file changes > .eslintignore 1`] = `
 exports[`expected file changes > .eslintrc.cjs 1`] = `
 "--- a/.eslintrc.cjs
 +++ b/.eslintrc.cjs
-@@ -1,13 +1,3 @@
+@@ ... @@
 -/*
 -👋 Hi! This ESLint configuration contains a lot more stuff than many repos'!
 -You can read from it to see all sorts of linting goodness, but don't worry -
@@ -29,7 +29,7 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
  /** @type {import("@types/eslint").Linter.Config} */
  module.exports = {
  	env: {
-@@ -76,18 +66,6 @@ module.exports = {
+@@ ... @@ module.exports = {
  			rules: {
  				// These off-by-default rules work well for this repo and we like them on.
  				"deprecation/deprecation": "error",
@@ -53,7 +53,7 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
 exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
 "--- a/.github/DEVELOPMENT.md
 +++ b/.github/DEVELOPMENT.md
-@@ -99,7 +99,6 @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
+@@ ... @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
  \`\`\`shell
  pnpm tsc --watch
  \`\`\`
@@ -66,7 +66,7 @@ exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
 exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
 "--- a/.github/workflows/lint-knip.yml
 +++ b/.github/workflows/lint-knip.yml
-@@ -4,7 +4,6 @@ jobs:
+@@ ... @@ jobs:
      steps:
        - uses: actions/checkout@v4
        - uses: ./.github/actions/prepare
@@ -79,7 +79,7 @@ exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
 exports[`expected file changes > .github/workflows/test.yml 1`] = `
 "--- a/.github/workflows/test.yml
 +++ b/.github/workflows/test.yml
-@@ -7,14 +7,6 @@ jobs:
+@@ ... @@ jobs:
        - run: pnpm run test --coverage
        - name: Codecov
          uses: codecov/codecov-action@v3
@@ -99,7 +99,7 @@ exports[`expected file changes > .github/workflows/test.yml 1`] = `
 exports[`expected file changes > .gitignore 1`] = `
 "--- a/.gitignore
 +++ b/.gitignore
-@@ -1,3 +1,3 @@
+@@ ... @@
 -coverage*/
 +coverage/
  lib/
@@ -109,7 +109,7 @@ exports[`expected file changes > .gitignore 1`] = `
 exports[`expected file changes > .prettierignore 1`] = `
 "--- a/.prettierignore
 +++ b/.prettierignore
-@@ -1,4 +1,4 @@
+@@ ... @@
  .all-contributorsrc
 -coverage*/
 +coverage/
@@ -120,7 +120,7 @@ exports[`expected file changes > .prettierignore 1`] = `
 exports[`expected file changes > README.md 1`] = `
 "--- a/README.md
 +++ b/README.md
-@@ -5,57 +5,20 @@
+@@ ... @@
  <p align="center">
  	<!-- prettier-ignore-start -->
  	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
@@ -186,7 +186,7 @@ exports[`expected file changes > README.md 1`] = `
  ## Development
  
  See [\`.github/CONTRIBUTING.md\`](./.github/CONTRIBUTING.md), then [\`.github/DEVELOPMENT.md\`](./.github/DEVELOPMENT.md).
-@@ -128,3 +91,7 @@ Thanks! 💖
+@@ ... @@ Thanks! 💖
  
  <!-- ALL-CONTRIBUTORS-LIST:END -->
  <!-- spellchecker: enable -->
@@ -199,7 +199,7 @@ exports[`expected file changes > README.md 1`] = `
 exports[`expected file changes > cspell.json 1`] = `
 "--- a/cspell.json
 +++ b/cspell.json
-@@ -1,40 +1,27 @@
+@@ ... @@
  {
  	"dictionaries": ["typescript"],
  	"ignorePaths": [
@@ -247,7 +247,7 @@ exports[`expected file changes > cspell.json 1`] = `
 exports[`expected file changes > knip.jsonc 1`] = `
 "--- a/knip.jsonc
 +++ b/knip.jsonc
-@@ -1,17 +1,6 @@
+@@ ... @@
  {
  	"$schema": "https://unpkg.com/knip@latest/schema.json",
 -	"entry": [
@@ -273,7 +273,7 @@ exports[`expected file changes > knip.jsonc 1`] = `
 exports[`expected file changes > package.json 1`] = `
 "--- a/package.json
 +++ b/package.json
-@@ -15,7 +15,6 @@
+@@ ... @@
  	"main": "./lib/index.js",
  	"bin": "./bin/index.js",
  	"files": [
@@ -281,7 +281,7 @@ exports[`expected file changes > package.json 1`] = `
  		"lib/",
  		"package.json",
  		"LICENSE.md",
-@@ -24,7 +23,6 @@
+@@ ... @@
  	"scripts": {
  		"build": "tsup",
  		"format": "prettier \\"**/*\\" --ignore-unknown",
@@ -289,7 +289,7 @@ exports[`expected file changes > package.json 1`] = `
  		"lint": "eslint . .*js --max-warnings 0",
  		"lint:knip": "knip",
  		"lint:md": "markdownlint \\"**/*.md\\" \\".github/**/*.md\\" --rules sentences-per-line",
-@@ -34,9 +32,6 @@
+@@ ... @@
  		"prepare": "husky install",
  		"should-semantic-release": "should-semantic-release --verbose",
  		"test": "vitest",
@@ -299,7 +299,7 @@ exports[`expected file changes > package.json 1`] = `
  		"tsc": "tsc"
  	},
  	"lint-staged": {
-@@ -107,7 +102,7 @@
+@@ ... @@
  		"vitest": "^1.0.2",
  		"yaml-eslint-parser": "^1.2.2"
  	},

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -112,7 +112,7 @@ describe("expected file changes", () => {
 			.split("\n")
 			.slice(2)
 			.join("\n")
-			.replaceAll(/@@ -.+ @@/, "@@ ... @@");
+			.replaceAll(/@@ -\d+,\d+ \+\d+,\d+ @@/g, "@@ ... @@");
 
 		assert(
 			stdout,

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -5,7 +5,7 @@ import { assert, describe, expect, test } from "vitest";
 
 import packageData from "../package.json" assert { type: "json" };
 
-const filesExpectedToBeChanged = new Set([
+const filesExpectedToBeChanged = [
 	"README.md",
 	"knip.jsonc",
 	"package.json",
@@ -17,6 +17,11 @@ const filesExpectedToBeChanged = new Set([
 	".gitignore",
 	".prettierignore",
 	"cspell.json",
+];
+
+const filesThatMightBeChanged = new Set([
+	...filesExpectedToBeChanged,
+	"script/__snapshots__/migrate-test-e2e.js.snap",
 ]);
 
 const {
@@ -34,6 +39,12 @@ const title = "Create TypeScript App";
 
 const originalDevelopment = (
 	await fs.readFile(".github/DEVELOPMENT.md")
+).toString();
+
+const originalReadme = (await fs.readFile("README.md")).toString();
+
+const originalSnapshots = (
+	await fs.readFile("script/__snapshots__/migrate-test-e2e.js.snap")
 ).toString();
 
 await $({
@@ -57,8 +68,45 @@ await fs.appendFile(
 	originalDevelopment.slice(originalDevelopment.indexOf("## Setup Scripts")),
 );
 
+// Ignore changes to the README.md all-contributor count and contributors table...
+const updatedReadme = (await fs.readFile("README.md")).toString();
+await fs.writeFile(
+	"README.md",
+	[
+		updatedReadme.slice(0, updatedReadme.indexOf("## Contributors")) +
+			originalReadme.slice(
+				originalReadme.indexOf("## Contributors"),
+				originalReadme.indexOf("<!-- markdownlint-restore -->"),
+			),
+		updatedReadme.slice(updatedReadme.indexOf("<!-- markdownlint-restore -->")),
+	]
+		.join("")
+		.replaceAll(
+			/All Contributors: \d+/g,
+			originalReadme.match(/All Contributors: \d+/)[0],
+		)
+		.replaceAll(
+			/all_contributors-\d+/g,
+			originalReadme.match(/all_contributors-\d+/)[0],
+		),
+);
+
+// ...and even to the snapshot file, so diffs don't mind it.
+await fs.writeFile(
+	"script/__snapshots__/migrate-test-e2e.js.snap",
+	originalSnapshots
+		.replaceAll(
+			/All Contributors: \d+/g,
+			originalReadme.match(/All Contributors: \d+/)[0],
+		)
+		.replaceAll(
+			/all_contributors-\d+/g,
+			originalReadme.match(/all_contributors-\d+/)[0],
+		),
+);
+
 describe("expected file changes", () => {
-	test.each([...filesExpectedToBeChanged])("%s", async (file) => {
+	test.each(filesExpectedToBeChanged)("%s", async (file) => {
 		const { stdout } = await execaCommand(`git diff HEAD -- ${file}`);
 		const contentsAfterGitMarkers = stdout.split("\n").slice(2).join("\n");
 
@@ -88,7 +136,7 @@ test("unexpected file changes", async () => {
 		.slice(indexOfUnstagedFilesMessage)
 		.match(/modified: {3}(\S+)\n/g)
 		.map((match) => match.split(/\s+/g)[1])
-		.filter((filePath) => !filesExpectedToBeChanged.has(filePath));
+		.filter((filePath) => !filesThatMightBeChanged.has(filePath));
 
 	console.log("Unexpected modified files are:", unstagedModifiedFiles);
 

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -108,7 +108,11 @@ await fs.writeFile(
 describe("expected file changes", () => {
 	test.each(filesExpectedToBeChanged)("%s", async (file) => {
 		const { stdout } = await execaCommand(`git diff HEAD -- ${file}`);
-		const contentsAfterGitMarkers = stdout.split("\n").slice(2).join("\n");
+		const contentsAfterGitMarkers = stdout
+			.split("\n")
+			.slice(2)
+			.join("\n")
+			.replaceAll(/@@ -.+ @@/, "@@ ... @@");
 
 		assert(
 			stdout,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1142 (again)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Resets the all-contributors count in the snapshot too. So there's much less diff noise around it.

In doing so, indicates that the snapshot file _might_ be changed. ANd that's ok.