### PR TITLE
fix: should not include extensions for markdown when excluded

### DIFF
--- a/src/steps/writing/creation/dotVSCode.test.ts
+++ b/src/steps/writing/creation/dotVSCode.test.ts
@@ -56,13 +56,7 @@ describe("createDotVSCode", () => {
 		expect(await createDotVSCode(fakeOptions(() => true)))
 			.toMatchInlineSnapshot(`
 				{
-				  "extensions.json": "{
-					"recommendations": [
-						"DavidAnson.vscode-markdownlint",
-						"dbaeumer.vscode-eslint",
-						"esbenp.prettier-vscode"
-					]
-				}
+				  "extensions.json": "{ "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"] }
 				",
 				  "settings.json": "{
 					"editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
@@ -244,13 +238,7 @@ describe("createDotVSCode", () => {
 		expect(await createDotVSCode(fakeOptions(() => true, "bin/index.js")))
 			.toMatchInlineSnapshot(`
 				{
-				  "extensions.json": "{
-					"recommendations": [
-						"DavidAnson.vscode-markdownlint",
-						"dbaeumer.vscode-eslint",
-						"esbenp.prettier-vscode"
-					]
-				}
+				  "extensions.json": "{ "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"] }
 				",
 				  "launch.json": "{
 					"configurations": [

--- a/src/steps/writing/creation/dotVSCode.ts
+++ b/src/steps/writing/creation/dotVSCode.ts
@@ -6,7 +6,7 @@ export async function createDotVSCode(options: Options) {
 	return {
 		"extensions.json": await formatJson({
 			recommendations: [
-				"DavidAnson.vscode-markdownlint",
+				!options.excludeLintMd && "DavidAnson.vscode-markdownlint",
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
 				!options.excludeLintSpelling && "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1622
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR excludes the extension for linting Markdown if the option specifies excluding that.