### PR TITLE
feat: configure Renovate to skip patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
 	"ignoreDeps": ["codecov/codecov-action"],
 	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
+	"patch": {
+		"enabled": false
+	},
 	"minimumReleaseAge": "3 days",
 	"postUpdateOptions": ["pnpmDedupe"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,7 @@
 	"extends": ["config:best-practices", "replacements:all"],
 	"ignoreDeps": ["codecov/codecov-action"],
 	"labels": ["dependencies"],
-	"patch": {
-		"enabled": false
-	},
 	"minimumReleaseAge": "3 days",
+	"patch": { "enabled": false },
 	"postUpdateOptions": ["pnpmDedupe"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
 	"automerge": true,
 	"extends": ["config:best-practices", "replacements:all"],
 	"ignoreDeps": ["codecov/codecov-action"],
-	"internalChecksFilter": "strict",
 	"labels": ["dependencies"],
 	"patch": {
 		"enabled": false

--- a/cspell.json
+++ b/cspell.json
@@ -13,6 +13,7 @@
 		"allcontributors",
 		"apexskier",
 		"arethetypeswrong",
+		"automerge",
 		"codespace",
 		"contributorsrc",
 		"execa",

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
@@ -1,0 +1,1142 @@
+import { describe, expect, it } from "vitest";
+
+import { createDotGitHubFiles } from "./createDotGitHubFiles.js";
+import { Options } from "../../../../shared/types.js";
+
+const createOptions = (exclude: boolean) =>
+	({
+		access: "public",
+		base: "everything",
+		bin: exclude ? undefined : "./bin/index.js",
+		description: "Test description.",
+		directory: ".",
+		email: {
+			github: "github@email.com",
+			npm: "npm@email.com",
+		},
+		excludeAllContributors: exclude,
+		excludeCompliance: exclude,
+		excludeLintJson: exclude,
+		excludeLintKnip: exclude,
+		excludeLintMd: exclude,
+		excludeLintPackageJson: exclude,
+		excludeLintPackages: exclude,
+		excludeLintPerfectionist: exclude,
+		excludeLintSpelling: exclude,
+		excludeLintYml: exclude,
+		excludeReleases: exclude,
+		excludeRenovate: exclude,
+		excludeTests: exclude,
+		mode: "create",
+		owner: "StubOwner",
+		repository: "stub-repository",
+		title: "Stub Title",
+	}) satisfies Options;
+
+describe("createDotGitHubFiles", () => {
+	it("creates only markdown files when given minimal options", async () => {
+		expect(await createDotGitHubFiles(createOptions(true)))
+			.toMatchInlineSnapshot(`
+			{
+			  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
+
+			## Our Pledge
+
+			We as members, contributors, and leaders pledge to make participation in our
+			community a harassment-free experience for everyone, regardless of age, body
+			size, visible or invisible disability, ethnicity, sex characteristics, gender
+			identity and expression, level of experience, education, socio-economic status,
+			nationality, personal appearance, race, caste, color, religion, or sexual
+			identity and orientation.
+
+			We pledge to act and interact in ways that contribute to an open, welcoming,
+			diverse, inclusive, and healthy community.
+
+			## Our Standards
+
+			Examples of behavior that contributes to a positive environment for our
+			community include:
+
+			- Demonstrating empathy and kindness toward other people
+			- Being respectful of differing opinions, viewpoints, and experiences
+			- Giving and gracefully accepting constructive feedback
+			- Accepting responsibility and apologizing to those affected by our mistakes,
+			and learning from the experience
+			- Focusing on what is best not just for us as individuals, but for the overall
+			community
+
+			Examples of unacceptable behavior include:
+
+			- The use of sexualized language or imagery, and sexual attention or advances of
+			any kind
+			- Trolling, insulting or derogatory comments, and personal or political attacks
+			- Public or private harassment
+			- Publishing others' private information, such as a physical or email address,
+			without their explicit permission
+			- Other conduct which could reasonably be considered inappropriate in a
+			professional setting
+
+			## Enforcement Responsibilities
+
+			Community leaders are responsible for clarifying and enforcing our standards of
+			acceptable behavior and will take appropriate and fair corrective action in
+			response to any behavior that they deem inappropriate, threatening, offensive,
+			or harmful.
+
+			Community leaders have the right and responsibility to remove, edit, or reject
+			comments, commits, code, wiki edits, issues, and other contributions that are
+			not aligned to this Code of Conduct, and will communicate reasons for moderation
+			decisions when appropriate.
+
+			## Scope
+
+			This Code of Conduct applies within all community spaces, and also applies when
+			an individual is officially representing the community in public spaces.
+			Examples of representing our community include using an official e-mail address,
+			posting via an official social media account, or acting as an appointed
+			representative at an online or offline event.
+
+			## Enforcement
+
+			Instances of abusive, harassing, or otherwise unacceptable behavior may be
+			reported to the community leaders responsible for enforcement at
+			github@email.com.
+			All complaints will be reviewed and investigated promptly and fairly.
+
+			All community leaders are obligated to respect the privacy and security of the
+			reporter of any incident.
+
+			## Enforcement Guidelines
+
+			Community leaders will follow these Community Impact Guidelines in determining
+			the consequences for any action they deem in violation of this Code of Conduct:
+
+			### 1. Correction
+
+			**Community Impact**: Use of inappropriate language or other behavior deemed
+			unprofessional or unwelcome in the community.
+
+			**Consequence**: A private, written warning from community leaders, providing
+			clarity around the nature of the violation and an explanation of why the
+			behavior was inappropriate. A public apology may be requested.
+
+			### 2. Warning
+
+			**Community Impact**: A violation through a single incident or series of
+			actions.
+
+			**Consequence**: A warning with consequences for continued behavior. No
+			interaction with the people involved, including unsolicited interaction with
+			those enforcing the Code of Conduct, for a specified period of time. This
+			includes avoiding interactions in community spaces as well as external channels
+			like social media. Violating these terms may lead to a temporary or permanent
+			ban.
+
+			### 3. Temporary Ban
+
+			**Community Impact**: A serious violation of community standards, including
+			sustained inappropriate behavior.
+
+			**Consequence**: A temporary ban from any sort of interaction or public
+			communication with the community for a specified period of time. No public or
+			private interaction with the people involved, including unsolicited interaction
+			with those enforcing the Code of Conduct, is allowed during this period.
+			Violating these terms may lead to a permanent ban.
+
+			### 4. Permanent Ban
+
+			**Community Impact**: Demonstrating a pattern of violation of community
+			standards, including sustained inappropriate behavior, harassment of an
+			individual, or aggression toward or disparagement of classes of individuals.
+
+			**Consequence**: A permanent ban from any sort of public interaction within the
+			community.
+
+			## Attribution
+
+			This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+			version 2.1, available at
+			[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+			Community Impact Guidelines were inspired by
+			[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+			For answers to common questions about this code of conduct, see the FAQ at
+			[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+			[https://www.contributor-covenant.org/translations][translations].
+
+			[homepage]: https://www.contributor-covenant.org
+			[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+			[mozilla coc]: https://github.com/mozilla/diversity
+			[faq]: https://www.contributor-covenant.org/faq
+			[translations]: https://www.contributor-covenant.org/translations
+			",
+			  "CONTRIBUTING.md": "# Contributing
+
+			Thanks for your interest in contributing to \`stub-repository\`! 💖
+
+			> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
+
+			## Code of Conduct
+
+			This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
+
+			## Reporting Issues
+
+			Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
+
+			## Sending Contributions
+
+			Sending your own changes as contribution is always appreciated!
+			There are two steps involved:
+
+			1. [Finding an Issue](#finding-an-issue)
+			2. [Sending a Pull Request](#sending-a-pull-request)
+
+			### Finding an Issue
+
+			With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+			If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+			If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
+
+			#### Issue Claiming
+
+			We don't use any kind of issue claiming system.
+			We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
+
+			If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
+			Please don't post comments asking for permission or stating you will work on an issue.
+
+			### Sending a Pull Request
+
+			Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
+			Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
+
+			PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
+			Only PR titles need to be in that format, not individual commits.
+			Don't worry if you get this wrong: you can always change the PR title after sending it.
+			Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
+
+			#### Draft PRs
+
+			If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
+			Draft PRs won't be reviewed.
+
+			#### Granular PRs
+
+			Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
+			Send one PR per area of concern.
+			Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
+
+			#### Pull Request Reviews
+
+			When a PR is not in draft, it's considered ready for review.
+			Please don't manually \`@\` tag anybody to request review.
+			A maintainer will look at it when they're next able to.
+
+			PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
+
+			#### Asking Questions
+
+			If you need help and/or have a question, posting a comment in the PR is a great way to do so.
+			There's no need to tag anybody individually.
+			One of us will drop by and help when we can.
+
+			Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
+			You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
+
+			#### Requested Changes
+
+			After a maintainer reviews your PR, they may request changes on it.
+			Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
+
+			Please try not to force-push commits to PRs that have already been reviewed.
+			Doing so makes it harder to review the changes.
+			We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
+
+			Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
+
+			Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
+
+			#### Post-Merge Recognition
+
+			Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
+			Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
+
+			## Emojis & Appreciation
+
+			If you made it all the way to the end, bravo dear user, we love you.
+			Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
+			💖 is a good starter if you're not sure which to use.
+			",
+			  "DEVELOPMENT.md": "# Development
+
+			After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
+
+			\`\`\`shell
+			git clone https://github.com/<your-name-here>/stub-repository
+			cd stub-repository
+			pnpm install
+			\`\`\`
+
+			> This repository includes a list of suggested VS Code extensions.
+			> It's a good idea to use [VS Code](https://code.visualstudio.com) and accept its suggestion to install them, as they'll help with development.
+
+			## Building
+
+			Run [**tsup**](https://tsup.egoist.dev) locally to build source files from \`src/\` into output files in \`lib/\`:
+
+			\`\`\`shell
+			pnpm build
+			\`\`\`
+
+			Add \`--watch\` to run the builder in a watch mode that continuously cleans and recreates \`lib/\` as you save files:
+
+			\`\`\`shell
+			pnpm build --watch
+			\`\`\`
+
+			## Formatting
+
+			[Prettier](https://prettier.io) is used to format code.
+			It should be applied automatically when you save files in VS Code or make a Git commit.
+
+			To manually reformat all files, you can run:
+
+			\`\`\`shell
+			pnpm format --write
+			\`\`\`
+
+			## Linting
+
+			This package includes several forms of linting to enforce consistent code quality and styling.
+			Each should be shown in VS Code, and can be run manually on the command-line:
+
+			- \`pnpm lint\` ([ESLint](https://eslint.org) with [typescript-eslint](https://typescript-eslint.io)): Lints JavaScript and TypeScript source files
+			- \`pnpm lint:knip\` ([knip](https://github.com/webpro/knip)): Detects unused files, dependencies, and code exports
+			- \`pnpm lint:md\` ([Markdownlint](https://github.com/DavidAnson/markdownlint)): Checks Markdown source files
+			- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yml\` file
+			- \`pnpm lint:spelling\` ([cspell](https://cspell.org)): Spell checks across all source files
+
+			Read the individual documentation for each linter to understand how it can be configured and used best.
+
+			For example, ESLint can be run with \`--fix\` to auto-fix some lint rule complaints:
+
+			\`\`\`shell
+			pnpm run lint --fix
+			\`\`\`
+
+			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
+
+			## Type Checking
+
+			You should be able to see suggestions from [TypeScript](https://typescriptlang.org) in your editor for all open files.
+
+			However, it can be useful to run the TypeScript command-line (\`tsc\`) to type check all files in \`src/\`:
+
+			\`\`\`shell
+			pnpm tsc
+			\`\`\`
+
+			Add \`--watch\` to keep the type checker running in a watch mode that updates the display as you save files:
+
+			\`\`\`shell
+			pnpm tsc --watch
+			\`\`\`
+
+			## Testing
+
+			[Vitest](https://vitest.dev) is used for tests.
+			You can run it locally on the command-line:
+
+			\`\`\`shell
+			pnpm run test
+			\`\`\`
+
+			Add the \`--coverage\` flag to compute test coverage and place reports in the \`coverage/\` directory:
+
+			\`\`\`shell
+			pnpm run test --coverage
+			\`\`\`
+
+			Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
+			Calls to \`console.log\`, \`console.warn\`, and other console methods will cause a test to fail.
+
+			### Debugging Tests
+
+			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging unit tests.
+			To launch it, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
+
+			## Debugging
+
+			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging.
+			Depending upon the type of usage, it can include debugging for unit tests _and_ for executable (or "bin") apps.
+
+			### Unit Tests
+
+			To debug a unit test, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
+
+			### \`bin\` Apps
+
+			To debug a \`bin\` app, add a breakpoint to your code, then run _Debug Program_ from the VS Code Debug panel (or press F5).
+
+			## Setup Scripts
+
+			As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository.
+
+			Each follows roughly the same general flow:
+
+			1. \`bin/index.ts\` uses \`bin/mode.ts\` to determine which of the three setup scripts to run
+			2. \`readOptions\` parses in options from local files, Git commands, npm APIs, and/or files on disk
+			3. \`runOrRestore\` wraps the setup script's main logic in a friendly prompt wrapper
+			4. The setup script wraps each portion of its main logic with \`withSpinner\`
+			   - Each step of setup logic is generally imported from within \`src/steps\`
+			5. A call to \`outro\` summarizes the results for the user
+
+			> **Warning**
+			> Each setup script overrides many files in the directory they're run in.
+			> Make sure to save any changes you want to preserve before running them.
+
+			### The Creation Script
+
+			> 📝 See [\`docs/Creation.md\`](../docs/Creation.md) for user documentation on the creation script.
+
+			This template's "creation" script is located in \`src/create/\`.
+			You can run it locally with \`node bin/index.js --mode create\`.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			#### Testing the Creation Script
+
+			You can run the end-to-end test for creation locally on the command-line.
+			Note that the files need to be built with \`pnpm run build\` beforehand.
+
+			\`\`\`shell
+			pnpm run test:create
+			\`\`\`
+
+			That end-to-end test executes \`script/create-test-e2e.ts\`, which:
+
+			1. Runs the creation script to create a new \`test-repository\` child directory and repository, capturing code coverage
+			2. Asserts that commands such as \`build\` and \`lint\` each pass
+
+			The \`pnpm run test:create\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-create.yml\`.
+
+			### The Initialization Script
+
+			> 📝 See [\`docs/Initialization.md\`](../docs/Initialization.md) for user documentation on the initialization script.
+
+			This template's "initialization" script is located in \`src/initialize/\`.
+			You can run it locally with \`pnpm run initialize\`.
+			It uses [\`tsx\`](https://github.com/esbuild-kit/tsx) so you don't need to build files before running.
+
+			\`\`\`shell
+			pnpm run initialize
+			\`\`\`
+
+			#### Testing the Initialization Script
+
+			You can run the end-to-end test for initializing locally on the command-line.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			\`\`\`shell
+			pnpm run test:initialize
+			\`\`\`
+
+			That end-to-end test executes \`script/initialize-test-e2e.ts\`, which:
+
+			1. Runs the initialization script using \`--skip-github-api\` and other skip flags
+			2. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
+			3. Runs \`pnpm run lint:knip\` to make sure no excess dependencies or files were left over
+			4. Resets everything
+			5. Runs initialization a second time, capturing test coverage
+
+			The \`pnpm run test:initialize\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-initialize.yml\`.
+
+			### The Migration Script
+
+			> 📝 See [\`docs/Migration.md\`](../docs/Migration.md) for user documentation on the migration script.
+
+			This template's "migration" script is located in \`src/migrate/\`.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			To test out the script locally, run it from a different repository's directory:
+
+			\`\`\`shell
+			cd ../other-repo
+			node ../create-typescript-app/bin/migrate.js
+			\`\`\`
+
+			The migration script will work on any directory.
+			You can try it out in a blank directory with scripts like:
+
+			\`\`\`shell
+			cd ..
+			mkdir temp
+			cd temp
+			node ../create-typescript-app/bin/migrate.js
+			\`\`\`
+
+			#### Testing the Migration Script
+
+			> 💡 Seeing \`Oh no! Running the migrate script unexpectedly modified:\` errors?
+			> _[Unexpected File Modifications](#unexpected-file-modifications)_ covers that below.
+
+			You can run the end-to-end test for migrating locally on the command-line:
+
+			\`\`\`shell
+			pnpm run test:migrate
+			\`\`\`
+
+			That end-to-end test executes \`script/migrate-test-e2e.ts\`, which:
+
+			1. Runs the migration script using \`--skip-github-api\` and other skip flags, capturing code coverage
+			2. Checks that only a small list of allowed files were changed
+			3. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
+
+			The \`pnpm run test:migrate\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-migrate.yml\`.
+
+			> Tip: if the migration test is failing in CI and you don't see any errors, try [downloading the full logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
+
+			##### Migration Snapshot Failures
+
+			The migration test uses the [Vitest file snapshot](https://vitest.dev/guide/snapshot#file-snapshots) in \`script/__snapshots__/migrate-test-e2e.ts.snap\` to store expected differences to this repository after running the migration script.
+			The end-to-end migration test will fail any changes that don't keep the same differences in that snapshot.
+
+			You can update the snapshot file by:
+
+			1. Committing any changes to your local repository
+			2. Running \`pnpm i\` and \`pnpm build\` if any updates have been made to the \`package.json\` or \`src/\` files, respectively
+			3. Running \`pnpm run test:migrate -u\` to update the snapshot
+
+			At this point there will be some files changed:
+
+			- \`script/__snapshots__/migrate-test-e2e.ts.snap\` will have updates if any files mismatched templates
+			- The actual updated files on disk will be there too
+
+			If the snapshot file changes are what you expected, then you can commit them.
+			The rest of the file changes can be reverted.
+
+			> [🚀 Feature: Add a way to apply known file changes after migration #1184](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1184) tracks turning the test snapshot into a feature.
+
+			##### Unexpected File Modifications
+
+			The migration test also asserts that no files were unexpectedly changed.
+			If you see a failure like:
+
+			\`\`\`plaintext
+			Oh no! Running the migrate script unexpectedly modified:
+			 - ...
+			\`\`\`
+
+			...then that means the file generated from templates differs from what's checked into the repository.
+			This is most often caused by changes to templates not being applied to checked-in files too.
+
+			Templates for files are generally stored in [\`src/steps/writing/creation\`] under a path roughly corresponding to the file they describe.
+			For example, the template for \`tsup.config.ts\` is stored in [\`src/steps/writing/creation/createTsupConfig.ts\`](../src/steps/writing/creation/createTsupConfig.ts).
+			If the \`createTsupConfig\` function were to be modified without an equivalent change to \`tsup.config.ts\` -or vice-versa- then the migration test would report:
+
+			\`\`\`plaintext
+			Oh no! Running the migrate script unexpectedly modified:
+			 - tsup.config.ts
+			\`\`\`
+			",
+			  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
+			<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
+			<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
+
+			<!-- This blank issue template is only for issues that don't fit any of the templates. -->
+
+			## Overview
+
+			...
+			",
+			  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
+			Please fill out all fields below and make sure each item is true and [x] checked.
+			Otherwise we may not be able to review your PR. -->
+
+			## PR Checklist
+
+			- [ ] Addresses an existing open issue: fixes #000
+			- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
+			- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
+
+			## Overview
+
+			<!-- Description of what is changed and how the code change does that. -->
+			",
+			  "SECURITY.md": "# Security Policy
+
+			We take all security vulnerabilities seriously.
+			If you have a vulnerability or other security issues to disclose:
+
+			- Thank you very much, please do!
+			- Please send them to us by emailing \`github@email.com\`
+
+			We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+			",
+			}
+		`);
+	});
+
+	it("creates markdown and extra files when given full options", async () => {
+		expect(await createDotGitHubFiles(createOptions(false)))
+			.toMatchInlineSnapshot(`
+			{
+			  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
+
+			## Our Pledge
+
+			We as members, contributors, and leaders pledge to make participation in our
+			community a harassment-free experience for everyone, regardless of age, body
+			size, visible or invisible disability, ethnicity, sex characteristics, gender
+			identity and expression, level of experience, education, socio-economic status,
+			nationality, personal appearance, race, caste, color, religion, or sexual
+			identity and orientation.
+
+			We pledge to act and interact in ways that contribute to an open, welcoming,
+			diverse, inclusive, and healthy community.
+
+			## Our Standards
+
+			Examples of behavior that contributes to a positive environment for our
+			community include:
+
+			- Demonstrating empathy and kindness toward other people
+			- Being respectful of differing opinions, viewpoints, and experiences
+			- Giving and gracefully accepting constructive feedback
+			- Accepting responsibility and apologizing to those affected by our mistakes,
+			and learning from the experience
+			- Focusing on what is best not just for us as individuals, but for the overall
+			community
+
+			Examples of unacceptable behavior include:
+
+			- The use of sexualized language or imagery, and sexual attention or advances of
+			any kind
+			- Trolling, insulting or derogatory comments, and personal or political attacks
+			- Public or private harassment
+			- Publishing others' private information, such as a physical or email address,
+			without their explicit permission
+			- Other conduct which could reasonably be considered inappropriate in a
+			professional setting
+
+			## Enforcement Responsibilities
+
+			Community leaders are responsible for clarifying and enforcing our standards of
+			acceptable behavior and will take appropriate and fair corrective action in
+			response to any behavior that they deem inappropriate, threatening, offensive,
+			or harmful.
+
+			Community leaders have the right and responsibility to remove, edit, or reject
+			comments, commits, code, wiki edits, issues, and other contributions that are
+			not aligned to this Code of Conduct, and will communicate reasons for moderation
+			decisions when appropriate.
+
+			## Scope
+
+			This Code of Conduct applies within all community spaces, and also applies when
+			an individual is officially representing the community in public spaces.
+			Examples of representing our community include using an official e-mail address,
+			posting via an official social media account, or acting as an appointed
+			representative at an online or offline event.
+
+			## Enforcement
+
+			Instances of abusive, harassing, or otherwise unacceptable behavior may be
+			reported to the community leaders responsible for enforcement at
+			github@email.com.
+			All complaints will be reviewed and investigated promptly and fairly.
+
+			All community leaders are obligated to respect the privacy and security of the
+			reporter of any incident.
+
+			## Enforcement Guidelines
+
+			Community leaders will follow these Community Impact Guidelines in determining
+			the consequences for any action they deem in violation of this Code of Conduct:
+
+			### 1. Correction
+
+			**Community Impact**: Use of inappropriate language or other behavior deemed
+			unprofessional or unwelcome in the community.
+
+			**Consequence**: A private, written warning from community leaders, providing
+			clarity around the nature of the violation and an explanation of why the
+			behavior was inappropriate. A public apology may be requested.
+
+			### 2. Warning
+
+			**Community Impact**: A violation through a single incident or series of
+			actions.
+
+			**Consequence**: A warning with consequences for continued behavior. No
+			interaction with the people involved, including unsolicited interaction with
+			those enforcing the Code of Conduct, for a specified period of time. This
+			includes avoiding interactions in community spaces as well as external channels
+			like social media. Violating these terms may lead to a temporary or permanent
+			ban.
+
+			### 3. Temporary Ban
+
+			**Community Impact**: A serious violation of community standards, including
+			sustained inappropriate behavior.
+
+			**Consequence**: A temporary ban from any sort of interaction or public
+			communication with the community for a specified period of time. No public or
+			private interaction with the people involved, including unsolicited interaction
+			with those enforcing the Code of Conduct, is allowed during this period.
+			Violating these terms may lead to a permanent ban.
+
+			### 4. Permanent Ban
+
+			**Community Impact**: Demonstrating a pattern of violation of community
+			standards, including sustained inappropriate behavior, harassment of an
+			individual, or aggression toward or disparagement of classes of individuals.
+
+			**Consequence**: A permanent ban from any sort of public interaction within the
+			community.
+
+			## Attribution
+
+			This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+			version 2.1, available at
+			[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+			Community Impact Guidelines were inspired by
+			[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+			For answers to common questions about this code of conduct, see the FAQ at
+			[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+			[https://www.contributor-covenant.org/translations][translations].
+
+			[homepage]: https://www.contributor-covenant.org
+			[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+			[mozilla coc]: https://github.com/mozilla/diversity
+			[faq]: https://www.contributor-covenant.org/faq
+			[translations]: https://www.contributor-covenant.org/translations
+			",
+			  "CONTRIBUTING.md": "# Contributing
+
+			Thanks for your interest in contributing to \`stub-repository\`! 💖
+
+			> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
+
+			## Code of Conduct
+
+			This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
+
+			## Reporting Issues
+
+			Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
+
+			## Sending Contributions
+
+			Sending your own changes as contribution is always appreciated!
+			There are two steps involved:
+
+			1. [Finding an Issue](#finding-an-issue)
+			2. [Sending a Pull Request](#sending-a-pull-request)
+
+			### Finding an Issue
+
+			With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+			If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+			If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
+
+			#### Issue Claiming
+
+			We don't use any kind of issue claiming system.
+			We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
+
+			If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
+			Please don't post comments asking for permission or stating you will work on an issue.
+
+			### Sending a Pull Request
+
+			Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
+			Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
+
+			PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
+			Only PR titles need to be in that format, not individual commits.
+			Don't worry if you get this wrong: you can always change the PR title after sending it.
+			Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
+
+			#### Draft PRs
+
+			If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
+			Draft PRs won't be reviewed.
+
+			#### Granular PRs
+
+			Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
+			Send one PR per area of concern.
+			Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
+
+			#### Pull Request Reviews
+
+			When a PR is not in draft, it's considered ready for review.
+			Please don't manually \`@\` tag anybody to request review.
+			A maintainer will look at it when they're next able to.
+
+			PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
+
+			#### Asking Questions
+
+			If you need help and/or have a question, posting a comment in the PR is a great way to do so.
+			There's no need to tag anybody individually.
+			One of us will drop by and help when we can.
+
+			Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
+			You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
+
+			#### Requested Changes
+
+			After a maintainer reviews your PR, they may request changes on it.
+			Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
+
+			Please try not to force-push commits to PRs that have already been reviewed.
+			Doing so makes it harder to review the changes.
+			We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
+
+			Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
+
+			Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
+
+			#### Post-Merge Recognition
+
+			Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
+			Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
+
+			## Emojis & Appreciation
+
+			If you made it all the way to the end, bravo dear user, we love you.
+			Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
+			💖 is a good starter if you're not sure which to use.
+			",
+			  "DEVELOPMENT.md": "# Development
+
+			After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
+
+			\`\`\`shell
+			git clone https://github.com/<your-name-here>/stub-repository
+			cd stub-repository
+			pnpm install
+			\`\`\`
+
+			> This repository includes a list of suggested VS Code extensions.
+			> It's a good idea to use [VS Code](https://code.visualstudio.com) and accept its suggestion to install them, as they'll help with development.
+
+			## Building
+
+			Run [**tsup**](https://tsup.egoist.dev) locally to build source files from \`src/\` into output files in \`lib/\`:
+
+			\`\`\`shell
+			pnpm build
+			\`\`\`
+
+			Add \`--watch\` to run the builder in a watch mode that continuously cleans and recreates \`lib/\` as you save files:
+
+			\`\`\`shell
+			pnpm build --watch
+			\`\`\`
+
+			## Formatting
+
+			[Prettier](https://prettier.io) is used to format code.
+			It should be applied automatically when you save files in VS Code or make a Git commit.
+
+			To manually reformat all files, you can run:
+
+			\`\`\`shell
+			pnpm format --write
+			\`\`\`
+
+			## Linting
+
+			This package includes several forms of linting to enforce consistent code quality and styling.
+			Each should be shown in VS Code, and can be run manually on the command-line:
+
+			- \`pnpm lint\` ([ESLint](https://eslint.org) with [typescript-eslint](https://typescript-eslint.io)): Lints JavaScript and TypeScript source files
+			- \`pnpm lint:knip\` ([knip](https://github.com/webpro/knip)): Detects unused files, dependencies, and code exports
+			- \`pnpm lint:md\` ([Markdownlint](https://github.com/DavidAnson/markdownlint)): Checks Markdown source files
+			- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yml\` file
+			- \`pnpm lint:spelling\` ([cspell](https://cspell.org)): Spell checks across all source files
+
+			Read the individual documentation for each linter to understand how it can be configured and used best.
+
+			For example, ESLint can be run with \`--fix\` to auto-fix some lint rule complaints:
+
+			\`\`\`shell
+			pnpm run lint --fix
+			\`\`\`
+
+			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
+
+			## Testing
+
+			[Vitest](https://vitest.dev) is used for tests.
+			You can run it locally on the command-line:
+
+			\`\`\`shell
+			pnpm run test
+			\`\`\`
+
+			Add the \`--coverage\` flag to compute test coverage and place reports in the \`coverage/\` directory:
+
+			\`\`\`shell
+			pnpm run test --coverage
+			\`\`\`
+
+			Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
+			Calls to \`console.log\`, \`console.warn\`, and other console methods will cause a test to fail.
+
+			### Debugging Tests
+
+			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging unit tests.
+			To launch it, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
+
+			## Type Checking
+
+			You should be able to see suggestions from [TypeScript](https://typescriptlang.org) in your editor for all open files.
+
+			However, it can be useful to run the TypeScript command-line (\`tsc\`) to type check all files in \`src/\`:
+
+			\`\`\`shell
+			pnpm tsc
+			\`\`\`
+
+			Add \`--watch\` to keep the type checker running in a watch mode that updates the display as you save files:
+
+			\`\`\`shell
+			pnpm tsc --watch
+			\`\`\`
+
+			## Debugging
+
+			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging.
+			Depending upon the type of usage, it can include debugging for unit tests _and_ for executable (or "bin") apps.
+
+			### Unit Tests
+
+			To debug a unit test, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
+
+			### \`bin\` Apps
+
+			To debug a \`bin\` app, add a breakpoint to your code, then run _Debug Program_ from the VS Code Debug panel (or press F5).
+
+			## Setup Scripts
+
+			As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository.
+
+			Each follows roughly the same general flow:
+
+			1. \`bin/index.ts\` uses \`bin/mode.ts\` to determine which of the three setup scripts to run
+			2. \`readOptions\` parses in options from local files, Git commands, npm APIs, and/or files on disk
+			3. \`runOrRestore\` wraps the setup script's main logic in a friendly prompt wrapper
+			4. The setup script wraps each portion of its main logic with \`withSpinner\`
+			   - Each step of setup logic is generally imported from within \`src/steps\`
+			5. A call to \`outro\` summarizes the results for the user
+
+			> **Warning**
+			> Each setup script overrides many files in the directory they're run in.
+			> Make sure to save any changes you want to preserve before running them.
+
+			### The Creation Script
+
+			> 📝 See [\`docs/Creation.md\`](../docs/Creation.md) for user documentation on the creation script.
+
+			This template's "creation" script is located in \`src/create/\`.
+			You can run it locally with \`node bin/index.js --mode create\`.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			#### Testing the Creation Script
+
+			You can run the end-to-end test for creation locally on the command-line.
+			Note that the files need to be built with \`pnpm run build\` beforehand.
+
+			\`\`\`shell
+			pnpm run test:create
+			\`\`\`
+
+			That end-to-end test executes \`script/create-test-e2e.ts\`, which:
+
+			1. Runs the creation script to create a new \`test-repository\` child directory and repository, capturing code coverage
+			2. Asserts that commands such as \`build\` and \`lint\` each pass
+
+			The \`pnpm run test:create\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-create.yml\`.
+
+			### The Initialization Script
+
+			> 📝 See [\`docs/Initialization.md\`](../docs/Initialization.md) for user documentation on the initialization script.
+
+			This template's "initialization" script is located in \`src/initialize/\`.
+			You can run it locally with \`pnpm run initialize\`.
+			It uses [\`tsx\`](https://github.com/esbuild-kit/tsx) so you don't need to build files before running.
+
+			\`\`\`shell
+			pnpm run initialize
+			\`\`\`
+
+			#### Testing the Initialization Script
+
+			You can run the end-to-end test for initializing locally on the command-line.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			\`\`\`shell
+			pnpm run test:initialize
+			\`\`\`
+
+			That end-to-end test executes \`script/initialize-test-e2e.ts\`, which:
+
+			1. Runs the initialization script using \`--skip-github-api\` and other skip flags
+			2. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
+			3. Runs \`pnpm run lint:knip\` to make sure no excess dependencies or files were left over
+			4. Resets everything
+			5. Runs initialization a second time, capturing test coverage
+
+			The \`pnpm run test:initialize\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-initialize.yml\`.
+
+			### The Migration Script
+
+			> 📝 See [\`docs/Migration.md\`](../docs/Migration.md) for user documentation on the migration script.
+
+			This template's "migration" script is located in \`src/migrate/\`.
+			Note that files need to be built with \`pnpm run build\` beforehand.
+
+			To test out the script locally, run it from a different repository's directory:
+
+			\`\`\`shell
+			cd ../other-repo
+			node ../create-typescript-app/bin/migrate.js
+			\`\`\`
+
+			The migration script will work on any directory.
+			You can try it out in a blank directory with scripts like:
+
+			\`\`\`shell
+			cd ..
+			mkdir temp
+			cd temp
+			node ../create-typescript-app/bin/migrate.js
+			\`\`\`
+
+			#### Testing the Migration Script
+
+			> 💡 Seeing \`Oh no! Running the migrate script unexpectedly modified:\` errors?
+			> _[Unexpected File Modifications](#unexpected-file-modifications)_ covers that below.
+
+			You can run the end-to-end test for migrating locally on the command-line:
+
+			\`\`\`shell
+			pnpm run test:migrate
+			\`\`\`
+
+			That end-to-end test executes \`script/migrate-test-e2e.ts\`, which:
+
+			1. Runs the migration script using \`--skip-github-api\` and other skip flags, capturing code coverage
+			2. Checks that only a small list of allowed files were changed
+			3. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
+
+			The \`pnpm run test:migrate\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
+			See \`.github/workflows/test-migrate.yml\`.
+
+			> Tip: if the migration test is failing in CI and you don't see any errors, try [downloading the full logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
+
+			##### Migration Snapshot Failures
+
+			The migration test uses the [Vitest file snapshot](https://vitest.dev/guide/snapshot#file-snapshots) in \`script/__snapshots__/migrate-test-e2e.ts.snap\` to store expected differences to this repository after running the migration script.
+			The end-to-end migration test will fail any changes that don't keep the same differences in that snapshot.
+
+			You can update the snapshot file by:
+
+			1. Committing any changes to your local repository
+			2. Running \`pnpm i\` and \`pnpm build\` if any updates have been made to the \`package.json\` or \`src/\` files, respectively
+			3. Running \`pnpm run test:migrate -u\` to update the snapshot
+
+			At this point there will be some files changed:
+
+			- \`script/__snapshots__/migrate-test-e2e.ts.snap\` will have updates if any files mismatched templates
+			- The actual updated files on disk will be there too
+
+			If the snapshot file changes are what you expected, then you can commit them.
+			The rest of the file changes can be reverted.
+
+			> [🚀 Feature: Add a way to apply known file changes after migration #1184](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1184) tracks turning the test snapshot into a feature.
+
+			##### Unexpected File Modifications
+
+			The migration test also asserts that no files were unexpectedly changed.
+			If you see a failure like:
+
+			\`\`\`plaintext
+			Oh no! Running the migrate script unexpectedly modified:
+			 - ...
+			\`\`\`
+
+			...then that means the file generated from templates differs from what's checked into the repository.
+			This is most often caused by changes to templates not being applied to checked-in files too.
+
+			Templates for files are generally stored in [\`src/steps/writing/creation\`] under a path roughly corresponding to the file they describe.
+			For example, the template for \`tsup.config.ts\` is stored in [\`src/steps/writing/creation/createTsupConfig.ts\`](../src/steps/writing/creation/createTsupConfig.ts).
+			If the \`createTsupConfig\` function were to be modified without an equivalent change to \`tsup.config.ts\` -or vice-versa- then the migration test would report:
+
+			\`\`\`plaintext
+			Oh no! Running the migrate script unexpectedly modified:
+			 - tsup.config.ts
+			\`\`\`
+			",
+			  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
+			<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
+			<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
+
+			<!-- This blank issue template is only for issues that don't fit any of the templates. -->
+
+			## Overview
+
+			...
+			",
+			  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
+			Please fill out all fields below and make sure each item is true and [x] checked.
+			Otherwise we may not be able to review your PR. -->
+
+			## PR Checklist
+
+			- [ ] Addresses an existing open issue: fixes #000
+			- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
+			- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
+
+			## Overview
+
+			<!-- Description of what is changed and how the code change does that. -->
+			",
+			  "SECURITY.md": "# Security Policy
+
+			We take all security vulnerabilities seriously.
+			If you have a vulnerability or other security issues to disclose:
+
+			- Thank you very much, please do!
+			- Please send them to us by emailing \`github@email.com\`
+
+			We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+			",
+			  "renovate.json": "{
+				"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+				"automerge": true,
+				"extends": ["config:best-practices", "replacements:all"],
+				"ignoreDeps": ["codecov/codecov-action"],
+				"internalChecksFilter": "strict",
+				"patch": { "enabled": false },
+				"labels": ["dependencies"],
+				"minimumReleaseAge": "3 days",
+				"postUpdateOptions": ["pnpmDedupe"]
+			}
+			",
+			}
+		`);
+	});
+});

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
@@ -587,7 +587,6 @@ describe("createDotGitHubFiles", () => {
 					"automerge": true,
 					"extends": ["config:best-practices", "replacements:all"],
 					"ignoreDeps": ["codecov/codecov-action"],
-					"internalChecksFilter": "strict",
 					"patch": { "enabled": false },
 					"labels": ["dependencies"],
 					"minimumReleaseAge": "3 days",

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createDotGitHubFiles } from "./createDotGitHubFiles.js";
 import { Options } from "../../../../shared/types.js";
+import { createDotGitHubFiles } from "./createDotGitHubFiles.js";
 
 vi.mock("./createDevelopment/index.js", () => ({
 	createDevelopment: () => "# Development!",

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createDotGitHubFiles } from "./createDotGitHubFiles.js";
 import { Options } from "../../../../shared/types.js";
+
+vi.mock("./createDevelopment/index.js", () => ({
+	createDevelopment: () => "# Development!",
+}));
 
 const createOptions = (exclude: boolean) =>
 	({
@@ -37,1106 +41,560 @@ describe("createDotGitHubFiles", () => {
 	it("creates only markdown files when given minimal options", async () => {
 		expect(await createDotGitHubFiles(createOptions(true)))
 			.toMatchInlineSnapshot(`
-			{
-			  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
+				{
+				  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
 
-			## Our Pledge
+				## Our Pledge
 
-			We as members, contributors, and leaders pledge to make participation in our
-			community a harassment-free experience for everyone, regardless of age, body
-			size, visible or invisible disability, ethnicity, sex characteristics, gender
-			identity and expression, level of experience, education, socio-economic status,
-			nationality, personal appearance, race, caste, color, religion, or sexual
-			identity and orientation.
+				We as members, contributors, and leaders pledge to make participation in our
+				community a harassment-free experience for everyone, regardless of age, body
+				size, visible or invisible disability, ethnicity, sex characteristics, gender
+				identity and expression, level of experience, education, socio-economic status,
+				nationality, personal appearance, race, caste, color, religion, or sexual
+				identity and orientation.
 
-			We pledge to act and interact in ways that contribute to an open, welcoming,
-			diverse, inclusive, and healthy community.
+				We pledge to act and interact in ways that contribute to an open, welcoming,
+				diverse, inclusive, and healthy community.
 
-			## Our Standards
+				## Our Standards
 
-			Examples of behavior that contributes to a positive environment for our
-			community include:
+				Examples of behavior that contributes to a positive environment for our
+				community include:
 
-			- Demonstrating empathy and kindness toward other people
-			- Being respectful of differing opinions, viewpoints, and experiences
-			- Giving and gracefully accepting constructive feedback
-			- Accepting responsibility and apologizing to those affected by our mistakes,
-			and learning from the experience
-			- Focusing on what is best not just for us as individuals, but for the overall
-			community
+				- Demonstrating empathy and kindness toward other people
+				- Being respectful of differing opinions, viewpoints, and experiences
+				- Giving and gracefully accepting constructive feedback
+				- Accepting responsibility and apologizing to those affected by our mistakes,
+				and learning from the experience
+				- Focusing on what is best not just for us as individuals, but for the overall
+				community
 
-			Examples of unacceptable behavior include:
+				Examples of unacceptable behavior include:
 
-			- The use of sexualized language or imagery, and sexual attention or advances of
-			any kind
-			- Trolling, insulting or derogatory comments, and personal or political attacks
-			- Public or private harassment
-			- Publishing others' private information, such as a physical or email address,
-			without their explicit permission
-			- Other conduct which could reasonably be considered inappropriate in a
-			professional setting
+				- The use of sexualized language or imagery, and sexual attention or advances of
+				any kind
+				- Trolling, insulting or derogatory comments, and personal or political attacks
+				- Public or private harassment
+				- Publishing others' private information, such as a physical or email address,
+				without their explicit permission
+				- Other conduct which could reasonably be considered inappropriate in a
+				professional setting
 
-			## Enforcement Responsibilities
+				## Enforcement Responsibilities
 
-			Community leaders are responsible for clarifying and enforcing our standards of
-			acceptable behavior and will take appropriate and fair corrective action in
-			response to any behavior that they deem inappropriate, threatening, offensive,
-			or harmful.
+				Community leaders are responsible for clarifying and enforcing our standards of
+				acceptable behavior and will take appropriate and fair corrective action in
+				response to any behavior that they deem inappropriate, threatening, offensive,
+				or harmful.
 
-			Community leaders have the right and responsibility to remove, edit, or reject
-			comments, commits, code, wiki edits, issues, and other contributions that are
-			not aligned to this Code of Conduct, and will communicate reasons for moderation
-			decisions when appropriate.
+				Community leaders have the right and responsibility to remove, edit, or reject
+				comments, commits, code, wiki edits, issues, and other contributions that are
+				not aligned to this Code of Conduct, and will communicate reasons for moderation
+				decisions when appropriate.
 
-			## Scope
+				## Scope
 
-			This Code of Conduct applies within all community spaces, and also applies when
-			an individual is officially representing the community in public spaces.
-			Examples of representing our community include using an official e-mail address,
-			posting via an official social media account, or acting as an appointed
-			representative at an online or offline event.
+				This Code of Conduct applies within all community spaces, and also applies when
+				an individual is officially representing the community in public spaces.
+				Examples of representing our community include using an official e-mail address,
+				posting via an official social media account, or acting as an appointed
+				representative at an online or offline event.
 
-			## Enforcement
+				## Enforcement
 
-			Instances of abusive, harassing, or otherwise unacceptable behavior may be
-			reported to the community leaders responsible for enforcement at
-			github@email.com.
-			All complaints will be reviewed and investigated promptly and fairly.
+				Instances of abusive, harassing, or otherwise unacceptable behavior may be
+				reported to the community leaders responsible for enforcement at
+				github@email.com.
+				All complaints will be reviewed and investigated promptly and fairly.
 
-			All community leaders are obligated to respect the privacy and security of the
-			reporter of any incident.
+				All community leaders are obligated to respect the privacy and security of the
+				reporter of any incident.
 
-			## Enforcement Guidelines
+				## Enforcement Guidelines
 
-			Community leaders will follow these Community Impact Guidelines in determining
-			the consequences for any action they deem in violation of this Code of Conduct:
+				Community leaders will follow these Community Impact Guidelines in determining
+				the consequences for any action they deem in violation of this Code of Conduct:
 
-			### 1. Correction
+				### 1. Correction
 
-			**Community Impact**: Use of inappropriate language or other behavior deemed
-			unprofessional or unwelcome in the community.
+				**Community Impact**: Use of inappropriate language or other behavior deemed
+				unprofessional or unwelcome in the community.
 
-			**Consequence**: A private, written warning from community leaders, providing
-			clarity around the nature of the violation and an explanation of why the
-			behavior was inappropriate. A public apology may be requested.
+				**Consequence**: A private, written warning from community leaders, providing
+				clarity around the nature of the violation and an explanation of why the
+				behavior was inappropriate. A public apology may be requested.
 
-			### 2. Warning
+				### 2. Warning
 
-			**Community Impact**: A violation through a single incident or series of
-			actions.
+				**Community Impact**: A violation through a single incident or series of
+				actions.
 
-			**Consequence**: A warning with consequences for continued behavior. No
-			interaction with the people involved, including unsolicited interaction with
-			those enforcing the Code of Conduct, for a specified period of time. This
-			includes avoiding interactions in community spaces as well as external channels
-			like social media. Violating these terms may lead to a temporary or permanent
-			ban.
+				**Consequence**: A warning with consequences for continued behavior. No
+				interaction with the people involved, including unsolicited interaction with
+				those enforcing the Code of Conduct, for a specified period of time. This
+				includes avoiding interactions in community spaces as well as external channels
+				like social media. Violating these terms may lead to a temporary or permanent
+				ban.
 
-			### 3. Temporary Ban
+				### 3. Temporary Ban
 
-			**Community Impact**: A serious violation of community standards, including
-			sustained inappropriate behavior.
+				**Community Impact**: A serious violation of community standards, including
+				sustained inappropriate behavior.
 
-			**Consequence**: A temporary ban from any sort of interaction or public
-			communication with the community for a specified period of time. No public or
-			private interaction with the people involved, including unsolicited interaction
-			with those enforcing the Code of Conduct, is allowed during this period.
-			Violating these terms may lead to a permanent ban.
+				**Consequence**: A temporary ban from any sort of interaction or public
+				communication with the community for a specified period of time. No public or
+				private interaction with the people involved, including unsolicited interaction
+				with those enforcing the Code of Conduct, is allowed during this period.
+				Violating these terms may lead to a permanent ban.
 
-			### 4. Permanent Ban
+				### 4. Permanent Ban
 
-			**Community Impact**: Demonstrating a pattern of violation of community
-			standards, including sustained inappropriate behavior, harassment of an
-			individual, or aggression toward or disparagement of classes of individuals.
+				**Community Impact**: Demonstrating a pattern of violation of community
+				standards, including sustained inappropriate behavior, harassment of an
+				individual, or aggression toward or disparagement of classes of individuals.
 
-			**Consequence**: A permanent ban from any sort of public interaction within the
-			community.
+				**Consequence**: A permanent ban from any sort of public interaction within the
+				community.
 
-			## Attribution
+				## Attribution
 
-			This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-			version 2.1, available at
-			[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+				This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+				version 2.1, available at
+				[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-			Community Impact Guidelines were inspired by
-			[Mozilla's code of conduct enforcement ladder][mozilla coc].
+				Community Impact Guidelines were inspired by
+				[Mozilla's code of conduct enforcement ladder][mozilla coc].
 
-			For answers to common questions about this code of conduct, see the FAQ at
-			[https://www.contributor-covenant.org/faq][faq]. Translations are available at
-			[https://www.contributor-covenant.org/translations][translations].
+				For answers to common questions about this code of conduct, see the FAQ at
+				[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+				[https://www.contributor-covenant.org/translations][translations].
 
-			[homepage]: https://www.contributor-covenant.org
-			[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-			[mozilla coc]: https://github.com/mozilla/diversity
-			[faq]: https://www.contributor-covenant.org/faq
-			[translations]: https://www.contributor-covenant.org/translations
-			",
-			  "CONTRIBUTING.md": "# Contributing
+				[homepage]: https://www.contributor-covenant.org
+				[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+				[mozilla coc]: https://github.com/mozilla/diversity
+				[faq]: https://www.contributor-covenant.org/faq
+				[translations]: https://www.contributor-covenant.org/translations
+				",
+				  "CONTRIBUTING.md": "# Contributing
 
-			Thanks for your interest in contributing to \`stub-repository\`! 💖
+				Thanks for your interest in contributing to \`stub-repository\`! 💖
 
-			> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
+				> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
 
-			## Code of Conduct
+				## Code of Conduct
 
-			This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
+				This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
 
-			## Reporting Issues
+				## Reporting Issues
 
-			Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
+				Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
 
-			## Sending Contributions
+				## Sending Contributions
 
-			Sending your own changes as contribution is always appreciated!
-			There are two steps involved:
+				Sending your own changes as contribution is always appreciated!
+				There are two steps involved:
 
-			1. [Finding an Issue](#finding-an-issue)
-			2. [Sending a Pull Request](#sending-a-pull-request)
+				1. [Finding an Issue](#finding-an-issue)
+				2. [Sending a Pull Request](#sending-a-pull-request)
 
-			### Finding an Issue
+				### Finding an Issue
 
-			With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-			If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-			If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
+				With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+				If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+				If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
-			#### Issue Claiming
+				#### Issue Claiming
 
-			We don't use any kind of issue claiming system.
-			We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
+				We don't use any kind of issue claiming system.
+				We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
 
-			If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
-			Please don't post comments asking for permission or stating you will work on an issue.
+				If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
+				Please don't post comments asking for permission or stating you will work on an issue.
 
-			### Sending a Pull Request
+				### Sending a Pull Request
 
-			Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
-			Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
+				Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
+				Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
 
-			PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
-			Only PR titles need to be in that format, not individual commits.
-			Don't worry if you get this wrong: you can always change the PR title after sending it.
-			Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
+				PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
+				Only PR titles need to be in that format, not individual commits.
+				Don't worry if you get this wrong: you can always change the PR title after sending it.
+				Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
 
-			#### Draft PRs
+				#### Draft PRs
 
-			If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
-			Draft PRs won't be reviewed.
+				If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
+				Draft PRs won't be reviewed.
 
-			#### Granular PRs
+				#### Granular PRs
 
-			Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
-			Send one PR per area of concern.
-			Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
+				Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
+				Send one PR per area of concern.
+				Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
 
-			#### Pull Request Reviews
+				#### Pull Request Reviews
 
-			When a PR is not in draft, it's considered ready for review.
-			Please don't manually \`@\` tag anybody to request review.
-			A maintainer will look at it when they're next able to.
+				When a PR is not in draft, it's considered ready for review.
+				Please don't manually \`@\` tag anybody to request review.
+				A maintainer will look at it when they're next able to.
 
-			PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
+				PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
 
-			#### Asking Questions
+				#### Asking Questions
 
-			If you need help and/or have a question, posting a comment in the PR is a great way to do so.
-			There's no need to tag anybody individually.
-			One of us will drop by and help when we can.
+				If you need help and/or have a question, posting a comment in the PR is a great way to do so.
+				There's no need to tag anybody individually.
+				One of us will drop by and help when we can.
 
-			Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
-			You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
+				Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
+				You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
 
-			#### Requested Changes
+				#### Requested Changes
 
-			After a maintainer reviews your PR, they may request changes on it.
-			Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
+				After a maintainer reviews your PR, they may request changes on it.
+				Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
 
-			Please try not to force-push commits to PRs that have already been reviewed.
-			Doing so makes it harder to review the changes.
-			We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
+				Please try not to force-push commits to PRs that have already been reviewed.
+				Doing so makes it harder to review the changes.
+				We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
 
-			Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
+				Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
 
-			Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
+				Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
 
-			#### Post-Merge Recognition
+				#### Post-Merge Recognition
 
-			Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
-			Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
+				Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
+				Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
 
-			## Emojis & Appreciation
+				## Emojis & Appreciation
 
-			If you made it all the way to the end, bravo dear user, we love you.
-			Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
-			💖 is a good starter if you're not sure which to use.
-			",
-			  "DEVELOPMENT.md": "# Development
+				If you made it all the way to the end, bravo dear user, we love you.
+				Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
+				💖 is a good starter if you're not sure which to use.
+				",
+				  "DEVELOPMENT.md": "# Development!",
+				  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
+				<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
+				<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
 
-			After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
+				<!-- This blank issue template is only for issues that don't fit any of the templates. -->
 
-			\`\`\`shell
-			git clone https://github.com/<your-name-here>/stub-repository
-			cd stub-repository
-			pnpm install
-			\`\`\`
+				## Overview
 
-			> This repository includes a list of suggested VS Code extensions.
-			> It's a good idea to use [VS Code](https://code.visualstudio.com) and accept its suggestion to install them, as they'll help with development.
+				...
+				",
+				  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
+				Please fill out all fields below and make sure each item is true and [x] checked.
+				Otherwise we may not be able to review your PR. -->
 
-			## Building
+				## PR Checklist
 
-			Run [**tsup**](https://tsup.egoist.dev) locally to build source files from \`src/\` into output files in \`lib/\`:
+				- [ ] Addresses an existing open issue: fixes #000
+				- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
+				- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
 
-			\`\`\`shell
-			pnpm build
-			\`\`\`
+				## Overview
 
-			Add \`--watch\` to run the builder in a watch mode that continuously cleans and recreates \`lib/\` as you save files:
+				<!-- Description of what is changed and how the code change does that. -->
+				",
+				  "SECURITY.md": "# Security Policy
 
-			\`\`\`shell
-			pnpm build --watch
-			\`\`\`
+				We take all security vulnerabilities seriously.
+				If you have a vulnerability or other security issues to disclose:
 
-			## Formatting
+				- Thank you very much, please do!
+				- Please send them to us by emailing \`github@email.com\`
 
-			[Prettier](https://prettier.io) is used to format code.
-			It should be applied automatically when you save files in VS Code or make a Git commit.
-
-			To manually reformat all files, you can run:
-
-			\`\`\`shell
-			pnpm format --write
-			\`\`\`
-
-			## Linting
-
-			This package includes several forms of linting to enforce consistent code quality and styling.
-			Each should be shown in VS Code, and can be run manually on the command-line:
-
-			- \`pnpm lint\` ([ESLint](https://eslint.org) with [typescript-eslint](https://typescript-eslint.io)): Lints JavaScript and TypeScript source files
-			- \`pnpm lint:knip\` ([knip](https://github.com/webpro/knip)): Detects unused files, dependencies, and code exports
-			- \`pnpm lint:md\` ([Markdownlint](https://github.com/DavidAnson/markdownlint)): Checks Markdown source files
-			- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yml\` file
-			- \`pnpm lint:spelling\` ([cspell](https://cspell.org)): Spell checks across all source files
-
-			Read the individual documentation for each linter to understand how it can be configured and used best.
-
-			For example, ESLint can be run with \`--fix\` to auto-fix some lint rule complaints:
-
-			\`\`\`shell
-			pnpm run lint --fix
-			\`\`\`
-
-			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
-
-			## Type Checking
-
-			You should be able to see suggestions from [TypeScript](https://typescriptlang.org) in your editor for all open files.
-
-			However, it can be useful to run the TypeScript command-line (\`tsc\`) to type check all files in \`src/\`:
-
-			\`\`\`shell
-			pnpm tsc
-			\`\`\`
-
-			Add \`--watch\` to keep the type checker running in a watch mode that updates the display as you save files:
-
-			\`\`\`shell
-			pnpm tsc --watch
-			\`\`\`
-
-			## Testing
-
-			[Vitest](https://vitest.dev) is used for tests.
-			You can run it locally on the command-line:
-
-			\`\`\`shell
-			pnpm run test
-			\`\`\`
-
-			Add the \`--coverage\` flag to compute test coverage and place reports in the \`coverage/\` directory:
-
-			\`\`\`shell
-			pnpm run test --coverage
-			\`\`\`
-
-			Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
-			Calls to \`console.log\`, \`console.warn\`, and other console methods will cause a test to fail.
-
-			### Debugging Tests
-
-			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging unit tests.
-			To launch it, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
-
-			## Debugging
-
-			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging.
-			Depending upon the type of usage, it can include debugging for unit tests _and_ for executable (or "bin") apps.
-
-			### Unit Tests
-
-			To debug a unit test, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
-
-			### \`bin\` Apps
-
-			To debug a \`bin\` app, add a breakpoint to your code, then run _Debug Program_ from the VS Code Debug panel (or press F5).
-
-			## Setup Scripts
-
-			As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository.
-
-			Each follows roughly the same general flow:
-
-			1. \`bin/index.ts\` uses \`bin/mode.ts\` to determine which of the three setup scripts to run
-			2. \`readOptions\` parses in options from local files, Git commands, npm APIs, and/or files on disk
-			3. \`runOrRestore\` wraps the setup script's main logic in a friendly prompt wrapper
-			4. The setup script wraps each portion of its main logic with \`withSpinner\`
-			   - Each step of setup logic is generally imported from within \`src/steps\`
-			5. A call to \`outro\` summarizes the results for the user
-
-			> **Warning**
-			> Each setup script overrides many files in the directory they're run in.
-			> Make sure to save any changes you want to preserve before running them.
-
-			### The Creation Script
-
-			> 📝 See [\`docs/Creation.md\`](../docs/Creation.md) for user documentation on the creation script.
-
-			This template's "creation" script is located in \`src/create/\`.
-			You can run it locally with \`node bin/index.js --mode create\`.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			#### Testing the Creation Script
-
-			You can run the end-to-end test for creation locally on the command-line.
-			Note that the files need to be built with \`pnpm run build\` beforehand.
-
-			\`\`\`shell
-			pnpm run test:create
-			\`\`\`
-
-			That end-to-end test executes \`script/create-test-e2e.ts\`, which:
-
-			1. Runs the creation script to create a new \`test-repository\` child directory and repository, capturing code coverage
-			2. Asserts that commands such as \`build\` and \`lint\` each pass
-
-			The \`pnpm run test:create\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-create.yml\`.
-
-			### The Initialization Script
-
-			> 📝 See [\`docs/Initialization.md\`](../docs/Initialization.md) for user documentation on the initialization script.
-
-			This template's "initialization" script is located in \`src/initialize/\`.
-			You can run it locally with \`pnpm run initialize\`.
-			It uses [\`tsx\`](https://github.com/esbuild-kit/tsx) so you don't need to build files before running.
-
-			\`\`\`shell
-			pnpm run initialize
-			\`\`\`
-
-			#### Testing the Initialization Script
-
-			You can run the end-to-end test for initializing locally on the command-line.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			\`\`\`shell
-			pnpm run test:initialize
-			\`\`\`
-
-			That end-to-end test executes \`script/initialize-test-e2e.ts\`, which:
-
-			1. Runs the initialization script using \`--skip-github-api\` and other skip flags
-			2. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
-			3. Runs \`pnpm run lint:knip\` to make sure no excess dependencies or files were left over
-			4. Resets everything
-			5. Runs initialization a second time, capturing test coverage
-
-			The \`pnpm run test:initialize\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-initialize.yml\`.
-
-			### The Migration Script
-
-			> 📝 See [\`docs/Migration.md\`](../docs/Migration.md) for user documentation on the migration script.
-
-			This template's "migration" script is located in \`src/migrate/\`.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			To test out the script locally, run it from a different repository's directory:
-
-			\`\`\`shell
-			cd ../other-repo
-			node ../create-typescript-app/bin/migrate.js
-			\`\`\`
-
-			The migration script will work on any directory.
-			You can try it out in a blank directory with scripts like:
-
-			\`\`\`shell
-			cd ..
-			mkdir temp
-			cd temp
-			node ../create-typescript-app/bin/migrate.js
-			\`\`\`
-
-			#### Testing the Migration Script
-
-			> 💡 Seeing \`Oh no! Running the migrate script unexpectedly modified:\` errors?
-			> _[Unexpected File Modifications](#unexpected-file-modifications)_ covers that below.
-
-			You can run the end-to-end test for migrating locally on the command-line:
-
-			\`\`\`shell
-			pnpm run test:migrate
-			\`\`\`
-
-			That end-to-end test executes \`script/migrate-test-e2e.ts\`, which:
-
-			1. Runs the migration script using \`--skip-github-api\` and other skip flags, capturing code coverage
-			2. Checks that only a small list of allowed files were changed
-			3. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
-
-			The \`pnpm run test:migrate\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-migrate.yml\`.
-
-			> Tip: if the migration test is failing in CI and you don't see any errors, try [downloading the full logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
-
-			##### Migration Snapshot Failures
-
-			The migration test uses the [Vitest file snapshot](https://vitest.dev/guide/snapshot#file-snapshots) in \`script/__snapshots__/migrate-test-e2e.ts.snap\` to store expected differences to this repository after running the migration script.
-			The end-to-end migration test will fail any changes that don't keep the same differences in that snapshot.
-
-			You can update the snapshot file by:
-
-			1. Committing any changes to your local repository
-			2. Running \`pnpm i\` and \`pnpm build\` if any updates have been made to the \`package.json\` or \`src/\` files, respectively
-			3. Running \`pnpm run test:migrate -u\` to update the snapshot
-
-			At this point there will be some files changed:
-
-			- \`script/__snapshots__/migrate-test-e2e.ts.snap\` will have updates if any files mismatched templates
-			- The actual updated files on disk will be there too
-
-			If the snapshot file changes are what you expected, then you can commit them.
-			The rest of the file changes can be reverted.
-
-			> [🚀 Feature: Add a way to apply known file changes after migration #1184](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1184) tracks turning the test snapshot into a feature.
-
-			##### Unexpected File Modifications
-
-			The migration test also asserts that no files were unexpectedly changed.
-			If you see a failure like:
-
-			\`\`\`plaintext
-			Oh no! Running the migrate script unexpectedly modified:
-			 - ...
-			\`\`\`
-
-			...then that means the file generated from templates differs from what's checked into the repository.
-			This is most often caused by changes to templates not being applied to checked-in files too.
-
-			Templates for files are generally stored in [\`src/steps/writing/creation\`] under a path roughly corresponding to the file they describe.
-			For example, the template for \`tsup.config.ts\` is stored in [\`src/steps/writing/creation/createTsupConfig.ts\`](../src/steps/writing/creation/createTsupConfig.ts).
-			If the \`createTsupConfig\` function were to be modified without an equivalent change to \`tsup.config.ts\` -or vice-versa- then the migration test would report:
-
-			\`\`\`plaintext
-			Oh no! Running the migrate script unexpectedly modified:
-			 - tsup.config.ts
-			\`\`\`
-			",
-			  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
-			<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
-			<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
-
-			<!-- This blank issue template is only for issues that don't fit any of the templates. -->
-
-			## Overview
-
-			...
-			",
-			  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
-			Please fill out all fields below and make sure each item is true and [x] checked.
-			Otherwise we may not be able to review your PR. -->
-
-			## PR Checklist
-
-			- [ ] Addresses an existing open issue: fixes #000
-			- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-			- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
-
-			## Overview
-
-			<!-- Description of what is changed and how the code change does that. -->
-			",
-			  "SECURITY.md": "# Security Policy
-
-			We take all security vulnerabilities seriously.
-			If you have a vulnerability or other security issues to disclose:
-
-			- Thank you very much, please do!
-			- Please send them to us by emailing \`github@email.com\`
-
-			We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
-			",
-			}
-		`);
+				We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+				",
+				}
+			`);
 	});
 
 	it("creates markdown and extra files when given full options", async () => {
 		expect(await createDotGitHubFiles(createOptions(false)))
 			.toMatchInlineSnapshot(`
-			{
-			  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
+				{
+				  "CODE_OF_CONDUCT.md": "# Contributor Covenant Code of Conduct
 
-			## Our Pledge
+				## Our Pledge
 
-			We as members, contributors, and leaders pledge to make participation in our
-			community a harassment-free experience for everyone, regardless of age, body
-			size, visible or invisible disability, ethnicity, sex characteristics, gender
-			identity and expression, level of experience, education, socio-economic status,
-			nationality, personal appearance, race, caste, color, religion, or sexual
-			identity and orientation.
+				We as members, contributors, and leaders pledge to make participation in our
+				community a harassment-free experience for everyone, regardless of age, body
+				size, visible or invisible disability, ethnicity, sex characteristics, gender
+				identity and expression, level of experience, education, socio-economic status,
+				nationality, personal appearance, race, caste, color, religion, or sexual
+				identity and orientation.
 
-			We pledge to act and interact in ways that contribute to an open, welcoming,
-			diverse, inclusive, and healthy community.
+				We pledge to act and interact in ways that contribute to an open, welcoming,
+				diverse, inclusive, and healthy community.
 
-			## Our Standards
+				## Our Standards
 
-			Examples of behavior that contributes to a positive environment for our
-			community include:
+				Examples of behavior that contributes to a positive environment for our
+				community include:
 
-			- Demonstrating empathy and kindness toward other people
-			- Being respectful of differing opinions, viewpoints, and experiences
-			- Giving and gracefully accepting constructive feedback
-			- Accepting responsibility and apologizing to those affected by our mistakes,
-			and learning from the experience
-			- Focusing on what is best not just for us as individuals, but for the overall
-			community
+				- Demonstrating empathy and kindness toward other people
+				- Being respectful of differing opinions, viewpoints, and experiences
+				- Giving and gracefully accepting constructive feedback
+				- Accepting responsibility and apologizing to those affected by our mistakes,
+				and learning from the experience
+				- Focusing on what is best not just for us as individuals, but for the overall
+				community
 
-			Examples of unacceptable behavior include:
+				Examples of unacceptable behavior include:
 
-			- The use of sexualized language or imagery, and sexual attention or advances of
-			any kind
-			- Trolling, insulting or derogatory comments, and personal or political attacks
-			- Public or private harassment
-			- Publishing others' private information, such as a physical or email address,
-			without their explicit permission
-			- Other conduct which could reasonably be considered inappropriate in a
-			professional setting
+				- The use of sexualized language or imagery, and sexual attention or advances of
+				any kind
+				- Trolling, insulting or derogatory comments, and personal or political attacks
+				- Public or private harassment
+				- Publishing others' private information, such as a physical or email address,
+				without their explicit permission
+				- Other conduct which could reasonably be considered inappropriate in a
+				professional setting
 
-			## Enforcement Responsibilities
+				## Enforcement Responsibilities
 
-			Community leaders are responsible for clarifying and enforcing our standards of
-			acceptable behavior and will take appropriate and fair corrective action in
-			response to any behavior that they deem inappropriate, threatening, offensive,
-			or harmful.
+				Community leaders are responsible for clarifying and enforcing our standards of
+				acceptable behavior and will take appropriate and fair corrective action in
+				response to any behavior that they deem inappropriate, threatening, offensive,
+				or harmful.
 
-			Community leaders have the right and responsibility to remove, edit, or reject
-			comments, commits, code, wiki edits, issues, and other contributions that are
-			not aligned to this Code of Conduct, and will communicate reasons for moderation
-			decisions when appropriate.
+				Community leaders have the right and responsibility to remove, edit, or reject
+				comments, commits, code, wiki edits, issues, and other contributions that are
+				not aligned to this Code of Conduct, and will communicate reasons for moderation
+				decisions when appropriate.
 
-			## Scope
+				## Scope
 
-			This Code of Conduct applies within all community spaces, and also applies when
-			an individual is officially representing the community in public spaces.
-			Examples of representing our community include using an official e-mail address,
-			posting via an official social media account, or acting as an appointed
-			representative at an online or offline event.
+				This Code of Conduct applies within all community spaces, and also applies when
+				an individual is officially representing the community in public spaces.
+				Examples of representing our community include using an official e-mail address,
+				posting via an official social media account, or acting as an appointed
+				representative at an online or offline event.
 
-			## Enforcement
+				## Enforcement
 
-			Instances of abusive, harassing, or otherwise unacceptable behavior may be
-			reported to the community leaders responsible for enforcement at
-			github@email.com.
-			All complaints will be reviewed and investigated promptly and fairly.
+				Instances of abusive, harassing, or otherwise unacceptable behavior may be
+				reported to the community leaders responsible for enforcement at
+				github@email.com.
+				All complaints will be reviewed and investigated promptly and fairly.
 
-			All community leaders are obligated to respect the privacy and security of the
-			reporter of any incident.
+				All community leaders are obligated to respect the privacy and security of the
+				reporter of any incident.
 
-			## Enforcement Guidelines
+				## Enforcement Guidelines
 
-			Community leaders will follow these Community Impact Guidelines in determining
-			the consequences for any action they deem in violation of this Code of Conduct:
+				Community leaders will follow these Community Impact Guidelines in determining
+				the consequences for any action they deem in violation of this Code of Conduct:
 
-			### 1. Correction
+				### 1. Correction
 
-			**Community Impact**: Use of inappropriate language or other behavior deemed
-			unprofessional or unwelcome in the community.
+				**Community Impact**: Use of inappropriate language or other behavior deemed
+				unprofessional or unwelcome in the community.
 
-			**Consequence**: A private, written warning from community leaders, providing
-			clarity around the nature of the violation and an explanation of why the
-			behavior was inappropriate. A public apology may be requested.
+				**Consequence**: A private, written warning from community leaders, providing
+				clarity around the nature of the violation and an explanation of why the
+				behavior was inappropriate. A public apology may be requested.
 
-			### 2. Warning
+				### 2. Warning
 
-			**Community Impact**: A violation through a single incident or series of
-			actions.
+				**Community Impact**: A violation through a single incident or series of
+				actions.
 
-			**Consequence**: A warning with consequences for continued behavior. No
-			interaction with the people involved, including unsolicited interaction with
-			those enforcing the Code of Conduct, for a specified period of time. This
-			includes avoiding interactions in community spaces as well as external channels
-			like social media. Violating these terms may lead to a temporary or permanent
-			ban.
+				**Consequence**: A warning with consequences for continued behavior. No
+				interaction with the people involved, including unsolicited interaction with
+				those enforcing the Code of Conduct, for a specified period of time. This
+				includes avoiding interactions in community spaces as well as external channels
+				like social media. Violating these terms may lead to a temporary or permanent
+				ban.
 
-			### 3. Temporary Ban
+				### 3. Temporary Ban
 
-			**Community Impact**: A serious violation of community standards, including
-			sustained inappropriate behavior.
+				**Community Impact**: A serious violation of community standards, including
+				sustained inappropriate behavior.
 
-			**Consequence**: A temporary ban from any sort of interaction or public
-			communication with the community for a specified period of time. No public or
-			private interaction with the people involved, including unsolicited interaction
-			with those enforcing the Code of Conduct, is allowed during this period.
-			Violating these terms may lead to a permanent ban.
+				**Consequence**: A temporary ban from any sort of interaction or public
+				communication with the community for a specified period of time. No public or
+				private interaction with the people involved, including unsolicited interaction
+				with those enforcing the Code of Conduct, is allowed during this period.
+				Violating these terms may lead to a permanent ban.
 
-			### 4. Permanent Ban
+				### 4. Permanent Ban
 
-			**Community Impact**: Demonstrating a pattern of violation of community
-			standards, including sustained inappropriate behavior, harassment of an
-			individual, or aggression toward or disparagement of classes of individuals.
+				**Community Impact**: Demonstrating a pattern of violation of community
+				standards, including sustained inappropriate behavior, harassment of an
+				individual, or aggression toward or disparagement of classes of individuals.
 
-			**Consequence**: A permanent ban from any sort of public interaction within the
-			community.
+				**Consequence**: A permanent ban from any sort of public interaction within the
+				community.
 
-			## Attribution
+				## Attribution
 
-			This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-			version 2.1, available at
-			[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+				This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+				version 2.1, available at
+				[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-			Community Impact Guidelines were inspired by
-			[Mozilla's code of conduct enforcement ladder][mozilla coc].
+				Community Impact Guidelines were inspired by
+				[Mozilla's code of conduct enforcement ladder][mozilla coc].
 
-			For answers to common questions about this code of conduct, see the FAQ at
-			[https://www.contributor-covenant.org/faq][faq]. Translations are available at
-			[https://www.contributor-covenant.org/translations][translations].
+				For answers to common questions about this code of conduct, see the FAQ at
+				[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+				[https://www.contributor-covenant.org/translations][translations].
 
-			[homepage]: https://www.contributor-covenant.org
-			[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-			[mozilla coc]: https://github.com/mozilla/diversity
-			[faq]: https://www.contributor-covenant.org/faq
-			[translations]: https://www.contributor-covenant.org/translations
-			",
-			  "CONTRIBUTING.md": "# Contributing
+				[homepage]: https://www.contributor-covenant.org
+				[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+				[mozilla coc]: https://github.com/mozilla/diversity
+				[faq]: https://www.contributor-covenant.org/faq
+				[translations]: https://www.contributor-covenant.org/translations
+				",
+				  "CONTRIBUTING.md": "# Contributing
 
-			Thanks for your interest in contributing to \`stub-repository\`! 💖
+				Thanks for your interest in contributing to \`stub-repository\`! 💖
 
-			> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
+				> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
 
-			## Code of Conduct
+				## Code of Conduct
 
-			This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
+				This project contains a [Contributor Covenant code of conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
 
-			## Reporting Issues
+				## Reporting Issues
 
-			Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
+				Please do [report an issue on the issue tracker](https://github.com/StubOwner/stub-repository/issues/new/choose) if there's any bugfix, documentation improvement, or general enhancement you'd like to see in the repository! Please fully fill out all required fields in the most appropriate issue form.
 
-			## Sending Contributions
+				## Sending Contributions
 
-			Sending your own changes as contribution is always appreciated!
-			There are two steps involved:
+				Sending your own changes as contribution is always appreciated!
+				There are two steps involved:
 
-			1. [Finding an Issue](#finding-an-issue)
-			2. [Sending a Pull Request](#sending-a-pull-request)
+				1. [Finding an Issue](#finding-an-issue)
+				2. [Sending a Pull Request](#sending-a-pull-request)
 
-			### Finding an Issue
+				### Finding an Issue
 
-			With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-			If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
-			If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
+				With the exception of very small typos, all changes to this repository generally need to correspond to an [unassigned open issue marked as \`status: accepting prs\` on the issue tracker](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+				If this is your first time contributing, consider searching for [unassigned issues that also have the \`good first issue\` label](https://github.com/StubOwner/stub-repository/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3A%22status%3A+accepting+prs%22+no%3Aassignee+).
+				If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
-			#### Issue Claiming
+				#### Issue Claiming
 
-			We don't use any kind of issue claiming system.
-			We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
+				We don't use any kind of issue claiming system.
+				We've found in the past that they result in accidental ["licked cookie"](https://devblogs.microsoft.com/oldnewthing/20091201-00/?p=15843) situations where contributors claim an issue but run out of time or energy trying before sending a PR.
 
-			If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
-			Please don't post comments asking for permission or stating you will work on an issue.
+				If an unassigned issue has been marked as \`status: accepting prs\` and an open PR does not exist, feel free to send a PR.
+				Please don't post comments asking for permission or stating you will work on an issue.
 
-			### Sending a Pull Request
+				### Sending a Pull Request
 
-			Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
-			Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
+				Once you've identified an open issue accepting PRs that doesn't yet have a PR sent, you're free to send a pull request.
+				Be sure to fill out the pull request template's requested information -- otherwise your PR will likely be closed.
 
-			PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
-			Only PR titles need to be in that format, not individual commits.
-			Don't worry if you get this wrong: you can always change the PR title after sending it.
-			Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
+				PRs are also expected to have a title that adheres to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0).
+				Only PR titles need to be in that format, not individual commits.
+				Don't worry if you get this wrong: you can always change the PR title after sending it.
+				Check [previously merged PRs](https://github.com/StubOwner/stub-repository/pulls?q=is%3Apr+is%3Amerged+-label%3Adependencies+) for reference.
 
-			#### Draft PRs
+				#### Draft PRs
 
-			If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
-			Draft PRs won't be reviewed.
+				If you don't think your PR is ready for review, [set it as a draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#converting-a-pull-request-to-a-draft).
+				Draft PRs won't be reviewed.
 
-			#### Granular PRs
+				#### Granular PRs
 
-			Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
-			Send one PR per area of concern.
-			Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
+				Please keep pull requests single-purpose: in other words, don't attempt to solve multiple unrelated problems in one pull request.
+				Send one PR per area of concern.
+				Multi-purpose pull requests are harder and slower to review, block all changes from being merged until the whole pull request is reviewed, and are difficult to name well with semantic PR titles.
 
-			#### Pull Request Reviews
+				#### Pull Request Reviews
 
-			When a PR is not in draft, it's considered ready for review.
-			Please don't manually \`@\` tag anybody to request review.
-			A maintainer will look at it when they're next able to.
+				When a PR is not in draft, it's considered ready for review.
+				Please don't manually \`@\` tag anybody to request review.
+				A maintainer will look at it when they're next able to.
 
-			PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
+				PRs should have passing [GitHub status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) before review is requested (unless there are explicit questions asked in the PR about any failures).
 
-			#### Asking Questions
+				#### Asking Questions
 
-			If you need help and/or have a question, posting a comment in the PR is a great way to do so.
-			There's no need to tag anybody individually.
-			One of us will drop by and help when we can.
+				If you need help and/or have a question, posting a comment in the PR is a great way to do so.
+				There's no need to tag anybody individually.
+				One of us will drop by and help when we can.
 
-			Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
-			You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
+				Please post comments as [line comments](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request) when possible, so that they can be threaded.
+				You can [resolve conversations](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations) on your own when you feel they're resolved - no need to comment explicitly and/or wait for a maintainer.
 
-			#### Requested Changes
+				#### Requested Changes
 
-			After a maintainer reviews your PR, they may request changes on it.
-			Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
+				After a maintainer reviews your PR, they may request changes on it.
+				Once you've made those changes, [re-request review on GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review).
 
-			Please try not to force-push commits to PRs that have already been reviewed.
-			Doing so makes it harder to review the changes.
-			We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
+				Please try not to force-push commits to PRs that have already been reviewed.
+				Doing so makes it harder to review the changes.
+				We squash merge all commits so there's no need to try to preserve Git history within a PR branch.
 
-			Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
+				Once you've addressed all our feedback by making code changes and/or started a followup discussion, [re-request review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review) from each maintainer whose feedback you addressed.
 
-			Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
+				Once all feedback is addressed and the PR is approved, we'll ensure the branch is up to date with \`main\` and merge it for you.
 
-			#### Post-Merge Recognition
+				#### Post-Merge Recognition
 
-			Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
-			Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
+				Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/docs/en/emoji-key "Allcontributors emoji key"), you should be soon.
+				Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
 
-			## Emojis & Appreciation
+				## Emojis & Appreciation
 
-			If you made it all the way to the end, bravo dear user, we love you.
-			Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
-			💖 is a good starter if you're not sure which to use.
-			",
-			  "DEVELOPMENT.md": "# Development
+				If you made it all the way to the end, bravo dear user, we love you.
+				Please include your favorite emoji in the bottom of your issues and PRs to signal to us that you did in fact read this file and are trying to conform to it as best as possible.
+				💖 is a good starter if you're not sure which to use.
+				",
+				  "DEVELOPMENT.md": "# Development!",
+				  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
+				<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
+				<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
 
-			After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation):
+				<!-- This blank issue template is only for issues that don't fit any of the templates. -->
 
-			\`\`\`shell
-			git clone https://github.com/<your-name-here>/stub-repository
-			cd stub-repository
-			pnpm install
-			\`\`\`
+				## Overview
 
-			> This repository includes a list of suggested VS Code extensions.
-			> It's a good idea to use [VS Code](https://code.visualstudio.com) and accept its suggestion to install them, as they'll help with development.
+				...
+				",
+				  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
+				Please fill out all fields below and make sure each item is true and [x] checked.
+				Otherwise we may not be able to review your PR. -->
 
-			## Building
+				## PR Checklist
 
-			Run [**tsup**](https://tsup.egoist.dev) locally to build source files from \`src/\` into output files in \`lib/\`:
+				- [ ] Addresses an existing open issue: fixes #000
+				- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
+				- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
 
-			\`\`\`shell
-			pnpm build
-			\`\`\`
+				## Overview
 
-			Add \`--watch\` to run the builder in a watch mode that continuously cleans and recreates \`lib/\` as you save files:
+				<!-- Description of what is changed and how the code change does that. -->
+				",
+				  "SECURITY.md": "# Security Policy
 
-			\`\`\`shell
-			pnpm build --watch
-			\`\`\`
+				We take all security vulnerabilities seriously.
+				If you have a vulnerability or other security issues to disclose:
 
-			## Formatting
+				- Thank you very much, please do!
+				- Please send them to us by emailing \`github@email.com\`
 
-			[Prettier](https://prettier.io) is used to format code.
-			It should be applied automatically when you save files in VS Code or make a Git commit.
-
-			To manually reformat all files, you can run:
-
-			\`\`\`shell
-			pnpm format --write
-			\`\`\`
-
-			## Linting
-
-			This package includes several forms of linting to enforce consistent code quality and styling.
-			Each should be shown in VS Code, and can be run manually on the command-line:
-
-			- \`pnpm lint\` ([ESLint](https://eslint.org) with [typescript-eslint](https://typescript-eslint.io)): Lints JavaScript and TypeScript source files
-			- \`pnpm lint:knip\` ([knip](https://github.com/webpro/knip)): Detects unused files, dependencies, and code exports
-			- \`pnpm lint:md\` ([Markdownlint](https://github.com/DavidAnson/markdownlint)): Checks Markdown source files
-			- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yml\` file
-			- \`pnpm lint:spelling\` ([cspell](https://cspell.org)): Spell checks across all source files
-
-			Read the individual documentation for each linter to understand how it can be configured and used best.
-
-			For example, ESLint can be run with \`--fix\` to auto-fix some lint rule complaints:
-
-			\`\`\`shell
-			pnpm run lint --fix
-			\`\`\`
-
-			Note that you'll likely need to run \`pnpm build\` before \`pnpm lint\` so that lint rules which check the file system can pick up on any built files.
-
-			## Testing
-
-			[Vitest](https://vitest.dev) is used for tests.
-			You can run it locally on the command-line:
-
-			\`\`\`shell
-			pnpm run test
-			\`\`\`
-
-			Add the \`--coverage\` flag to compute test coverage and place reports in the \`coverage/\` directory:
-
-			\`\`\`shell
-			pnpm run test --coverage
-			\`\`\`
-
-			Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
-			Calls to \`console.log\`, \`console.warn\`, and other console methods will cause a test to fail.
-
-			### Debugging Tests
-
-			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging unit tests.
-			To launch it, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
-
-			## Type Checking
-
-			You should be able to see suggestions from [TypeScript](https://typescriptlang.org) in your editor for all open files.
-
-			However, it can be useful to run the TypeScript command-line (\`tsc\`) to type check all files in \`src/\`:
-
-			\`\`\`shell
-			pnpm tsc
-			\`\`\`
-
-			Add \`--watch\` to keep the type checker running in a watch mode that updates the display as you save files:
-
-			\`\`\`shell
-			pnpm tsc --watch
-			\`\`\`
-
-			## Debugging
-
-			This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging.
-			Depending upon the type of usage, it can include debugging for unit tests _and_ for executable (or "bin") apps.
-
-			### Unit Tests
-
-			To debug a unit test, open a test file, then run _Debug Current Test File_ from the VS Code Debug panel (or press F5).
-
-			### \`bin\` Apps
-
-			To debug a \`bin\` app, add a breakpoint to your code, then run _Debug Program_ from the VS Code Debug panel (or press F5).
-
-			## Setup Scripts
-
-			As described in the \`README.md\` file and \`docs/\`, this template repository comes with three scripts that can set up an existing or new repository.
-
-			Each follows roughly the same general flow:
-
-			1. \`bin/index.ts\` uses \`bin/mode.ts\` to determine which of the three setup scripts to run
-			2. \`readOptions\` parses in options from local files, Git commands, npm APIs, and/or files on disk
-			3. \`runOrRestore\` wraps the setup script's main logic in a friendly prompt wrapper
-			4. The setup script wraps each portion of its main logic with \`withSpinner\`
-			   - Each step of setup logic is generally imported from within \`src/steps\`
-			5. A call to \`outro\` summarizes the results for the user
-
-			> **Warning**
-			> Each setup script overrides many files in the directory they're run in.
-			> Make sure to save any changes you want to preserve before running them.
-
-			### The Creation Script
-
-			> 📝 See [\`docs/Creation.md\`](../docs/Creation.md) for user documentation on the creation script.
-
-			This template's "creation" script is located in \`src/create/\`.
-			You can run it locally with \`node bin/index.js --mode create\`.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			#### Testing the Creation Script
-
-			You can run the end-to-end test for creation locally on the command-line.
-			Note that the files need to be built with \`pnpm run build\` beforehand.
-
-			\`\`\`shell
-			pnpm run test:create
-			\`\`\`
-
-			That end-to-end test executes \`script/create-test-e2e.ts\`, which:
-
-			1. Runs the creation script to create a new \`test-repository\` child directory and repository, capturing code coverage
-			2. Asserts that commands such as \`build\` and \`lint\` each pass
-
-			The \`pnpm run test:create\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-create.yml\`.
-
-			### The Initialization Script
-
-			> 📝 See [\`docs/Initialization.md\`](../docs/Initialization.md) for user documentation on the initialization script.
-
-			This template's "initialization" script is located in \`src/initialize/\`.
-			You can run it locally with \`pnpm run initialize\`.
-			It uses [\`tsx\`](https://github.com/esbuild-kit/tsx) so you don't need to build files before running.
-
-			\`\`\`shell
-			pnpm run initialize
-			\`\`\`
-
-			#### Testing the Initialization Script
-
-			You can run the end-to-end test for initializing locally on the command-line.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			\`\`\`shell
-			pnpm run test:initialize
-			\`\`\`
-
-			That end-to-end test executes \`script/initialize-test-e2e.ts\`, which:
-
-			1. Runs the initialization script using \`--skip-github-api\` and other skip flags
-			2. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
-			3. Runs \`pnpm run lint:knip\` to make sure no excess dependencies or files were left over
-			4. Resets everything
-			5. Runs initialization a second time, capturing test coverage
-
-			The \`pnpm run test:initialize\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-initialize.yml\`.
-
-			### The Migration Script
-
-			> 📝 See [\`docs/Migration.md\`](../docs/Migration.md) for user documentation on the migration script.
-
-			This template's "migration" script is located in \`src/migrate/\`.
-			Note that files need to be built with \`pnpm run build\` beforehand.
-
-			To test out the script locally, run it from a different repository's directory:
-
-			\`\`\`shell
-			cd ../other-repo
-			node ../create-typescript-app/bin/migrate.js
-			\`\`\`
-
-			The migration script will work on any directory.
-			You can try it out in a blank directory with scripts like:
-
-			\`\`\`shell
-			cd ..
-			mkdir temp
-			cd temp
-			node ../create-typescript-app/bin/migrate.js
-			\`\`\`
-
-			#### Testing the Migration Script
-
-			> 💡 Seeing \`Oh no! Running the migrate script unexpectedly modified:\` errors?
-			> _[Unexpected File Modifications](#unexpected-file-modifications)_ covers that below.
-
-			You can run the end-to-end test for migrating locally on the command-line:
-
-			\`\`\`shell
-			pnpm run test:migrate
-			\`\`\`
-
-			That end-to-end test executes \`script/migrate-test-e2e.ts\`, which:
-
-			1. Runs the migration script using \`--skip-github-api\` and other skip flags, capturing code coverage
-			2. Checks that only a small list of allowed files were changed
-			3. Checks that the local repository's files were changed correctly (e.g. removed initialization-only files)
-
-			The \`pnpm run test:migrate\` script is run in CI to ensure that templating changes are in sync with the template's actual files.
-			See \`.github/workflows/test-migrate.yml\`.
-
-			> Tip: if the migration test is failing in CI and you don't see any errors, try [downloading the full logs](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/using-workflow-run-logs#downloading-logs).
-
-			##### Migration Snapshot Failures
-
-			The migration test uses the [Vitest file snapshot](https://vitest.dev/guide/snapshot#file-snapshots) in \`script/__snapshots__/migrate-test-e2e.ts.snap\` to store expected differences to this repository after running the migration script.
-			The end-to-end migration test will fail any changes that don't keep the same differences in that snapshot.
-
-			You can update the snapshot file by:
-
-			1. Committing any changes to your local repository
-			2. Running \`pnpm i\` and \`pnpm build\` if any updates have been made to the \`package.json\` or \`src/\` files, respectively
-			3. Running \`pnpm run test:migrate -u\` to update the snapshot
-
-			At this point there will be some files changed:
-
-			- \`script/__snapshots__/migrate-test-e2e.ts.snap\` will have updates if any files mismatched templates
-			- The actual updated files on disk will be there too
-
-			If the snapshot file changes are what you expected, then you can commit them.
-			The rest of the file changes can be reverted.
-
-			> [🚀 Feature: Add a way to apply known file changes after migration #1184](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1184) tracks turning the test snapshot into a feature.
-
-			##### Unexpected File Modifications
-
-			The migration test also asserts that no files were unexpectedly changed.
-			If you see a failure like:
-
-			\`\`\`plaintext
-			Oh no! Running the migrate script unexpectedly modified:
-			 - ...
-			\`\`\`
-
-			...then that means the file generated from templates differs from what's checked into the repository.
-			This is most often caused by changes to templates not being applied to checked-in files too.
-
-			Templates for files are generally stored in [\`src/steps/writing/creation\`] under a path roughly corresponding to the file they describe.
-			For example, the template for \`tsup.config.ts\` is stored in [\`src/steps/writing/creation/createTsupConfig.ts\`](../src/steps/writing/creation/createTsupConfig.ts).
-			If the \`createTsupConfig\` function were to be modified without an equivalent change to \`tsup.config.ts\` -or vice-versa- then the migration test would report:
-
-			\`\`\`plaintext
-			Oh no! Running the migrate script unexpectedly modified:
-			 - tsup.config.ts
-			\`\`\`
-			",
-			  "ISSUE_TEMPLATE.md": "<!-- Note: Please must use one of our issue templates to file an issue! 🛑 -->
-			<!-- 👉 https://github.com/StubOwner/stub-repository/issues/new/choose 👈 -->
-			<!-- **Issues that should have been filed with a template will be closed without action, and we will ask you to use a template.** -->
-
-			<!-- This blank issue template is only for issues that don't fit any of the templates. -->
-
-			## Overview
-
-			...
-			",
-			  "PULL_REQUEST_TEMPLATE.md": "<!-- 👋 Hi, thanks for sending a PR to stub-repository! 💖.
-			Please fill out all fields below and make sure each item is true and [x] checked.
-			Otherwise we may not be able to review your PR. -->
-
-			## PR Checklist
-
-			- [ ] Addresses an existing open issue: fixes #000
-			- [ ] That issue was marked as [\`status: accepting prs\`](https://github.com/StubOwner/stub-repository/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-			- [ ] Steps in [CONTRIBUTING.md](https://github.com/StubOwner/stub-repository/blob/main/.github/CONTRIBUTING.md) were taken
-
-			## Overview
-
-			<!-- Description of what is changed and how the code change does that. -->
-			",
-			  "SECURITY.md": "# Security Policy
-
-			We take all security vulnerabilities seriously.
-			If you have a vulnerability or other security issues to disclose:
-
-			- Thank you very much, please do!
-			- Please send them to us by emailing \`github@email.com\`
-
-			We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
-			",
-			  "renovate.json": "{
-				"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-				"automerge": true,
-				"extends": ["config:best-practices", "replacements:all"],
-				"ignoreDeps": ["codecov/codecov-action"],
-				"internalChecksFilter": "strict",
-				"patch": { "enabled": false },
-				"labels": ["dependencies"],
-				"minimumReleaseAge": "3 days",
-				"postUpdateOptions": ["pnpmDedupe"]
-			}
-			",
-			}
-		`);
+				We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+				",
+				  "renovate.json": "{
+					"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+					"automerge": true,
+					"extends": ["config:best-practices", "replacements:all"],
+					"ignoreDeps": ["codecov/codecov-action"],
+					"internalChecksFilter": "strict",
+					"patch": { "enabled": false },
+					"labels": ["dependencies"],
+					"minimumReleaseAge": "3 days",
+					"postUpdateOptions": ["pnpmDedupe"]
+				}
+				",
+				}
+			`);
 	});
 });

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.test.ts
@@ -587,9 +587,9 @@ describe("createDotGitHubFiles", () => {
 					"automerge": true,
 					"extends": ["config:best-practices", "replacements:all"],
 					"ignoreDeps": ["codecov/codecov-action"],
-					"patch": { "enabled": false },
 					"labels": ["dependencies"],
 					"minimumReleaseAge": "3 days",
+					"patch": { "enabled": false },
 					"postUpdateOptions": ["pnpmDedupe"]
 				}
 				",

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -282,11 +282,11 @@ We appreciate your efforts and responsible disclosure and will make every effort
 				automerge: true,
 				extends: ["config:best-practices", "replacements:all"],
 				ignoreDeps: ["codecov/codecov-action"],
+				labels: ["dependencies"],
+				minimumReleaseAge: "3 days",
 				patch: {
 					enabled: false,
 				},
-				labels: ["dependencies"],
-				minimumReleaseAge: "3 days",
 				postUpdateOptions: ["pnpmDedupe"],
 			}),
 		}),

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -284,9 +284,7 @@ We appreciate your efforts and responsible disclosure and will make every effort
 				ignoreDeps: ["codecov/codecov-action"],
 				labels: ["dependencies"],
 				minimumReleaseAge: "3 days",
-				patch: {
-					enabled: false,
-				},
+				patch: { enabled: false },
 				postUpdateOptions: ["pnpmDedupe"],
 			}),
 		}),

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -282,7 +282,6 @@ We appreciate your efforts and responsible disclosure and will make every effort
 				automerge: true,
 				extends: ["config:best-practices", "replacements:all"],
 				ignoreDeps: ["codecov/codecov-action"],
-				internalChecksFilter: "strict",
 				patch: {
 					enabled: false,
 				},

--- a/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
+++ b/src/steps/writing/creation/dotGitHub/createDotGitHubFiles.ts
@@ -283,6 +283,9 @@ We appreciate your efforts and responsible disclosure and will make every effort
 				extends: ["config:best-practices", "replacements:all"],
 				ignoreDeps: ["codecov/codecov-action"],
 				internalChecksFilter: "strict",
+				patch: {
+					enabled: false,
+				},
 				labels: ["dependencies"],
 				minimumReleaseAge: "3 days",
 				postUpdateOptions: ["pnpmDedupe"],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1541
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes `"internalChecksFilter": "strict"` because that's the default value.

Adds some unit tests because `createDotGitHubFiles` wasn't unit tested before, too.

💖 