### PR TITLE
feat: streamlined and unified README.md badges

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-  "badgeTemplate": "\t<a href=\"#contributors\" target=\"_blank\"><img alt=\"All Contributors: <%= contributors.length %> 👪\" src=\"https://img.shields.io/badge/all_contributors-<%= contributors.length %>_👪-21bb42.svg\" /></a>",
+  "badgeTemplate": "\t<a href=\"#contributors\" target=\"_blank\"><img alt=\"👪 All Contributors: <%= contributors.length %>\" src=\"https://img.shields.io/badge/👪_all_contributors-<%= contributors.length %>-21bb42.svg\" /></a>",
   "commit": false,
   "commitConvention": "angular",
   "commitType": "docs",

--- a/README.md
+++ b/README.md
@@ -5,16 +5,14 @@
 <p align="center">
 	<!-- prettier-ignore-start -->
 	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-  <a href="#contributors" target="_blank"><img alt="All Contributors: 40 👪" src="https://img.shields.io/badge/all_contributors-40_👪-21bb42.svg" /></a>
+	<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 40" src="https://img.shields.io/badge/👪_all_contributors-40-21bb42.svg" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 	<!-- prettier-ignore-end -->
-	<a href="https://codecov.io/gh/JoshuaKGoldberg/create-typescript-app" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/create-typescript-app/branch/main/graph/badge.svg"/></a>
-	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Code of Conduct: Enforced 🤝" src="https://img.shields.io/badge/code_of_conduct-enforced_🤝-21bb42" /></a>
-	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT 📝" src="https://img.shields.io/badge/license-MIT_📝-21bb42.svg"></a>
-	<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub 💸" src="https://img.shields.io/badge/sponsor-on_github_💸-21bb42.svg" /></a>
-	<img alt="Style: Prettier 🧹" src="https://img.shields.io/badge/style-prettier_🧹-21bb42.svg" />
-	<img alt="TypeScript: Strict 💪" src="https://img.shields.io/badge/typescript-strict_💪-21bb42.svg" />
-	<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
+	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+	<a href="https://codecov.io/gh/JoshuaKGoldberg/create-typescript-app" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/JoshuaKGoldberg/create-typescript-app?label=🧪%20coverage"/></a>
+	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+	<a href="http://npmjs.com/package/create-typescript-app"><img alt="📦 npm version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42&label=📦%20npm" /></a>
+	<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 </p>
 
 <img align="right" alt="Project logo: the TypeScript blue square with rounded corners, but a plus sign instead of 'TS'" src="./create-typescript-app.png">

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -95,27 +95,7 @@ exports[`expected file changes > README.md 1`] = `
 "--- a/README.md
 +++ b/README.md
 @@ ... @@
- <p align="center">
- 	<!-- prettier-ignore-start -->
- 	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
--  <a href="#contributors" target="_blank"><img alt="All Contributors: 39 👪" src="https://img.shields.io/badge/all_contributors-39_👪-21bb42.svg" /></a>
-+	<a href="#contributors" target="_blank"><img alt="All Contributors: 39 👪" src="https://img.shields.io/badge/all_contributors-39_👪-21bb42.svg" /></a>
- <!-- ALL-CONTRIBUTORS-BADGE:END -->
- 	<!-- prettier-ignore-end -->
- 	<a href="https://codecov.io/gh/JoshuaKGoldberg/create-typescript-app" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/create-typescript-app/branch/main/graph/badge.svg"/></a>
--	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Code of Conduct: Enforced 🤝" src="https://img.shields.io/badge/code_of_conduct-enforced_🤝-21bb42" /></a>
--	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT 📝" src="https://img.shields.io/badge/license-MIT_📝-21bb42.svg"></a>
--	<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub 💸" src="https://img.shields.io/badge/sponsor-on_github_💸-21bb42.svg" /></a>
--	<img alt="Style: Prettier 🧹" src="https://img.shields.io/badge/style-prettier_🧹-21bb42.svg" />
--	<img alt="TypeScript: Strict 💪" src="https://img.shields.io/badge/typescript-strict_💪-21bb42.svg" />
-+	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-+	<a href="https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/create-typescript-app?color=21bb42"></a>
-+	<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
-+	<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-+	<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
- 	<img alt="npm package version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42" />
-+	<a href="#contributors" target="_blank"><img alt="All Contributors: 39 👪" src="https://img.shields.io/badge/all_contributors-39_👪-21bb42.svg" /></a>
-+	<img alt="Sponsor: On GitHub 💸" src="https://img.shields.io/badge/sponsor-on_github_💸-21bb42.svg" />
+ 	<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
  </p>
  
 -<img align="right" alt="Project logo: the TypeScript blue square with rounded corners, but a plus sign instead of 'TS'" src="./create-typescript-app.png">

--- a/src/steps/writeReadme/findExistingBadges.test.ts
+++ b/src/steps/writeReadme/findExistingBadges.test.ts
@@ -20,7 +20,7 @@ describe("findExistingBadges", () => {
 
 	describe("single result cases", () => {
 		test.each([
-			`[![GitHub CI](https://github.com/JoshuaKGoldberg/console-fail-test/actions/workflows/compile.yml/badge.svg)](https://github.com/JoshuaKGoldberg/console-fail-test/actions/workflows/compile.yml)`,
+			`[![GitHub CI](https://github.com/ExampleOwner/console-fail-test/actions/workflows/compile.yml/badge.svg)](https://github.com/ExampleOwner/console-fail-test/actions/workflows/compile.yml)`,
 			`[![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)`,
 			`![TypeScript: Strict](https://img.shields.io/badge/typescript-strict-brightgreen.svg)`,
 			`[![NPM version](https://badge.fury.io/js/console-fail-test.svg)](http://badge.fury.io/js/console-fail-test)`,
@@ -36,14 +36,22 @@ describe("findExistingBadges", () => {
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
 					</a>`,
-			` <a href="https://codecov.io/gh/JoshuaKGoldberg/all-contributors-auto-action" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/all-contributors-auto-action/branch/main/graph/badge.svg"/></a>`,
-			` <a href="https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>`,
+			` <a href="https://codecov.io/gh/ExampleOwner/example-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/ExampleOwner/example-repository/branch/main/graph/badge.svg"/></a>`,
+			` <a href="https://github.com/ExampleOwner/example-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>`,
+			`<a href="http://npmjs.com/package/example-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/example-repository?color=21bb42&label=📦%20npm" /></a>`,
+			`<a href="https://codecov.io/gh/ExampleOwner/example-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/ExampleOwner/example-repository?label=🧪%20coverage"/></a>`,
+			`<a href="https://github.com/ExampleOwner/example-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: kept" src="https://img.shields.io/badge/kept-21bb42?label=🤝%20code%20of%20conduct" /></a>`,
+			`<a href="https://github.com/ExampleOwner/example-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>`,
+			`<a href="https://github.com/ExampleOwner/example-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/ExampleOwner/example-repository?color=21bb42"></a>`,
 			`
-			<a href="https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/all-contributors-auto-action?color=21bb42"></a>`,
-			`
-			<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>`,
+				<a href="https://github.com/ExampleOwner/example-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/ExampleOwner/example-repository?color=21bb42"></a>
+			`,
+			`<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />`,
 			`<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />`,
 			`<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />`,
+			`
+				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
+			`,
 		])("%s", (contents) => {
 			expect(findExistingBadges(contents)).toEqual([contents.trim()]);
 		});
@@ -82,10 +90,9 @@ describe("findExistingBadges", () => {
 	<a href="#contributors" target="_blank"><img alt="All Contributors: 1" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" /></a>
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- prettier-ignore-end -->
-	<a href="https://codecov.io/gh/JoshuaKGoldberg/all-contributors-auto-action" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/all-contributors-auto-action/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/></a>
-	<a href="https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-	<a href="https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/all-contributors-auto-action?color=21bb42"></a>
-	<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
+	<a href="https://codecov.io/gh/ExampleOwner/example-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/ExampleOwner/example-repository/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/></a>
+	<a href="https://github.com/ExampleOwner/example-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+	<a href="https://github.com/ExampleOwner/example-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/ExampleOwner/example-repository?color=21bb42"></a>
 	<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
   <img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
 </p>
@@ -93,10 +100,11 @@ describe("findExistingBadges", () => {
 		).toMatchInlineSnapshot(`
 			[
 			  "<a href="#contributors" target="_blank"><img alt="All Contributors: 1" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" /></a>",
-			  "<a href="https://github.com/JoshuaKGoldberg/all-contributors-auto-action/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>",
-			  "<a href="https://github.com/sponsors/JoshuaKGoldberg" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>",
-			  "<img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/all-contributors-auto-action/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/>",
+			  "<a href="https://codecov.io/gh/ExampleOwner/example-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/ExampleOwner/example-repository/branch/main/graph/badge.svg?token=eVIFY4MhfQ"/></a>",
+			  "<a href="https://github.com/ExampleOwner/example-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>",
+			  "<a href="https://github.com/ExampleOwner/example-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/ExampleOwner/example-repository?color=21bb42"></a>",
 			  "<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />",
+			  "<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />",
 			]
 		`);
 	});

--- a/src/steps/writeReadme/findExistingBadges.ts
+++ b/src/steps/writeReadme/findExistingBadges.ts
@@ -10,9 +10,8 @@ export function findExistingBadges(contents: string): string[] {
 	let remaining = contents.split(/<\s*h2.*>|##/)[0];
 
 	for (const createMatcher of existingBadgeMatcherCreators) {
-		const matcher = createMatcher();
-
 		while (true) {
+			const matcher = createMatcher();
 			const matched = matcher.exec(remaining);
 
 			if (!matched) {
@@ -22,10 +21,8 @@ export function findExistingBadges(contents: string): string[] {
 			const [badge] = matched;
 
 			badges.push(badge.trim());
-			remaining = [
-				remaining.slice(0, matched.index),
-				remaining.slice(matched.index + badge.length),
-			].join("");
+
+			remaining = remaining.replace(badge, "");
 		}
 	}
 

--- a/src/steps/writeReadme/generateTopContent.test.ts
+++ b/src/steps/writeReadme/generateTopContent.test.ts
@@ -27,15 +27,14 @@ describe("findExistingBadges", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/test-owner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 			</p>
 
 			## Usage
@@ -64,15 +63,14 @@ describe("findExistingBadges", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/test-owner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 			</p>
 
 			## Usage
@@ -101,15 +99,14 @@ describe("findExistingBadges", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/test-owner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 				<img alt="Unknown Badge" src="unknown.svg" />
 			</p>
 
@@ -136,15 +133,14 @@ describe("findExistingBadges", () => {
 				<p align="center">
 					<!-- prettier-ignore-start -->
 					<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-					<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+					<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 					<!-- ALL-CONTRIBUTORS-BADGE:END -->
 					<!-- prettier-ignore-end -->
-					<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/test-owner/test-repository/branch/main/graph/badge.svg"/></a>
-					<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-					<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/test-owner/test-repository?color=21bb42"></a>
-					<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-					<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-					<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+					<a href="https://github.com/test-owner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+					<a href="https://codecov.io/gh/test-owner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/test-owner/test-repository?label=🧪%20coverage"/></a>
+					<a href="https://github.com/test-owner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+					<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+					<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 				</p>"
 			`);
 	});

--- a/src/steps/writeReadme/generateTopContent.ts
+++ b/src/steps/writeReadme/generateTopContent.ts
@@ -4,10 +4,38 @@ export function generateTopContent(options: Options, existingBadges: string[]) {
 	const remainingExistingBadges = new Set(existingBadges);
 	const badges: string[] = [];
 
-	function spliceBadge(
-		badgeLine: false | string | undefined,
-		existingMatcher: RegExp,
-	) {
+	for (const [badgeLine, existingMatcher] of [
+		[
+			!options.excludeAllContributors &&
+				`<!-- prettier-ignore-start -->
+	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+	<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
+	<!-- ALL-CONTRIBUTORS-BADGE:END -->
+	<!-- prettier-ignore-end -->`,
+			/<a\s+href.*contributors.*All\s+Contributors/,
+		],
+		[
+			`<a href="https://github.com/${options.owner}/${options.repository}/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>`,
+			/CODE_OF_CONDUCT\.md/,
+		],
+		[
+			!options.excludeTests &&
+				`<a href="https://codecov.io/gh/${options.owner}/${options.repository}" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/${options.owner}/${options.repository}?label=🧪%20coverage"/></a>`,
+			/https:\/\/codecov\.io\/gh/,
+		],
+		[
+			`<a href="https://github.com/${options.owner}/${options.repository}/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>`,
+			/LICENSE\.(md|txt)/,
+		],
+		[
+			`<a href="http://npmjs.com/package/${options.repository}"><img alt="📦 npm version" src="https://img.shields.io/npm/v/${options.repository}?color=21bb42&label=📦%20npm" /></a>`,
+			/npm.*v/i,
+		],
+		[
+			`<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />`,
+			/typescript.*strict/i,
+		],
+	] as const) {
 		const existingMatch = existingBadges.find((existingLine) =>
 			existingMatcher.test(existingLine),
 		);
@@ -19,50 +47,6 @@ export function generateTopContent(options: Options, existingBadges: string[]) {
 		if (badgeLine) {
 			badges.push(badgeLine);
 		}
-	}
-
-	for (const [badgeLine, existingMatcher] of [
-		[
-			!options.excludeAllContributors &&
-				`<!-- prettier-ignore-start -->
-	<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-	<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
-	<!-- ALL-CONTRIBUTORS-BADGE:END -->
-	<!-- prettier-ignore-end -->`,
-			/ALL-CONTRIBUTORS-BADGE:START/,
-		],
-		[
-			!options.excludeTests &&
-				`<a href="https://codecov.io/gh/${options.owner}/${options.repository}" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/${options.owner}/${options.repository}/branch/main/graph/badge.svg"/></a>`,
-			/https:\/\/codecov\.io\/gh/,
-		],
-		[
-			`<a href="https://github.com/${options.owner}/${options.repository}/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>`,
-			/CODE_OF_CONDUCT\.md/,
-		],
-		[
-			`<a href="https://github.com/${options.owner}/${options.repository}/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/${options.owner}/${options.repository}?color=21bb42"></a>`,
-			/LICENSE\.(md|txt)/,
-		],
-		[
-			options.funding &&
-				`<a href="https://github.com/sponsors/${options.funding}" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>`,
-			/github.+sponsors/,
-		],
-		[
-			`<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />`,
-			/style.*prettier/i,
-		],
-		[
-			`<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />`,
-			/typescript.*strict/i,
-		],
-		[
-			`<img alt="npm package version" src="https://img.shields.io/npm/v/${options.repository}?color=21bb42" />`,
-			/npm.*v/i,
-		],
-	] as const) {
-		spliceBadge(badgeLine, existingMatcher);
 	}
 
 	return `<h1 align="center">${options.title}</h1>

--- a/src/steps/writeReadme/index.test.ts
+++ b/src/steps/writeReadme/index.test.ts
@@ -57,16 +57,14 @@ describe("writeReadme", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42"></a>
-				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/TestOwner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 			</p>
 
 			## Usage
@@ -118,16 +116,14 @@ describe("writeReadme", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42"></a>
-				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/TestOwner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 			</p>
 
 			## Usage
@@ -182,16 +178,14 @@ describe("writeReadme", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42"></a>
-				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
-				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
+				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/TestOwner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 			</p>
 
 			## Usage
@@ -280,17 +274,15 @@ describe("writeReadme", () => {
 			<p align="center">
 				<!-- prettier-ignore-start -->
 				<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
+				<a href="#contributors" target="_blank"><img alt="👪 All Contributors: 1" src="https://img.shields.io/badge/👪_all_contributors-1-21bb42.svg" /></a>
 				<!-- ALL-CONTRIBUTORS-BADGE:END -->
 				<!-- prettier-ignore-end -->
-				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/TestOwner/test-repository/branch/main/graph/badge.svg"/></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
-				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/TestOwner/test-repository?color=21bb42"></a>
-				<a href="https://github.com/sponsors/TestFunding" target="_blank"><img alt="Sponsor: On GitHub" src="https://img.shields.io/badge/sponsor-on_github-21bb42.svg" /></a>
+				<a href="https://github.com/TestOwner/test-repository/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="🤝 Code of Conduct: Kept" src="https://img.shields.io/badge/🤝_code_of_conduct-kept-21bb42" /></a>
+				<a href="https://codecov.io/gh/TestOwner/test-repository" target="_blank"><img alt="🧪 Coverage" src="https://img.shields.io/codecov/c/github/TestOwner/test-repository?label=🧪%20coverage"/></a>
+				<a href="https://github.com/TestOwner/test-repository/blob/main/LICENSE.md" target="_blank"><img alt="📝 License: MIT" src="https://img.shields.io/badge/📝_license-MIT-21bb42.svg"></a>
+				<a href="http://npmjs.com/package/test-repository"><img alt="📦 npm version" src="https://img.shields.io/npm/v/test-repository?color=21bb42&label=📦%20npm" /></a>
+				<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/💪_typescript-strict-21bb42.svg" />
 				<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
-				<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
-				<img alt="npm package version" src="https://img.shields.io/npm/v/test-repository?color=21bb42" />
-				<a href="#contributors" target="_blank"><img alt="All Contributors: 2" src="https://img.shields.io/badge/all_contributors-17-21bb42.svg" /></a>
 			</p>
 
 			## Usage

--- a/src/steps/writing/creation/writeAllContributorsRC.ts
+++ b/src/steps/writing/creation/writeAllContributorsRC.ts
@@ -9,7 +9,7 @@ export async function writeAllContributorsRC(options: Options) {
 
 	return await formatJson({
 		badgeTemplate:
-			'	<a href="#contributors" target="_blank"><img alt="All Contributors: <%= contributors.length %> 👪" src="https://img.shields.io/badge/all_contributors-<%= contributors.length %>_👪-21bb42.svg" /></a>',
+			'	<a href="#contributors" target="_blank"><img alt="👪 All Contributors: <%= contributors.length %>" src="https://img.shields.io/badge/👪_all_contributors-<%= contributors.length %>-21bb42.svg" /></a>',
 		commit: false,
 		commitConvention: "angular",
 		commitType: "docs",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1088
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Standardizes README.md badges to have the emoji at the start because I want them consistent and the npm version badge can't have the emoji tacked on.

Streamlines them by removing the _sponsor_ and _style_ badges and trimming the _code of conduct_ badge down to say _kept_ instead of _enforced. This means they should all fit on one line in the npm site.

Also fixes a bug in `findExistingBadges` where matchers were being re-created _then_ looped on, instead of re-created each instance of the loop. `/g` regexp state matters!