### PR TITLE
ci: do not run accessibility checks for bots

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,5 +1,6 @@
 jobs:
   accessibility_alt_text_bot:
+    if: ${{ !endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: github/accessibility-alt-text-bot@v1.4.0

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -51,6 +51,7 @@ interface WorkflowFileOptionsBase {
 	concurrency?: WorkflowFileConcurrency;
 	name: string;
 	on?: WorkflowFileOn;
+	if?: string;
 	permissions?: WorkflowFilePermissions;
 }
 
@@ -81,6 +82,7 @@ export function createWorkflowFile({
 			concurrency,
 			jobs: {
 				[name.replaceAll(" ", "_").toLowerCase()]: {
+					...(options.if && { if: options.if }),
 					"runs-on": "ubuntu-latest",
 					steps:
 						"runs" in options

--- a/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflowFile.ts
@@ -49,9 +49,9 @@ interface WorkflowFileStep {
 
 interface WorkflowFileOptionsBase {
 	concurrency?: WorkflowFileConcurrency;
+	if?: string;
 	name: string;
 	on?: WorkflowFileOn;
-	if?: string;
 	permissions?: WorkflowFilePermissions;
 }
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -41,7 +41,7 @@ describe("createWorkflows", () => {
 			{
 			  "accessibility-alt-text-bot.yml": "jobs:
 			  accessibility_alt_text_bot:
-					if: \${{ !endsWith(github.actor, '[bot]') }}
+			    if: \${{ !endsWith(github.actor, '[bot]') }}
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0
@@ -352,7 +352,7 @@ describe("createWorkflows", () => {
 			{
 			  "accessibility-alt-text-bot.yml": "jobs:
 			  accessibility_alt_text_bot:
-					if: \${{ !endsWith(github.actor, '[bot]') }}
+			    if: \${{ !endsWith(github.actor, '[bot]') }}
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -41,7 +41,7 @@ describe("createWorkflows", () => {
 			{
 			  "accessibility-alt-text-bot.yml": "jobs:
 			  accessibility_alt_text_bot:
-				if: \${{ !endsWith(github.actor, '[bot]') }}
+					if: \${{ !endsWith(github.actor, '[bot]') }}
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0
@@ -352,6 +352,7 @@ describe("createWorkflows", () => {
 			{
 			  "accessibility-alt-text-bot.yml": "jobs:
 			  accessibility_alt_text_bot:
+					if: \${{ !endsWith(github.actor, '[bot]') }}
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -41,6 +41,7 @@ describe("createWorkflows", () => {
 			{
 			  "accessibility-alt-text-bot.yml": "jobs:
 			  accessibility_alt_text_bot:
+				if: \${{ !endsWith(github.actor, '[bot]') }}
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -108,6 +108,7 @@ export function createWorkflows(options: Options) {
 			},
 			steps: [
 				{
+					if: "${{ !endsWith(github.actor, '[bot]') }}",
 					uses: "github/accessibility-alt-text-bot@v1.4.0",
 				},
 			],

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -90,6 +90,7 @@ export function createWorkflows(options: Options) {
 			}),
 		}),
 		"accessibility-alt-text-bot.yml": createWorkflowFile({
+			if: "${{ !endsWith(github.actor, '[bot]') }}",
 			name: "Accessibility Alt Text Bot",
 			on: {
 				issue_comment: {
@@ -106,7 +107,6 @@ export function createWorkflows(options: Options) {
 				issues: "write",
 				"pull-requests": "write",
 			},
-			if: "${{ !endsWith(github.actor, '[bot]') }}",
 			steps: [
 				{
 					uses: "github/accessibility-alt-text-bot@v1.4.0",

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -106,9 +106,9 @@ export function createWorkflows(options: Options) {
 				issues: "write",
 				"pull-requests": "write",
 			},
+			if: "${{ !endsWith(github.actor, '[bot]') }}",
 			steps: [
 				{
-					if: "${{ !endsWith(github.actor, '[bot]') }}",
 					uses: "github/accessibility-alt-text-bot@v1.4.0",
 				},
 			],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1318
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

See linked issue. I set this up in my repo in https://github.com/danvk/gravlax/pull/58 following https://github.com/typescript-eslint/typescript-eslint/pull/8212. We can wait for a few renovate bot updates on my repo to confirm that this has the desired effect.

I added support for top-level `if` statements on jobs. It's possible to skip an individual step (which is already supported) but skipping the entire job seems more correct: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif