### PR TITLE
fix: simplify post-release.yml with release_tag instead of npm pkg get

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -5,7 +5,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"
       - uses: apexskier/github-release-commenter@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -15,7 +14,7 @@ jobs:
             The release is available on:
 
             * [GitHub releases](https://github.com/JoshuaKGoldberg/create-typescript-app/releases/tag/{release_tag})
-            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/create-typescript-app/v/${{ env.npm_version }})
+            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/create-typescript-app/v/{release_tag})
 
             Cheers! 📦🚀
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -197,7 +197,6 @@ describe("createWorkflows", () => {
 			      - uses: actions/checkout@v4
 			        with:
 			          fetch-depth: 0
-			      - run: echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"
 			      - uses: apexskier/github-release-commenter@v1
 			        with:
 			          GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
@@ -207,7 +206,7 @@ describe("createWorkflows", () => {
 			              The release is available on:
 
 			              * [GitHub releases](https://github.com/StubOwner/stub-repository/releases/tag/{release_tag})
-			              * [npm package (@latest dist-tag)](https://www.npmjs.com/package/stub-repository/v/\${{ env.npm_version }})
+			              * [npm package (@latest dist-tag)](https://www.npmjs.com/package/stub-repository/v/{release_tag})
 
 			              Cheers! 📦🚀
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -156,9 +156,6 @@ export function createWorkflows(options: Options) {
 				steps: [
 					{ uses: "actions/checkout@v4", with: { "fetch-depth": 0 } },
 					{
-						run: `echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"`,
-					},
-					{
 						uses: "apexskier/github-release-commenter@v1",
 						with: {
 							"comment-template": `
@@ -167,7 +164,7 @@ export function createWorkflows(options: Options) {
 							The release is available on:
 
 							* [GitHub releases](https://github.com/${options.owner}/${options.repository}/releases/tag/{release_tag})
-							* [npm package (@latest dist-tag)](https://www.npmjs.com/package/${options.repository}/v/\${{ env.npm_version }})
+							* [npm package (@latest dist-tag)](https://www.npmjs.com/package/${options.repository}/v/{release_tag})
 
 							Cheers! 📦🚀
 						`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1115
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the same `{release_tag}` as the _GitHub releases_ link.

💖 