### PR TITLE
perf: use --no-dts in cleanup and pre-lint builds

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
-      - run: pnpm build || true
+      - run: pnpm build --no-dts
       - run: pnpm lint
 
 name: Lint

--- a/src/shared/createCleanupCommands.test.ts
+++ b/src/shared/createCleanupCommands.test.ts
@@ -20,7 +20,7 @@ describe("createCleanupCommands", () => {
 
 		expect(actual).toEqual([
 			"pnpm dedupe",
-			"pnpm build",
+			"pnpm build --no-dts",
 			"pnpm lint --fix",
 			"pnpm format --write",
 		]);

--- a/src/shared/createCleanupCommands.ts
+++ b/src/shared/createCleanupCommands.ts
@@ -8,7 +8,7 @@ export function createCleanupCommands({
 		// There's no need to dedupe when initializing from the fixed template
 		...(mode === "initialize" ? [] : ["pnpm dedupe"]),
 		// n/no-missing-import rightfully reports on a missing the bin .js file
-		...(bin ? ["pnpm build"] : []),
+		...(bin ? ["pnpm build --no-dts"] : []),
 		"pnpm lint --fix",
 		"pnpm format --write",
 	];

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -216,7 +216,7 @@ describe("createWorkflows", () => {
 			    steps:
 			      - uses: actions/checkout@v4
 			      - uses: ./.github/actions/prepare
-			      - run: pnpm build || true
+			      - run: pnpm build --no-dts
 			      - run: pnpm lint
 
 			name: Lint

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -114,7 +114,7 @@ export function createWorkflows(options: Options) {
 		}),
 		"lint.yml": createWorkflowFile({
 			name: "Lint",
-			runs: [...(options.bin ? ["pnpm build || true"] : []), "pnpm lint"],
+			runs: [...(options.bin ? ["pnpm build --no-dts"] : []), "pnpm lint"],
 		}),
 		...(!options.excludeLintKnip && {
 			"lint-knip.yml": createWorkflowFile({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1162
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the lovely, newly-discovered-by-me `--no-dts` option. Now the builds done before CI linting (when `options.bin` is enabled) and in the cleanup commands should be much faster.