### PR TITLE
fix: skip replacing existing tooling in --mode migrate

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -101,43 +101,9 @@ exports[`expected file changes > README.md 1`] = `
 -\`create-typescript-app\` is a one-stop-shop solution to set up a new or existing repository with the latest and greatest TypeScript tooling.
 -It includes options not just for building and testing but also GitHub repository templates, contributor recognition, automated release management, and more.
 -
--## Getting Started
--
--First make sure you have the following installed:
--
--- [GitHub CLI](https://cli.github.com) _(you'll need to be logged in)_
--- [Node.js](https://nodejs.org)
--- [pnpm](https://pnpm.io)
--
--Then in an existing repository or in your directory where you'd like to make a new repository:
--
--\`\`\`shell
--npx create-typescript-app
--\`\`\`
--
--That setup script will walk you through using the template.
--You can read more about the supported setup modes in their docs pages:
--
--- [**Creating from the terminal**](./docs/Creation.md): creating a new repository locally on the command-line _(recommended)_
--- [**Initializing from the template**](./docs/Initialization.md): creating a new repository with the [_Use this template_](https://github.com/JoshuaKGoldberg/create-typescript-app/generate) button on GitHub
--- [**Migrating an existing repository**](./docs/Migration.md): adding this template's tooling on top of an existing repository
--
--## Documentation
--
--You can read more about \`create-typescript-app\` and the tooling it supports:
--
--1. [**Tooling**](./docs/Tooling.md): a breakdown of all the pieces this template can set up.
--2. [**Options**](./docs/Options.md): granular options to customize how the template is run.
--3. [**FAQs**](./docs/FAQs.md): frequently asked questions
--
--> [!NOTE]  
--> This template is early stage, opinionated, and not endorsed by the TypeScript team.
--> It can be configured to set up a _lot_ of tooling out of the box.
--> If you don't want to use any particular tool, you can always remove it manually.
--
- ## Development
+ ## Getting Started
  
- See [\`.github/CONTRIBUTING.md\`](./.github/CONTRIBUTING.md), then [\`.github/DEVELOPMENT.md\`](./.github/DEVELOPMENT.md).
+ First make sure you have the following installed:
 @@ ... @@ Thanks! 💖
  
  <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -37,10 +37,6 @@ const logoAlt = `Project logo: the TypeScript blue square with rounded corners, 
 const owner = "JoshuaKGoldberg";
 const title = "Create TypeScript App";
 
-const originalDevelopment = (
-	await fs.readFile(".github/DEVELOPMENT.md")
-).toString();
-
 const originalReadme = (await fs.readFile("README.md")).toString();
 
 const originalSnapshots = (
@@ -59,14 +55,6 @@ await fs.writeFile(
 		null,
 		2,
 	) + "\n",
-);
-
-// The development setup scripts docs can be ignored from snapshots.
-// We manually add them back after hydration to clear them from Git diffs.
-await fs.appendFile(
-	".github/DEVELOPMENT.md",
-	"\n" +
-		originalDevelopment.slice(originalDevelopment.indexOf("## Setup Scripts")),
 );
 
 // Ignore changes to the README.md all-contributor count and contributors table...

--- a/src/steps/updateLocalFiles.test.ts
+++ b/src/steps/updateLocalFiles.test.ts
@@ -383,6 +383,75 @@ describe("updateLocalFiles", () => {
 		`);
 	});
 
+	it("doesn't remove existing tooling when mode is migrate", async () => {
+		mockReadFileSafeAsJson.mockResolvedValue({});
+		mockReplaceInFile.mockResolvedValue([]);
+
+		await updateLocalFiles({ ...options, mode: "migrate" });
+
+		expect(mockReplaceInFile.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /Create TypeScript App/g,
+			      "to": "Stub Title",
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /JoshuaKGoldberg\\(\\?:\\\\/\\(\\.\\+\\)\\)\\?/g,
+			      "to": [Function],
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": "package.json",
+			      "from": /JoshuaKGoldberg/g,
+			      "to": "StubOwner",
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": [
+			        "./.github/**/*",
+			        "./*.*",
+			      ],
+			      "from": /create-typescript-app/g,
+			      "to": "stub-repository",
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": ".eslintrc.cjs",
+			      "from": /\\\\/\\\\\\*\\\\n\\.\\+\\\\\\*\\\\/\\\\n\\\\n/gs,
+			      "to": "",
+			    },
+			  ],
+			  [
+			    {
+			      "allowEmptyPaths": true,
+			      "files": "./package.json",
+			      "from": /"author": "\\.\\+"/g,
+			      "to": ""author": "undefined"",
+			    },
+			  ],
+			]
+		`);
+	});
+
 	it("does not replace an existing description when it does not exist", async () => {
 		mockReadFileSafeAsJson.mockResolvedValue({});
 		mockReplaceInFile.mockResolvedValue([]);
@@ -396,6 +465,7 @@ describe("updateLocalFiles", () => {
 			to: options.description,
 		});
 	});
+
 	it("replaces an existing description when it exists", async () => {
 		const existingDescription = "Existing description.";
 

--- a/src/steps/updateLocalFiles.ts
+++ b/src/steps/updateLocalFiles.ts
@@ -21,26 +21,40 @@ export async function updateLocalFiles(options: Options) {
 		[/create-typescript-app/g, options.repository],
 		[/\/\*\n.+\*\/\n\n/gs, ``, ".eslintrc.cjs"],
 		[/"author": ".+"/g, `"author": "${options.author}"`, "./package.json"],
-		[/"test:create": ".+\n/g, ``, "./package.json"],
-		[/"test:initialize": ".*/g, ``, "./package.json"],
-		[/"initialize": ".*/g, ``, "./package.json"],
-		[/"test:migrate": ".+\n/g, ``, "./package.json"],
-		[/## Getting Started.*## Development/gs, `## Development`, "./README.md"],
-		[/\n## Setup Scripts.*$/gs, "", "./.github/DEVELOPMENT.md"],
-		[`\t\t"src/initialize/index.ts",\n`, ``, "./knip.jsonc"],
-		[`\t\t"src/migrate/index.ts",\n`, ``, "./knip.jsonc"],
-		[
-			`["src/index.ts!", "script/initialize*.js"]`,
-			`"src/index.ts!"`,
-			"./knip.jsonc",
-		],
-		[`["src/**/*.ts!", "script/**/*.js"]`, `"src/**/*.ts!"`, "./knip.jsonc"],
-		// Edge case: migration scripts will rewrite README.md attribution
-		[
-			/> 💙 This package was templated with .+\./g,
-			endOfReadmeTemplateLine,
-			"./README.md",
-		],
+		...(options.mode === "migrate"
+			? []
+			: ([
+					// Only creating a new repository should remove these parts.
+					// Existing ones might coincidentally have them too.
+					[/"test:create": ".+\n/g, ``, "./package.json"],
+					[/"test:initialize": ".*/g, ``, "./package.json"],
+					[/"initialize": ".*/g, ``, "./package.json"],
+					[/"test:migrate": ".+\n/g, ``, "./package.json"],
+					[
+						/## Getting Started.*## Development/gs,
+						`## Development`,
+						"./README.md",
+					],
+					[/\n## Setup Scripts.*$/gs, "", "./.github/DEVELOPMENT.md"],
+					[`\t\t"src/initialize/index.ts",\n`, ``, "./knip.jsonc"],
+					[`\t\t"src/migrate/index.ts",\n`, ``, "./knip.jsonc"],
+					[
+						`["src/index.ts!", "script/initialize*.js"]`,
+						`"src/index.ts!"`,
+						"./knip.jsonc",
+					],
+					[
+						`["src/**/*.ts!", "script/**/*.js"]`,
+						`"src/**/*.ts!"`,
+						"./knip.jsonc",
+					],
+					// Edge case: migration scripts will rewrite README.md attribution
+					[
+						/> 💙 This package was templated with .+\./g,
+						endOfReadmeTemplateLine,
+						"./README.md",
+					],
+			  ] as typeof replacements)),
 	];
 
 	if (existingPackage.description) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1220
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Gates those elements of `replacements` behind `options.mode` not being `"migrate"`. Which means the end-to-end migration snapshot for `.github/DEVELOPMENT.md` no longer shows removing `## Setup Scripts`! Yay!