### PR TITLE
chore: unify pnpm @8.14.0

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -231,14 +231,5 @@ exports[`expected file changes > package.json 1`] = `
 -		"test:migrate": "vitest run -r script/",
  		"tsc": "tsc"
  	},
- 	"lint-staged": {
-@@ ... @@
- 		"vitest": "^1.0.2",
- 		"yaml-eslint-parser": "^1.2.2"
- 	},
--	"packageManager": "pnpm@8.13.1",
-+	"packageManager": "pnpm@8.7.0",
- 	"engines": {
- 		"node": ">=18"
- 	},"
+ 	"lint-staged": {"
 `;

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -91,7 +91,7 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@8.7.0",
+			  "packageManager": "pnpm@8.14.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },
@@ -164,7 +164,7 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@8.7.0",
+			  "packageManager": "pnpm@8.14.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -73,7 +73,7 @@ export async function writePackageJson(options: Options) {
 		},
 		main: "./lib/index.js",
 		name: options.repository,
-		packageManager: "pnpm@8.7.0",
+		packageManager: "pnpm@8.14.0",
 		publishConfig: {
 			provenance: true,
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1199
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sets `pnpm` to always reference the current latest `pnpm@8.14.0`. Removes the unnecessary diff in the migration test snapshot.