### PR TITLE
fix: ignore codecov-action in renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"automerge": true,
+	"ignoreDeps": ["codecov/codecov-action"],
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
 	"minimumReleaseAge": "3 days",

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -280,6 +280,7 @@ We appreciate your efforts and responsible disclosure and will make every effort
 			"renovate.json": await formatJson({
 				$schema: "https://docs.renovatebot.com/renovate-schema.json",
 				automerge: true,
+				ignoreDeps: ["codecov/codecov-action"],
 				internalChecksFilter: "strict",
 				labels: ["dependencies"],
 				minimumReleaseAge: "3 days",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1435
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Altogether stops repositories from being upgraded to `codecov/codev-action@v4`. 

This can always be revisited if & when Codecov provides more details on tokenless uploads (https://github.com/codecov/codecov-action/issues/1293).