### PR TITLE
feat: remove no-padding-line-between-statements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -166,10 +166,6 @@ module.exports = {
 		"no-mixed-spaces-and-tabs": "off",
 
 		// Stylistic concerns that don't interfere with Prettier
-		"@typescript-eslint/padding-line-between-statements": [
-			"error",
-			{ blankLine: "always", next: "*", prev: "block-like" },
-		],
 		"no-useless-rename": "error",
 		"object-shorthand": "error",
 		"perfectionist/sort-objects": [

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -254,10 +254,6 @@ describe("createESLintRC", () => {
 				    "no-mixed-spaces-and-tabs": "off",
 
 				    // Stylistic concerns that don't interfere with Prettier
-				    "@typescript-eslint/padding-line-between-statements": [
-				      "error",
-				      { blankLine: "always", next: "*", prev: "block-like" },
-				    ],
 				    "no-useless-rename": "error",
 				    "object-shorthand": "error",
 				    "perfectionist/sort-objects": [

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -220,10 +220,6 @@ module.exports = {
 			options.excludeLintStylistic
 				? ""
 				: `// Stylistic concerns that don't interfere with Prettier
-		"@typescript-eslint/padding-line-between-statements": [
-			"error",
-			{ blankLine: "always", next: "*", prev: "block-like" },
-		],
 		"no-useless-rename": "error",
 		"object-shorthand": "error",
 		`


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1458
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Straightforward removal.