### PR TITLE
feat: remove disable of no-case-declarations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -155,7 +155,6 @@ module.exports = {
 		"@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
 
 		// These on-by-default rules don't work well for this repo and we like them off.
-		"no-case-declarations": "off",
 		"no-constant-condition": "off",
 		"no-inner-declarations": "off",
 		"no-mixed-spaces-and-tabs": "off",

--- a/src/shared/options/augmentOptionsWithExcludes.ts
+++ b/src/shared/options/augmentOptionsWithExcludes.ts
@@ -71,7 +71,7 @@ export async function augmentOptionsWithExcludes(
 				base,
 				...getExclusions(options, base),
 			};
-		case "prompt":
+		case "prompt": {
 			const exclusionsNotEnabled = new Set(
 				filterPromptCancel(
 					await prompts.multiselect({
@@ -99,6 +99,7 @@ export async function augmentOptionsWithExcludes(
 					),
 				),
 			};
+		}
 	}
 }
 

--- a/src/shared/options/ensureRepositoryExists.ts
+++ b/src/shared/options/ensureRepositoryExists.ts
@@ -66,7 +66,7 @@ export async function ensureRepositoryExists(
 				});
 				return { github, repository };
 
-			case "different":
+			case "different": {
 				const newRepository = filterPromptCancel(
 					await prompts.text({
 						message: `What would you like to call the repository?`,
@@ -79,6 +79,7 @@ export async function ensureRepositoryExists(
 
 				repository = newRepository;
 				break;
+			}
 
 			case "local":
 				github = undefined;

--- a/src/steps/writing/creation/createESLintRC.test.ts
+++ b/src/steps/writing/creation/createESLintRC.test.ts
@@ -97,7 +97,6 @@ describe("createESLintRC", () => {
 				    "@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
 
 				    // These on-by-default rules don't work well for this repo and we like them off.
-				    "no-case-declarations": "off",
 				    "no-constant-condition": "off",
 				    "no-inner-declarations": "off",
 				    "no-mixed-spaces-and-tabs": "off",
@@ -238,7 +237,6 @@ describe("createESLintRC", () => {
 				    "@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
 
 				    // These on-by-default rules don't work well for this repo and we like them off.
-				    "no-case-declarations": "off",
 				    "no-constant-condition": "off",
 				    "no-inner-declarations": "off",
 				    "no-mixed-spaces-and-tabs": "off",

--- a/src/steps/writing/creation/createESLintRC.ts
+++ b/src/steps/writing/creation/createESLintRC.ts
@@ -189,7 +189,6 @@ module.exports = {
 		"@typescript-eslint/no-unused-vars": ["error", { caughtErrors: "all" }],
 
 		// These on-by-default rules don't work well for this repo and we like them off.
-		"no-case-declarations": "off",
 		"no-constant-condition": "off",
 		"no-inner-declarations": "off",
 		"no-mixed-spaces-and-tabs": "off",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1467
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the disable of the rule, and adds `{}` blocks around the two violations in the code base.