### PR TITLE
fix: remove package.json packageManager field

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,6 +5,8 @@ name: Prepare
 runs:
   steps:
     - uses: pnpm/action-setup@v2
+      with:
+        version: 9
     - uses: actions/setup-node@v4
       with:
         cache: pnpm

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
 		"typescript-eslint": "^7.7.0",
 		"vitest": "^1.4.0"
 	},
-	"packageManager": "pnpm@9.1.0",
 	"engines": {
 		"node": ">=18"
 	},

--- a/src/steps/writing/creation/dotGitHub/actions.test.ts
+++ b/src/steps/writing/creation/dotGitHub/actions.test.ts
@@ -15,6 +15,8 @@ name: Prepare
 runs:
   steps:
     - uses: pnpm/action-setup@v2
+      with:
+        version: 9
     - uses: actions/setup-node@v4
       with:
         cache: pnpm

--- a/src/steps/writing/creation/dotGitHub/actions.ts
+++ b/src/steps/writing/creation/dotGitHub/actions.ts
@@ -9,7 +9,10 @@ export function createDotGitHubActions() {
 					name: "Prepare",
 					runs: {
 						steps: [
-							{ uses: "pnpm/action-setup@v2" },
+							{
+								uses: "pnpm/action-setup@v2",
+								with: { version: 9 },
+							},
 							{
 								uses: "actions/setup-node@v4",
 								with: { cache: "pnpm", "node-version": "20" },

--- a/src/steps/writing/creation/writePackageJson.test.ts
+++ b/src/steps/writing/creation/writePackageJson.test.ts
@@ -91,7 +91,6 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@9.1.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },
@@ -162,7 +161,6 @@ describe("writePackageJson", () => {
 			  },
 			  "main": "./lib/index.js",
 			  "name": "test-repository",
-			  "packageManager": "pnpm@9.1.0",
 			  "publishConfig": {
 			    "provenance": true,
 			  },

--- a/src/steps/writing/creation/writePackageJson.ts
+++ b/src/steps/writing/creation/writePackageJson.ts
@@ -75,7 +75,6 @@ export async function writePackageJson(options: Options) {
 		},
 		main: "./lib/index.js",
 		name: options.repository,
-		packageManager: "pnpm@9.1.0",
 		publishConfig: {
 			provenance: true,
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1513
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Right now, trying to use `create-typescript-app` with anything but the _exact correct pnpm major.minor.patch version_ installed produces an error. That's very annoying.

Pending https://github.com/nodejs/corepack/issues/95, removes usage of the [experimental `package.json` `packageManager` field](https://nodejs.org/api/packages.html#packagemanager).