### PR TITLE
fix: preserve existing package.json scripts

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -160,26 +160,3 @@ exports[`expected file changes > knip.json 1`] = `
 +	"project": ["src/**/*.ts!"]
  }"
 `;
-
-exports[`expected file changes > package.json 1`] = `
-"--- a/package.json
-+++ b/package.json
-@@ ... @@
- 	"scripts": {
- 		"build": "tsup",
- 		"format": "prettier .",
--		"initialize": "tsx ./bin/index.js --mode initialize",
- 		"lint": "eslint . .*js --max-warnings 0",
- 		"lint:knip": "knip",
- 		"lint:md": "markdownlint \\"**/*.md\\" \\".github/**/*.md\\" --rules sentences-per-line",
-@@ ... @@
- 		"prepare": "husky install",
- 		"should-semantic-release": "should-semantic-release --verbose",
- 		"test": "vitest",
--		"test:create": "node script/create-test-e2e.js",
--		"test:initialize": "node script/initialize-test-e2e.js",
--		"test:migrate": "vitest run -r script/",
- 		"tsc": "tsc"
- 	},
- 	"lint-staged": {"
-`;

--- a/script/migrate-test-e2e.js
+++ b/script/migrate-test-e2e.js
@@ -9,7 +9,6 @@ import packageData from "../package.json" assert { type: "json" };
 const filesExpectedToBeChanged = [
 	"README.md",
 	"knip.json",
-	"package.json",
 	".eslintignore",
 	".eslintrc.cjs",
 	".github/workflows/test.yml",

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -1,5 +1,5 @@
 import { readFileSafeAsJson } from "../../../shared/readFileSafeAsJson.js";
-import { Options } from "../../../shared/types.js";
+import { Options, PartialPackageData } from "../../../shared/types.js";
 import { formatJson } from "./formatters/formatJson.js";
 
 const devDependenciesToRemove = [
@@ -31,7 +31,9 @@ const devDependenciesToRemove = [
 
 export async function writePackageJson(options: Options) {
 	const existingPackageJson =
-		((await readFileSafeAsJson("./package.json")) as null | object) ?? {};
+		((await readFileSafeAsJson(
+			"./package.json",
+		)) as PartialPackageData | null) ?? {};
 
 	return await formatJson({
 		// If we didn't already have a version, set it to 0.0.0
@@ -82,6 +84,7 @@ export async function writePackageJson(options: Options) {
 			url: `https://github.com/${options.owner}/${options.repository}`,
 		},
 		scripts: {
+			...existingPackageJson.scripts,
 			build: "tsup",
 			format: "prettier .",
 			lint: "eslint . .*js --max-warnings 0",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1226
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Changes `package.json` creation to preserve any existing `scripts`.