### PR TITLE
fix: upgrade pnpm/action-setup to v4

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,7 +4,7 @@ name: Prepare
 
 runs:
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         version: 9
     - uses: actions/setup-node@v4

--- a/src/steps/writing/creation/dotGitHub/actions.test.ts
+++ b/src/steps/writing/creation/dotGitHub/actions.test.ts
@@ -14,7 +14,7 @@ name: Prepare
 
 runs:
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         version: 9
     - uses: actions/setup-node@v4

--- a/src/steps/writing/creation/dotGitHub/actions.ts
+++ b/src/steps/writing/creation/dotGitHub/actions.ts
@@ -10,7 +10,7 @@ export function createDotGitHubActions() {
 					runs: {
 						steps: [
 							{
-								uses: "pnpm/action-setup@v2",
+								uses: "pnpm/action-setup@v4",
 								with: { version: 9 },
 							},
 							{


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1619
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This PR upgrades the `pnpm/action-setup@v2` to `pnpm/action-setup@v4` which should resolve the warning.

From the looks of the releases page, 3 would work as well: https://github.com/pnpm/action-setup/releases