### PR TITLE
fix: allow chmod to fail in setup

### DIFF
--- a/src/steps/writing/writeStructure.test.ts
+++ b/src/steps/writing/writeStructure.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Options } from "../../shared/types.js";
+import { writeStructure } from "./writeStructure.js";
+
+const mock$ = vi.fn();
+
+vi.mock("execa", () => ({
+	get $() {
+		return mock$;
+	},
+}));
+
+vi.mock("./creation/index.js");
+vi.mock("./writeStructureWorker.js");
+
+const options = {
+	access: "public",
+	author: "TestAuthor",
+	base: "everything",
+	description: "Test description.",
+	directory: ".",
+	email: {
+		github: "github@email.com",
+		npm: "npm@email.com",
+	},
+	keywords: ["abc", "def ghi", "jkl mno pqr"],
+	mode: "create",
+	owner: "TestOwner",
+	repository: "test-repository",
+	title: "Test Title",
+} satisfies Options;
+
+describe("writeStructure", () => {
+	it("resolves when chmod resolves", async () => {
+		mock$.mockResolvedValue(undefined);
+
+		await expect(writeStructure(options)).resolves.toBeUndefined();
+	});
+
+	it("resolves when chmod rejects", async () => {
+		mock$.mockRejectedValue(new Error("Oh no!"));
+
+		await expect(writeStructure(options)).resolves.toBeUndefined();
+	});
+});

--- a/src/steps/writing/writeStructure.ts
+++ b/src/steps/writing/writeStructure.ts
@@ -7,6 +7,10 @@ import { writeStructureWorker } from "./writeStructureWorker.js";
 export async function writeStructure(options: Options) {
 	await writeStructureWorker(await createStructure(options), ".");
 
-	// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/718
-	await $`chmod ug+x .husky/pre-commit`;
+	try {
+		// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/718
+		await $`chmod ug+x .husky/pre-commit`;
+	} catch {
+		// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1195
+	}
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1195
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Wraps the `chmod` with a `try`/`catch`. I figure if it fails then that's probably a sign the running OS doesn't have it and therefore doesn't need it.