### PR TITLE
fix: include bin entry in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"main": "./lib/index.js",
 	"bin": "./bin/index.js",
 	"files": [
-		"bin/",
+		"bin/index.js",
 		"lib/",
 		"package.json",
 		"LICENSE.md",

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -274,14 +274,6 @@ exports[`expected file changes > package.json 1`] = `
 "--- a/package.json
 +++ b/package.json
 @@ ... @@
- 	"main": "./lib/index.js",
- 	"bin": "./bin/index.js",
- 	"files": [
--		"bin/",
- 		"lib/",
- 		"package.json",
- 		"LICENSE.md",
-@@ ... @@
  	"scripts": {
  		"build": "tsup",
  		"format": "prettier \\"**/*\\" --ignore-unknown",

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -145,7 +145,7 @@ describe("writePackageJson", () => {
 			    "email": "npm@email.com",
 			    "name": "test-author",
 			  },
-			  "bin": "bin/index.js",
+			  "bin": "./bin/index.js",
 			  "description": "Test description.",
 			  "devDependencies": {},
 			  "engines": {

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -124,6 +124,7 @@ describe("writePackageJson", () => {
 
 		const packageJson = await writePackageJson({
 			...options,
+			bin: "./bin/index.js",
 			excludeAllContributors: true,
 			excludeCompliance: true,
 			excludeLintJson: true,
@@ -144,12 +145,14 @@ describe("writePackageJson", () => {
 			    "email": "npm@email.com",
 			    "name": "test-author",
 			  },
+			  "bin": "bin/index.js",
 			  "description": "Test description.",
 			  "devDependencies": {},
 			  "engines": {
 			    "node": ">=18",
 			  },
 			  "files": [
+			    "bin/index.js",
 			    "lib/",
 			    "package.json",
 			    "LICENSE.md",

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -33,8 +33,6 @@ export async function writePackageJson(options: Options) {
 	const existingPackageJson =
 		((await readFileSafeAsJson("./package.json")) as null | object) ?? {};
 
-	const bin = options.bin?.replace(/^\.\//, "");
-
 	return await formatJson({
 		// If we didn't already have a version, set it to 0.0.0
 		version: "0.0.0",
@@ -43,7 +41,7 @@ export async function writePackageJson(options: Options) {
 		...existingPackageJson,
 
 		author: { email: options.email.npm, name: options.author },
-		bin,
+		bin: options.bin,
 		description: options.description,
 		keywords: options.keywords?.length
 			? options.keywords.flatMap((keyword) => keyword.split(/ /))
@@ -62,9 +60,13 @@ export async function writePackageJson(options: Options) {
 		engines: {
 			node: ">=18",
 		},
-		files: [bin, "lib/", "package.json", "LICENSE.md", "README.md"].filter(
-			Boolean,
-		),
+		files: [
+			options.bin?.replace(/^\.\//, ""),
+			"lib/",
+			"package.json",
+			"LICENSE.md",
+			"README.md",
+		].filter(Boolean),
 		license: "MIT",
 		"lint-staged": {
 			"*": "prettier --ignore-unknown --write",

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -33,6 +33,8 @@ export async function writePackageJson(options: Options) {
 	const existingPackageJson =
 		((await readFileSafeAsJson("./package.json")) as null | object) ?? {};
 
+	const bin = options.bin?.replace(/^\.\//, "");
+
 	return await formatJson({
 		// If we didn't already have a version, set it to 0.0.0
 		version: "0.0.0",
@@ -41,7 +43,7 @@ export async function writePackageJson(options: Options) {
 		...existingPackageJson,
 
 		author: { email: options.email.npm, name: options.author },
-		bin: options.bin,
+		bin,
 		description: options.description,
 		keywords: options.keywords?.length
 			? options.keywords.flatMap((keyword) => keyword.split(/ /))
@@ -60,7 +62,9 @@ export async function writePackageJson(options: Options) {
 		engines: {
 			node: ">=18",
 		},
-		files: ["lib/", "package.json", "LICENSE.md", "README.md"],
+		files: [bin, "lib/", "package.json", "LICENSE.md", "README.md"].filter(
+			Boolean,
+		),
 		license: "MIT",
 		"lint-staged": {
 			"*": "prettier --ignore-unknown --write",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1147
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Includes a `files` entry if `bin` exists. Also strips a preceding `./` from it if it's there.