### PR TITLE
docs: mention GitHub tab size setting

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -128,4 +128,6 @@ It does so because tabs have been phrased by the community as generally better f
 Note that those points on tabs over spaces have generally been made by accessibility-experienced _individuals_ rather than accessibility-focused _organizations_.
 If you know of any accessibility organization that's published more formal recommendations or research, please do file an issue here for this FAQ entry to be updated.
 
+You can adjust the tab size that GitHub uses to display files from your [account settings page](https://github.com/settings/appearance#tab-size-heading) (the default is 8 spaces).
+
 If you really want spaces in your project you can always remove the `"useTabs": true`.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I was going to change my prettier settings from tabs to spaces until I discovered that GitHub has a setting that lets you change the tab size from the default of 8. If I'd had this set to 2 (my preference) before setting up my repo, I probably wouldn't have even noticed that I was using tabs!
