### PR TITLE
fix: use plugin:markdown/recommended-legacy

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,7 +25,7 @@ module.exports = {
 	ignorePatterns: ["!.*", "coverage*", "lib", "node_modules", "pnpm-lock.yaml"],
 	overrides: [
 		{
-			extends: ["plugin:markdown/recommended"],
+			extends: ["plugin:markdown/recommended-legacy"],
 			files: ["**/*.md"],
 			processor: "markdown/markdown",
 		},

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"eslint-plugin-eslint-comments": "^3.2.0",
 		"eslint-plugin-jsdoc": "^48.0.0",
 		"eslint-plugin-jsonc": "^2.10.0",
-		"eslint-plugin-markdown": "^3.0.1",
+		"eslint-plugin-markdown": "^4.0.1",
 		"eslint-plugin-n": "^16.3.1",
 		"eslint-plugin-package-json": "^0.10.0",
 		"eslint-plugin-perfectionist": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ devDependencies:
     specifier: ^2.10.0
     version: 2.13.0(eslint@8.57.0)
   eslint-plugin-markdown:
-    specifier: ^3.0.1
-    version: 3.0.1(eslint@8.57.0)
+    specifier: ^4.0.1
+    version: 4.0.1(eslint@8.57.0)
   eslint-plugin-n:
     specifier: ^16.3.1
     version: 16.6.2(eslint@8.57.0)
@@ -3569,11 +3569,11 @@ packages:
       synckit: 0.6.2
     dev: true
 
-  /eslint-plugin-markdown@3.0.1(eslint@8.57.0):
-    resolution: {integrity: sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /eslint-plugin-markdown@4.0.1(eslint@8.57.0):
+    resolution: {integrity: sha512-5/MnGvYU0i8MbHH5cg8S+Vl3DL+bqRNYshk1xUO86DilNBaxtTkhH+5FD0/yO03AmlI6+lfNFdk2yOw72EPzpA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: '>=8'
     dependencies:
       eslint: 8.57.0
       mdast-util-from-markdown: 0.8.5

--- a/script/__snapshots__/migrate-test-e2e.js.snap
+++ b/script/__snapshots__/migrate-test-e2e.js.snap
@@ -25,7 +25,7 @@ exports[`expected file changes > .eslintrc.cjs 1`] = `
 +	ignorePatterns: ["!.*", "coverage", "lib", "node_modules", "pnpm-lock.yaml"],
  	overrides: [
  		{
- 			extends: ["plugin:markdown/recommended"],
+ 			extends: ["plugin:markdown/recommended-legacy"],
 @@ ... @@ module.exports = {
  			rules: {
  				// These off-by-default rules work well for this repo and we like them on.

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -128,7 +128,7 @@ describe("createESLintRC", () => {
 				  ignorePatterns: ["!.*", "coverage", "lib", "node_modules", "pnpm-lock.yaml"],
 				  overrides: [
 				    {
-				      extends: ["plugin:markdown/recommended"],
+				      extends: ["plugin:markdown/recommended-legacy"],
 				      files: ["**/*.md"],
 				      processor: "markdown/markdown",
 				    },

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -35,7 +35,7 @@ module.exports = {
 			? ""
 			: `
 		{
-			extends: ["plugin:markdown/recommended"],
+			extends: ["plugin:markdown/recommended-legacy"],
 			files: ["**/*.md"],
 			processor: "markdown/markdown",
 		},`


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1380
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches to the `recommended-legacy` plugin and bumps `eslint-plugin-markdown` to the latest version, 4.x.