### PR TITLE
fix: don't || exit 0 in cleanup build

### DIFF
--- a/src/shared/createCleanUpFilesCommands.test.ts
+++ b/src/shared/createCleanUpFilesCommands.test.ts
@@ -17,7 +17,7 @@ describe("createCleanUpFilesCommands", () => {
 
 		expect(actual).toEqual([
 			"pnpm dedupe",
-			"pnpm build || exit 0",
+			"pnpm build",
 			"pnpm lint --fix",
 			"pnpm format --write",
 		]);

--- a/src/shared/createCleanUpFilesCommands.ts
+++ b/src/shared/createCleanUpFilesCommands.ts
@@ -11,7 +11,7 @@ export function createCleanUpFilesCommands({
 		// There's no need to dedupe when initializing from the fixed template
 		...(dedupe ? ["pnpm dedupe"] : []),
 		// n/no-missing-import rightfully reports on a missing the bin .js file
-		...(bin ? ["pnpm build || exit 0"] : []),
+		...(bin ? ["pnpm build"] : []),
 		"pnpm lint --fix",
 		"pnpm format --write",
 	];


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the `|| exit 0` per the issue.