### PR TITLE
chore: use prettier .

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
-		"format": "prettier \"**/*\" --ignore-unknown",
+		"format": "prettier .",
 		"initialize": "tsx ./bin/index.js --mode initialize",
 		"lint": "eslint . .*js --max-warnings 0",
 		"lint:knip": "knip",

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -167,7 +167,7 @@ exports[`expected file changes > package.json 1`] = `
 @@ ... @@
  	"scripts": {
  		"build": "tsup",
- 		"format": "prettier \\"**/*\\" --ignore-unknown",
+ 		"format": "prettier .",
 -		"initialize": "tsx ./bin/index.js --mode initialize",
  		"lint": "eslint . .*js --max-warnings 0",
  		"lint:knip": "knip",

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -101,7 +101,7 @@ describe("writePackageJson", () => {
 			  },
 			  "scripts": {
 			    "build": "tsup",
-			    "format": "prettier "**/*" --ignore-unknown",
+			    "format": "prettier .",
 			    "lint": "eslint . .*js --max-warnings 0",
 			    "lint:knip": "knip",
 			    "lint:md": "markdownlint "**/*.md" ".github/**/*.md" --rules sentences-per-line",
@@ -174,7 +174,7 @@ describe("writePackageJson", () => {
 			  },
 			  "scripts": {
 			    "build": "tsup",
-			    "format": "prettier "**/*" --ignore-unknown",
+			    "format": "prettier .",
 			    "lint": "eslint . .*js --max-warnings 0",
 			    "prepare": "husky install",
 			    "tsc": "tsc",

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -83,7 +83,7 @@ export async function writePackageJson(options: Options) {
 		},
 		scripts: {
 			build: "tsup",
-			format: 'prettier "**/*" --ignore-unknown',
+			format: "prettier .",
 			lint: "eslint . .*js --max-warnings 0",
 			...(!options.excludeLintKnip && {
 				"lint:knip": "knip",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1218
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Directly replaces `prettier "**/*" --ignore-unknown` with `prettier .` per Prettier's blog post.