### PR TITLE
fix: omit default --access value in rerun suggestions

### DIFF
--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -46,7 +46,18 @@ describe("createRerunSuggestion", () => {
 		const actual = createRerunSuggestion(options);
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode create --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --mode create --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+		);
+	});
+
+	it("includes a non-default value when specified", () => {
+		const actual = createRerunSuggestion({
+			...options,
+			access: "restricted",
+		});
+
+		expect(actual).toMatchInlineSnapshot(
+			`"npx create-typescript-app --mode create --base everything --access restricted --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -61,7 +72,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -76,7 +87,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -90,7 +101,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --access public --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-md --exclude-lint-package-json --exclude-lint-perfectionist --exclude-lint-spelling --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-md --exclude-lint-package-json --exclude-lint-perfectionist --exclude-lint-spelling --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -102,7 +113,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(common).toMatchInlineSnapshot(
-			'"npx create-typescript-app --mode undefined --base common"',
+			`"npx create-typescript-app --mode undefined --base common"`,
 		);
 	});
 
@@ -114,7 +125,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(minimum).toMatchInlineSnapshot(
-			'"npx create-typescript-app --mode undefined --base minimum"',
+			`"npx create-typescript-app --mode undefined --base minimum"`,
 		);
 	});
 });

--- a/src/create/createRerunSuggestion.ts
+++ b/src/create/createRerunSuggestion.ts
@@ -11,6 +11,8 @@ function getFirstMatchingArg(key: string) {
 	);
 }
 
+const defaultValues = new Map([["access", "public"]]);
+
 export function createRerunSuggestion(options: Partial<Options>): string {
 	const optionsNormalized = {
 		...options,
@@ -38,11 +40,13 @@ export function createRerunSuggestion(options: Partial<Options>): string {
 		.sort(([a], [b]) =>
 			a === "base" ? -1 : b === "base" ? 1 : a.localeCompare(b),
 		)
-		// Filter out all entries that have a key in the excluded object or have a falsy value
+		// Filter out entries with an excluded key or a default or falsy value
 		.filter(
 			([key, value]) =>
 				getExclusions(options, optionsNormalized.base)[key as ExclusionKey] ==
-					undefined && !!value,
+					undefined &&
+				!!value &&
+				value !== defaultValues.get(key),
 		)
 		.map(([key, value]) => {
 			return `--${getFirstMatchingArg(key)}${stringifyValue(value)}`;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1127
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `defaultValues` map and filters out key/value pairs matched in it.