### PR TITLE
fix: use root-level slashes in .gitignore and .prettierignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-coverage*/
-lib/
-node_modules/
+/coverage
+/lib
+/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/coverage
+/coverage*
 /lib
 /node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
-.all-contributorsrc
-.husky/
-coverage*/
-lib/
-pnpm-lock.yaml
+/.all-contributorsrc
+/.husky
+/coverage*
+/lib
+/pnpm-lock.yaml

--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -31,22 +31,22 @@ exports[`expected file changes > .gitignore 1`] = `
 "--- a/.gitignore
 +++ b/.gitignore
 @@ ... @@
--coverage*/
-+coverage/
- lib/
- node_modules/"
+-/coverage*
++/coverage
+ /lib
+ /node_modules"
 `;
 
 exports[`expected file changes > .prettierignore 1`] = `
 "--- a/.prettierignore
 +++ b/.prettierignore
 @@ ... @@
- .all-contributorsrc
- .husky/
--coverage*/
-+coverage/
- lib/
- pnpm-lock.yaml"
+ /.all-contributorsrc
+ /.husky
+-/coverage*
++/coverage
+ /lib
+ /pnpm-lock.yaml"
 `;
 
 exports[`expected file changes > README.md 1`] = `

--- a/src/steps/writing/creation/createDotGitignore.test.ts
+++ b/src/steps/writing/creation/createDotGitignore.test.ts
@@ -7,9 +7,9 @@ describe("createDotGitignore", () => {
 		const actual = createDotGitignore({ excludeTests: false });
 
 		expect(actual).toMatchInlineSnapshot(`
-			"coverage/
-			lib/
-			node_modules/
+			"/coverage
+			/lib
+			/node_modules
 			"
 		`);
 	});
@@ -18,8 +18,8 @@ describe("createDotGitignore", () => {
 		const actual = createDotGitignore({ excludeTests: true });
 
 		expect(actual).toMatchInlineSnapshot(`
-			"lib/
-			node_modules/
+			"/lib
+			/node_modules
 			"
 		`);
 	});

--- a/src/steps/writing/creation/createDotGitignore.ts
+++ b/src/steps/writing/creation/createDotGitignore.ts
@@ -3,8 +3,8 @@ import { formatIgnoreFile } from "./formatters/formatIgnoreFile.js";
 
 export function createDotGitignore(options: Pick<Options, "excludeTests">) {
 	return formatIgnoreFile([
-		...(options.excludeTests ? [] : ["coverage/"]),
-		"lib/",
-		"node_modules/",
+		...(options.excludeTests ? [] : ["/coverage"]),
+		"/lib",
+		"/node_modules",
 	]);
 }

--- a/src/steps/writing/creation/rootFiles.ts
+++ b/src/steps/writing/creation/rootFiles.ts
@@ -27,11 +27,11 @@ export async function createRootFiles(options: Options) {
 		}),
 		".nvmrc": `20.12.2\n`,
 		".prettierignore": formatIgnoreFile([
-			...(options.excludeAllContributors ? [] : [".all-contributorsrc"]),
-			".husky/",
-			...(options.excludeTests ? [] : ["coverage/"]),
-			"lib/",
-			"pnpm-lock.yaml",
+			...(options.excludeAllContributors ? [] : ["/.all-contributorsrc"]),
+			"/.husky",
+			...(options.excludeTests ? [] : ["/coverage"]),
+			"/lib",
+			"/pnpm-lock.yaml",
 		]),
 		".prettierrc.json": await formatJson({
 			$schema: "http://json.schemastore.org/prettierrc",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1693
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per https://git-scm.com/docs/gitignore#_pattern_format, uses preceding `/` slashes to indicate directories and files that should only be matched at the root. Which is all of them.

The Git docs also noted that a trailing `/` makes the pattern only match directories. Since these are known directory names that won't be swapped with files accidentally, I took out any trailing `/`s to keep the files as small as possible.

Aside: Per https://lore.kernel.org/git/pull.1720.git.git.1715705582609.gitgitgadget@gmail.com, I'm pretty sure the Git docs have a small typo. But per https://lore.kernel.org/git/xmqqseyk2hce.fsf@gitster.g I don't know that it'll get resolved soon.

💖 