### PR TITLE
fix: preserve post-badge paragraph in README.md migration

### DIFF
--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -39,16 +39,6 @@ exports[`expected file changes > .prettierignore 1`] = `
 exports[`expected file changes > README.md 1`] = `
 "--- a/README.md
 +++ b/README.md
-@@ ... @@
- 
- <img align="right" alt="Project logo: the TypeScript blue square with rounded corners, but a plus sign instead of 'TS'" src="./docs/create-typescript-app.png">
- 
--\`create-typescript-app\` is a one-stop-shop solution to set up a new or existing repository with the latest and greatest TypeScript tooling.
--It includes options not just for building and testing but also GitHub repository templates, contributor recognition, automated release management, and more.
--
- ## Getting Started
- 
- First make sure you have the following installed:
 @@ ... @@ Thanks! 💖
  
  <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/src/steps/writeReadme/findIntroSectionClose.test.ts
+++ b/src/steps/writeReadme/findIntroSectionClose.test.ts
@@ -42,7 +42,24 @@ Next line.
 `,
 			14,
 		],
-	])("%s", (contents, expected) => {
+		[
+			`<h1 align="center">Title</h1>
+
+<p align="center">Description.</p>
+
+<p align="center">
+	(existing badges)
+</p>
+
+<img align="right" alt="Project logo: ..." src="./logo.png">
+
+First intro text.
+
+## Getting Started
+`,
+			173,
+		],
+	])("%o", (contents, expected) => {
 		expect(findIntroSectionClose(contents)).toEqual(expected);
 	});
 });

--- a/src/steps/writeReadme/findIntroSectionClose.ts
+++ b/src/steps/writeReadme/findIntroSectionClose.ts
@@ -2,9 +2,8 @@ import { existingBadgeMatcherCreators } from "./findExistingBadges.js";
 
 export function findIntroSectionClose(contents: string) {
 	// Highest priority: after an existing create-typescript-app-style logo
-	const projectLogoMatch = /<img align="right" alt=".+" src=".+">/.exec(
-		contents,
-	);
+	const projectLogoMatch =
+		/<img align="right" alt="Project logo.+" src=".+">/.exec(contents);
 	if (projectLogoMatch) {
 		return contents.indexOf("\n", projectLogoMatch.index) + 2;
 	}

--- a/src/steps/writeReadme/findIntroSectionClose.ts
+++ b/src/steps/writeReadme/findIntroSectionClose.ts
@@ -1,14 +1,22 @@
 import { existingBadgeMatcherCreators } from "./findExistingBadges.js";
 
 export function findIntroSectionClose(contents: string) {
-	// Highest priority match: an h2, presumably following badges
+	// Highest priority: after an existing create-typescript-app-style logo
+	const projectLogoMatch = /<img align="right" alt=".+" src=".+">/.exec(
+		contents,
+	);
+	if (projectLogoMatch) {
+		return contents.indexOf("\n", projectLogoMatch.index) + 2;
+	}
+
+	// Next: before a first code block or h2, presumably following badges
 	const indexOfH2OrCodeBlock = contents.search(/## |<\s*h2|```/);
 
 	if (indexOfH2OrCodeBlock !== -1) {
 		return indexOfH2OrCodeBlock - 2;
 	}
 
-	// Failing that, if any badges are found, go after the last of them
+	// Failing those, if any badges are found, go after the last of them
 	for (const createMatcher of existingBadgeMatcherCreators) {
 		const lastMatch = [...contents.matchAll(createMatcher())].at(-1);
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1159
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a special case for a README.md already having a CTA-style project logo image.

💖 
