### PR TITLE
chore: align knip.jsonc lines to Prettier

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -2,9 +2,6 @@
 	"$schema": "https://unpkg.com/knip@latest/schema.json",
 	"entry": ["src/index.ts!", "script/*e2e.js"],
 	"ignoreBinaries": ["gh"],
-	"ignoreExportsUsedInFile": {
-		"interface": true,
-		"type": true
-	},
+	"ignoreExportsUsedInFile": { "interface": true, "type": true },
 	"project": ["src/**/*.ts!", "script/**/*.js"]
 }

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -204,13 +204,9 @@ exports[`expected file changes > knip.jsonc 1`] = `
  	"$schema": "https://unpkg.com/knip@latest/schema.json",
 -	"entry": ["src/index.ts!", "script/*e2e.js"],
 -	"ignoreBinaries": ["gh"],
--	"ignoreExportsUsedInFile": {
--		"interface": true,
--		"type": true
--	},
--	"project": ["src/**/*.ts!", "script/**/*.js"]
 +	"entry": ["src/index.ts!"],
-+	"ignoreExportsUsedInFile": { "interface": true, "type": true },
+ 	"ignoreExportsUsedInFile": { "interface": true, "type": true },
+-	"project": ["src/**/*.ts!", "script/**/*.js"]
 +	"project": ["src/**/*.ts!"]
  }"
 `;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1179
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Puts the `ignoreExportsUsedInFile` properties all on one line, to reduce snapshot size.