### PR TITLE
fix: normalize whether build happens before lint/knip

### DIFF
--- a/.github/workflows/lint-knip.yml
+++ b/.github/workflows/lint-knip.yml
@@ -4,7 +4,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
-      - run: pnpm build || true
       - run: pnpm lint:knip
 
 name: Lint Knip

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -63,19 +63,6 @@ exports[`expected file changes > .github/DEVELOPMENT.md 1`] = `
  As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository."
 `;
 
-exports[`expected file changes > .github/workflows/lint-knip.yml 1`] = `
-"--- a/.github/workflows/lint-knip.yml
-+++ b/.github/workflows/lint-knip.yml
-@@ ... @@ jobs:
-     steps:
-       - uses: actions/checkout@v4
-       - uses: ./.github/actions/prepare
--      - run: pnpm build || true
-       - run: pnpm lint:knip
- 
- name: Lint Knip"
-`;
-
 exports[`expected file changes > .github/workflows/test.yml 1`] = `
 "--- a/.github/workflows/test.yml
 +++ b/.github/workflows/test.yml

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -12,7 +12,6 @@ const filesExpectedToBeChanged = [
 	".eslintignore",
 	".eslintrc.cjs",
 	".github/DEVELOPMENT.md",
-	".github/workflows/lint-knip.yml",
 	".github/workflows/test.yml",
 	".gitignore",
 	".prettierignore",

--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -1,7 +1,7 @@
 import { $ } from "execa";
 
-import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { doesRepositoryExist } from "../shared/doesRepositoryExist.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { addToolAllContributors } from "../steps/addToolAllContributors.js";

--- a/src/create/createWithOptions.ts
+++ b/src/create/createWithOptions.ts
@@ -1,5 +1,6 @@
 import { $ } from "execa";
 
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
 import { doesRepositoryExist } from "../shared/doesRepositoryExist.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
@@ -37,11 +38,13 @@ export async function createWithOptions({ github, options }: GitHubAndOptions) {
 			finalizeDependencies(options),
 		);
 
-		await runCommands("Cleaning up files", [
-			"pnpm dedupe",
-			"pnpm lint --fix",
-			"pnpm format --write",
-		]);
+		await runCommands(
+			"Cleaning up files",
+			createCleanUpFilesCommands({
+				bin: !!options.bin,
+				dedupe: true,
+			}),
+		);
 	}
 
 	const sendToGitHub =

--- a/src/initialize/initializeWithOptions.ts
+++ b/src/initialize/initializeWithOptions.ts
@@ -1,5 +1,5 @@
-import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { addOwnerAsAllContributor } from "../steps/addOwnerAsAllContributor.js";
 import { clearChangelog } from "../steps/clearChangelog.js";

--- a/src/initialize/initializeWithOptions.ts
+++ b/src/initialize/initializeWithOptions.ts
@@ -1,3 +1,4 @@
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { addOwnerAsAllContributor } from "../steps/addOwnerAsAllContributor.js";
@@ -60,8 +61,10 @@ export async function initializeWithOptions({
 		);
 	}
 
-	await runCommands("Cleaning up files", [
-		"pnpm lint --fix",
-		"pnpm format --write",
-	]);
+	await runCommands(
+		"Cleaning up files",
+		createCleanUpFilesCommands({
+			bin: !!options.bin,
+		}),
+	);
 }

--- a/src/migrate/migrateWithOptions.ts
+++ b/src/migrate/migrateWithOptions.ts
@@ -1,3 +1,4 @@
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { clearUnnecessaryFiles } from "../steps/clearUnnecessaryFiles.js";
@@ -60,8 +61,11 @@ export async function migrateWithOptions({
 		);
 	}
 
-	await runCommands("Cleaning up files", [
-		"pnpm lint --fix",
-		"pnpm format --write",
-	]);
+	await runCommands(
+		"Cleaning up files",
+		createCleanUpFilesCommands({
+			bin: !!options.bin,
+			dedupe: true,
+		}),
+	);
 }

--- a/src/migrate/migrateWithOptions.ts
+++ b/src/migrate/migrateWithOptions.ts
@@ -1,5 +1,5 @@
-import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { withSpinner, withSpinners } from "../shared/cli/spinners.js";
+import { createCleanUpFilesCommands } from "../shared/createCleanUpFilesCommands.js";
 import { GitHubAndOptions } from "../shared/options/readOptions.js";
 import { clearUnnecessaryFiles } from "../steps/clearUnnecessaryFiles.js";
 import { detectExistingContributors } from "../steps/detectExistingContributors.js";

--- a/src/shared/createCleanUpFilesCommands.test.ts
+++ b/src/shared/createCleanUpFilesCommands.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { createCleanUpFilesCommands } from "./createCleanUpFilesCommands.js";
 

--- a/src/shared/createCleanUpFilesCommands.test.ts
+++ b/src/shared/createCleanUpFilesCommands.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCleanUpFilesCommands } from "./createCleanUpFilesCommands.js";
+
+describe("createCleanUpFilesCommands", () => {
+	it("only lints and formats when no options are specified", () => {
+		const actual = createCleanUpFilesCommands({});
+
+		expect(actual).toEqual(["pnpm lint --fix", "pnpm format --write"]);
+	});
+
+	it("runs dedupe and build before it lints and formats when both options are specified", () => {
+		const actual = createCleanUpFilesCommands({
+			bin: true,
+			dedupe: true,
+		});
+
+		expect(actual).toEqual([
+			"pnpm dedupe",
+			"pnpm build || exit 0",
+			"pnpm lint --fix",
+			"pnpm format --write",
+		]);
+	});
+});

--- a/src/shared/createCleanUpFilesCommands.ts
+++ b/src/shared/createCleanUpFilesCommands.ts
@@ -1,0 +1,18 @@
+export interface CleanUpFilesOptions {
+	bin?: boolean;
+	dedupe?: boolean;
+}
+
+export function createCleanUpFilesCommands({
+	bin,
+	dedupe,
+}: CleanUpFilesOptions) {
+	return [
+		// There's no need to dedupe when initializing from the fixed template
+		...(dedupe ? ["pnpm dedupe"] : []),
+		// n/no-missing-import rightfully reports on a missing the bin .js file
+		...(bin ? ["pnpm build || exit 0"] : []),
+		"pnpm lint --fix",
+		"pnpm format --write",
+	];
+}

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -7,6 +7,7 @@ const createOptions = (exclude: boolean) =>
 	({
 		access: "public",
 		base: "everything",
+		bin: exclude ? undefined : "./bin/index.js",
 		description: "Test description.",
 		directory: ".",
 		email: {
@@ -413,7 +414,6 @@ describe("createWorkflows", () => {
 			    steps:
 			      - uses: actions/checkout@v4
 			      - uses: ./.github/actions/prepare
-			      - run: pnpm build || true
 			      - run: pnpm lint
 
 			name: Lint

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -114,7 +114,7 @@ export function createWorkflows(options: Options) {
 		}),
 		"lint.yml": createWorkflowFile({
 			name: "Lint",
-			runs: ["pnpm build || true", "pnpm lint"],
+			runs: [...(options.bin ? ["pnpm build || true"] : []), "pnpm lint"],
 		}),
 		...(!options.excludeLintKnip && {
 			"lint-knip.yml": createWorkflowFile({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1087
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Finally makes it so a `pnpm build || exit 0` only happens if `bin` is specified. This is because:
* `n/no-missing-import` will complain if the referenced `.js` file doesn't exist
* The only way for that file to exist is to `build`
* But, building failing -especially in migrating an existing repo- shouldn't prevent the rest of the commands from running