### PR TITLE
fix: remove outdated vscode-eslint eslint.useFlatConfig setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,5 @@
 		"yaml"
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"eslint.useFlatConfig": true,
 	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/src/steps/writing/creation/dotVSCode.test.ts
+++ b/src/steps/writing/creation/dotVSCode.test.ts
@@ -74,7 +74,6 @@ describe("createDotVSCode", () => {
 						"yaml"
 					],
 					"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-					"eslint.useFlatConfig": true,
 					"typescript.tsdk": "node_modules/typescript/lib"
 				}
 				",
@@ -149,7 +148,6 @@ describe("createDotVSCode", () => {
 						"yaml"
 					],
 					"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-					"eslint.useFlatConfig": true,
 					"typescript.tsdk": "node_modules/typescript/lib"
 				}
 				",
@@ -216,7 +214,6 @@ describe("createDotVSCode", () => {
 						"yaml"
 					],
 					"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-					"eslint.useFlatConfig": true,
 					"typescript.tsdk": "node_modules/typescript/lib"
 				}
 				",
@@ -272,7 +269,6 @@ describe("createDotVSCode", () => {
 						"yaml"
 					],
 					"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-					"eslint.useFlatConfig": true,
 					"typescript.tsdk": "node_modules/typescript/lib"
 				}
 				",

--- a/src/steps/writing/creation/dotVSCode.ts
+++ b/src/steps/writing/creation/dotVSCode.ts
@@ -68,7 +68,6 @@ export async function createDotVSCode(options: Options) {
 				"yaml",
 			],
 			"eslint.rules.customizations": [{ rule: "*", severity: "warn" }],
-			"eslint.useFlatConfig": true,
 			"typescript.tsdk": "node_modules/typescript/lib",
 		}),
 		"tasks.json": await formatJson({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1692
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

💖 
