### PR TITLE
feat(tools): use config:recommended for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,11 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"automerge": true,
+	"extends": [
+		"config:recommended",
+		":maintainLockFilesWeekly",
+		"replacements:all"
+	],
 	"ignoreDeps": ["codecov/codecov-action"],
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1455
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Using `config:recommended` for renovate config. `config:best-practices` looked too opinionated for common user, so I think this recommended is better fit. I also added `maintainLockFilesWeekly` and `replacements:all`. I'm not sure if `maintainLockFilesWeekly` is needed when there is pnpm dedupe in every PR already. 

- maintainLockFilesWeekly: "Run lock file maintenance (updates) early Monday mornings." https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
- replacementsall: "Apply crowd-sourced package replacement rules." https://docs.renovatebot.com/presets-replacements/#replacementsall

BTW, some tools seems to be fighting over formatting in this repo. When I save this file in VS code it's formatted differently than what is seen in this PR. So when you stage / commit the file, it gets different formatting.