### PR TITLE
fix: use payload.release.tag_name for npm package release

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -14,7 +14,7 @@ jobs:
             The release is available on:
 
             * [GitHub releases](https://github.com/JoshuaKGoldberg/create-typescript-app/releases/tag/{release_tag})
-            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/create-typescript-app/v/{release_tag})
+            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/create-typescript-app/v/{${{ payload.release.tag_name }}})
 
             Cheers! 📦🚀
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.test.ts
@@ -206,7 +206,7 @@ describe("createWorkflows", () => {
 			              The release is available on:
 
 			              * [GitHub releases](https://github.com/StubOwner/stub-repository/releases/tag/{release_tag})
-			              * [npm package (@latest dist-tag)](https://www.npmjs.com/package/stub-repository/v/{release_tag})
+			              * [npm package (@latest dist-tag)](https://www.npmjs.com/package/stub-repository/v/{\${{ payload.release.tag_name }}})
 
 			              Cheers! 📦🚀
 

--- a/src/steps/writing/creation/dotGitHub/createWorkflows.ts
+++ b/src/steps/writing/creation/dotGitHub/createWorkflows.ts
@@ -164,7 +164,7 @@ export function createWorkflows(options: Options) {
 							The release is available on:
 
 							* [GitHub releases](https://github.com/${options.owner}/${options.repository}/releases/tag/{release_tag})
-							* [npm package (@latest dist-tag)](https://www.npmjs.com/package/${options.repository}/v/{release_tag})
+							* [npm package (@latest dist-tag)](https://www.npmjs.com/package/${options.repository}/v/{\${{ payload.release.tag_name }}})
 
 							Cheers! 📦🚀
 						`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1115
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `${{ payload.release.tag_name }}` this time, as suggested.

💖 