### PR TITLE
fix: run pnpm dedupe --offline in cleanups

### DIFF
--- a/src/shared/createCleanupCommands.test.ts
+++ b/src/shared/createCleanupCommands.test.ts
@@ -19,7 +19,7 @@ describe("createCleanupCommands", () => {
 		});
 
 		expect(actual).toEqual([
-			"pnpm dedupe",
+			"pnpm dedupe --offline",
 			"pnpm build",
 			"pnpm lint --fix",
 			"pnpm format --write",

--- a/src/shared/createCleanupCommands.ts
+++ b/src/shared/createCleanupCommands.ts
@@ -6,7 +6,7 @@ export function createCleanupCommands({
 }: Pick<Options, "bin" | "mode">) {
 	return [
 		// There's no need to dedupe when initializing from the fixed template
-		...(mode === "initialize" ? [] : ["pnpm dedupe"]),
+		...(mode === "initialize" ? [] : ["pnpm dedupe --offline"]),
 		// n/no-missing-import rightfully reports on a missing the bin .js file
 		...(bin ? ["pnpm build"] : []),
 		"pnpm lint --fix",

--- a/src/steps/finalizeDependencies.test.ts
+++ b/src/steps/finalizeDependencies.test.ts
@@ -44,7 +44,7 @@ describe("finalize", () => {
 			    "npx all-contributors-cli generate",
 			  ],
 			  [
-			    "pnpm dedupe",
+			    "pnpm dedupe --offline",
 			  ],
 			]
 		`);
@@ -65,7 +65,7 @@ describe("finalize", () => {
 			    "npx all-contributors-cli generate",
 			  ],
 			  [
-			    "pnpm dedupe",
+			    "pnpm dedupe --offline",
 			  ],
 			]
 		`);
@@ -95,7 +95,7 @@ describe("finalize", () => {
 			    "pnpm add @eslint-community/eslint-plugin-eslint-comments@latest @eslint/js@latest @types/eslint-plugin-markdown@latest @types/eslint__js@latest @types/node@latest eslint@latest eslint-plugin-jsdoc@latest eslint-plugin-n@latest eslint-plugin-regexp@latest husky@latest lint-staged@latest prettier@latest prettier-plugin-curly@latest prettier-plugin-packagejson@latest prettier-plugin-sh@latest tsup@latest typescript@latest typescript-eslint@latest -D",
 			  ],
 			  [
-			    "pnpm dedupe",
+			    "pnpm dedupe --offline",
 			  ],
 			]
 		`);

--- a/src/steps/finalizeDependencies.ts
+++ b/src/steps/finalizeDependencies.ts
@@ -73,5 +73,5 @@ export async function finalizeDependencies(options: Options) {
 		);
 	}
 
-	await execaCommand(`pnpm dedupe`);
+	await execaCommand(`pnpm dedupe --offline`);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1610
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Doesn't impact `pnpm lint:packages`, just the migration/setup scripts.

💖 