### PR TITLE
fix: don't suggest --skip options in rerun if --offline

### DIFF
--- a/src/create/createRerunSuggestion.test.ts
+++ b/src/create/createRerunSuggestion.test.ts
@@ -42,11 +42,27 @@ const options = {
 } satisfies Options;
 
 describe("createRerunSuggestion", () => {
+	it("prints no options when no options are provided", () => {
+		const actual = createRerunSuggestion({});
+
+		expect(actual).toMatchInlineSnapshot(`"npx create-typescript-app"`);
+	});
+
+	it("prints only mode when no other options are provided", () => {
+		const actual = createRerunSuggestion({
+			mode: "create",
+		});
+
+		expect(actual).toMatchInlineSnapshot(
+			`"npx create-typescript-app --mode create"`,
+		);
+	});
+
 	it("includes key-value pairs with mixed truthy and falsy values", () => {
 		const actual = createRerunSuggestion(options);
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode create --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -57,7 +73,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode create --base everything --access restricted --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --base everything --access restricted --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -72,7 +88,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --guide https://example.com --guide-title "Test Title" --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -87,7 +103,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --logo test/src.png --logo-alt "Test alt." --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -101,7 +117,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(actual).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode initialize --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-md --exclude-lint-package-json --exclude-lint-perfectionist --exclude-lint-spelling --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
+			`"npx create-typescript-app --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-md --exclude-lint-package-json --exclude-lint-perfectionist --exclude-lint-spelling --keywords "abc def ghi jkl mno pqr" --mode initialize --owner TestOwner --repository test-repository --skip-github-api --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 
@@ -113,7 +129,7 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(common).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode undefined --base common"`,
+			`"npx create-typescript-app --base common"`,
 		);
 	});
 
@@ -125,7 +141,20 @@ describe("createRerunSuggestion", () => {
 		});
 
 		expect(minimum).toMatchInlineSnapshot(
-			`"npx create-typescript-app --mode undefined --base minimum"`,
+			`"npx create-typescript-app --base minimum"`,
+		);
+	});
+
+	it("does not list API skip flags when --offline is true", () => {
+		const actual = createRerunSuggestion({
+			...options,
+			offline: true,
+			skipAllContributorsApi: true,
+			skipGitHubApi: true,
+		});
+
+		expect(actual).toMatchInlineSnapshot(
+			`"npx create-typescript-app --base everything --author TestAuthor --description "Test description." --directory . --email-github github@email.com --email-npm npm@email.com --exclude-all-contributors --exclude-compliance --exclude-lint-jsdoc --exclude-lint-json --exclude-lint-knip --exclude-lint-package-json --exclude-lint-perfectionist --keywords "abc def ghi jkl mno pqr" --mode create --offline --owner TestOwner --repository test-repository --skip-install --skip-removal --title "Test Title""`,
 		);
 	});
 });

--- a/src/create/createRerunSuggestion.ts
+++ b/src/create/createRerunSuggestion.ts
@@ -33,6 +33,10 @@ export function createRerunSuggestion(options: Partial<Options>): string {
 					logoAlt: options.logo.alt,
 			  }
 			: { logo: undefined }),
+		...(options.offline && {
+			skipAllContributorsApi: undefined,
+			skipGitHubApi: undefined,
+		}),
 	};
 
 	const args = Object.entries(optionsNormalized)
@@ -53,7 +57,7 @@ export function createRerunSuggestion(options: Partial<Options>): string {
 		})
 		.join(" ");
 
-	return `npx create-typescript-app --mode ${options.mode} ${args}`;
+	return ["npx create-typescript-app", args].filter(Boolean).join(" ");
 }
 
 function stringifyValue(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1128; #1130
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies a couple of bits of good normalization to printed options:

* Removes the manual `--mode` so it doesn't get duplicated
* Sets the relevant `skip*` options to `undefined` if `options.offline` is enabled

Also adds some unit tests around partial options, as that was missing before.