### PR TITLE
chore: change label color for area:testing

### DIFF
--- a/src/steps/initializeGitHubRepository/labels/outcomeLabels.ts
+++ b/src/steps/initializeGitHubRepository/labels/outcomeLabels.ts
@@ -6,7 +6,7 @@ export const outcomeLabels = [
 		name: "area: documentation",
 	},
 	{
-		color: "6009D7",
+		color: "1177aa",
 		description:
 			"Improving how the repository's tests are run and/or code is tested 🧪",
 		name: "area: testing",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1201
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Changes the color for the `area:testing`  label to `#1177AA`
<!-- Description of what is changed and how the code change does that. -->
