### PR TITLE
fix: disable jsonc/comma-dangle

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -96,6 +96,7 @@ module.exports = {
 			files: ["*.json", "*.jsonc"],
 			parser: "jsonc-eslint-parser",
 			rules: {
+				"jsonc/comma-dangle": "off",
 				"jsonc/sort-keys": "error",
 			},
 		},

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -183,6 +183,7 @@ describe("createESLintRC", () => {
 				      files: ["*.json", "*.jsonc"],
 				      parser: "jsonc-eslint-parser",
 				      rules: {
+				        "jsonc/comma-dangle": "off",
 				        "jsonc/sort-keys": "error",
 				      },
 				    },

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -124,6 +124,7 @@ module.exports = {
 			files: ["*.json", "*.jsonc"],
 			parser: "jsonc-eslint-parser",
 			rules: {
+				"jsonc/comma-dangle": "off",
 				"jsonc/sort-keys": "error",
 			},
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1257
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Disables the `jsonc/comma-dangle` rule altogether so as to not conflict with Prettier. I suppose if any tool doesn't support trailing commas in a file, it'll report that directly. And most tools generally support jsonc anyway. 🤷 