### PR TITLE
fix: remove unnecessary devDependencies for --base common

### DIFF
--- a/src/steps/finalizeDependencies.test.ts
+++ b/src/steps/finalizeDependencies.test.ts
@@ -92,7 +92,7 @@ describe("finalize", () => {
 		expect(mockExecaCommand.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
-			    "pnpm add @eslint-community/eslint-plugin-eslint-comments@latest @eslint/js@latest @types/eslint-plugin-markdown@latest @types/eslint__js@latest @types/node@latest eslint@latest eslint-plugin-jsdoc@latest eslint-plugin-n@latest eslint-plugin-regexp@latest husky@latest lint-staged@latest prettier@latest prettier-plugin-curly@latest prettier-plugin-packagejson@latest prettier-plugin-sh@latest tsup@latest typescript@latest typescript-eslint@latest -D",
+			    "pnpm add @eslint-community/eslint-plugin-eslint-comments@latest @eslint/js@latest @types/eslint__js@latest @types/node@latest eslint@latest eslint-plugin-jsdoc@latest eslint-plugin-n@latest eslint-plugin-regexp@latest husky@latest lint-staged@latest prettier@latest prettier-plugin-curly@latest prettier-plugin-packagejson@latest prettier-plugin-sh@latest tsup@latest typescript@latest typescript-eslint@latest -D",
 			  ],
 			  [
 			    "pnpm dedupe --offline",

--- a/src/steps/finalizeDependencies.ts
+++ b/src/steps/finalizeDependencies.ts
@@ -6,14 +6,10 @@ import { Options } from "../shared/types.js";
 export async function finalizeDependencies(options: Options) {
 	const devDependencies = [
 		"@eslint/js",
-		"@eslint-community/eslint-plugin-eslint-comments",
-		"@types/eslint-plugin-markdown",
 		"@types/eslint__js",
 		"@types/node",
 		"eslint",
-		"eslint-plugin-jsdoc",
 		"eslint-plugin-n",
-		"eslint-plugin-regexp",
 		"husky",
 		"lint-staged",
 		"prettier",
@@ -24,6 +20,10 @@ export async function finalizeDependencies(options: Options) {
 		"typescript",
 		"typescript-eslint",
 		...(options.excludeAllContributors ? [] : ["all-contributors-cli"]),
+		...(options.excludeLintESLint
+			? []
+			: ["@eslint-community/eslint-plugin-eslint-comments"]),
+		...(options.excludeLintJSDoc ? [] : ["eslint-plugin-jsdoc"]),
 		...(options.excludeLintJson ? [] : ["eslint-plugin-jsonc"]),
 		...(options.excludeLintJson && options.excludeLintPackageJson
 			? []
@@ -32,6 +32,7 @@ export async function finalizeDependencies(options: Options) {
 		...(options.excludeLintMd
 			? []
 			: [
+					"@types/eslint-plugin-markdown",
 					"eslint-plugin-markdown",
 					"markdownlint",
 					"markdownlint-cli",
@@ -41,6 +42,7 @@ export async function finalizeDependencies(options: Options) {
 		...(options.excludeLintPerfectionist
 			? []
 			: ["eslint-plugin-perfectionist"]),
+		...(options.excludeLintRegex ? [] : ["eslint-plugin-regexp"]),
 		...(options.excludeLintSpelling ? [] : ["cspell"]),
 		...(options.excludeLintYml ? [] : ["eslint-plugin-yml"]),
 		...(options.excludeReleases


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1635
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds `options.*` checking in `finalizeDependencies`, to better restrict what gets installed.

💖 