### PR TITLE
feat: include vitest.explorer VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"DavidAnson.vscode-markdownlint",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
-		"streetsidesoftware.code-spell-checker"
+		"streetsidesoftware.code-spell-checker",
+		"vitest.explorer"
 	]
 }

--- a/src/steps/writing/creation/dotVSCode.test.ts
+++ b/src/steps/writing/creation/dotVSCode.test.ts
@@ -103,7 +103,8 @@ describe("createDotVSCode", () => {
 						"DavidAnson.vscode-markdownlint",
 						"dbaeumer.vscode-eslint",
 						"esbenp.prettier-vscode",
-						"streetsidesoftware.code-spell-checker"
+						"streetsidesoftware.code-spell-checker",
+						"vitest.explorer"
 					]
 				}
 				",
@@ -177,7 +178,8 @@ describe("createDotVSCode", () => {
 						"DavidAnson.vscode-markdownlint",
 						"dbaeumer.vscode-eslint",
 						"esbenp.prettier-vscode",
-						"streetsidesoftware.code-spell-checker"
+						"streetsidesoftware.code-spell-checker",
+						"vitest.explorer"
 					]
 				}
 				",

--- a/src/steps/writing/creation/dotVSCode.ts
+++ b/src/steps/writing/creation/dotVSCode.ts
@@ -10,6 +10,7 @@ export async function createDotVSCode(options: Options) {
 				"dbaeumer.vscode-eslint",
 				"esbenp.prettier-vscode",
 				!options.excludeLintSpelling && "streetsidesoftware.code-spell-checker",
+				!options.excludeTests && "vitest.explorer",
 			].filter(Boolean),
 		}),
 		...(options.excludeTests && !options.bin


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1628
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR adds the Vitest Explorer extension