### PR TITLE
chore: fill in newline for .github/DEVELOPMENT.md migration snapshot

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -50,19 +50,6 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
  		{"
 `;
 
-exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
-"--- a/.github/DEVELOPMENT.md
-+++ b/.github/DEVELOPMENT.md
-@@ ... @@ Add \`--watch\` to keep the type checker running in a watch mode that updates the
- \`\`\`shell
- pnpm tsc --watch
- \`\`\`
--
- ## Setup Scripts
- 
- As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository."
-`;
-
 exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
 "--- a/.github/workflows/lint-knip.yml
 +++ b/.github/workflows/lint-knip.yml

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -65,7 +65,8 @@ await fs.writeFile(
 // We manually add them back after hydration to clear them from Git diffs.
 await fs.appendFile(
 	".github/DEVELOPMENT.md",
-	originalDevelopment.slice(originalDevelopment.indexOf("## Setup Scripts")),
+	"\n" +
+		originalDevelopment.slice(originalDevelopment.indexOf("## Setup Scripts")),
 );
 
 // Ignore changes to the README.md all-contributor count and contributors table...

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -11,7 +11,6 @@ const filesExpectedToBeChanged = [
 	"package.json",
 	".eslintignore",
 	".eslintrc.cjs",
-	".github/DEVELOPMENT.md",
 	".github/workflows/lint-knip.yml",
 	".github/workflows/test.yml",
 	".gitignore",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1150
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fills in that little `\n` to get rid of the file's expected diffs.