### PR TITLE
feat: remove now-unnecessary disable of jsdoc/lines-before-block

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,9 +64,6 @@ export default tseslint.config(
 			},
 		},
 		rules: {
-			// These on-by-default rules don't work well for this repo and we like them off.
-			"jsdoc/lines-before-block": "off",
-
 			// These on-by-default rules work well for this repo if configured
 			"@typescript-eslint/no-unnecessary-condition": [
 				"error",

--- a/src/steps/writing/creation/createESLintConfig.test.ts
+++ b/src/steps/writing/creation/createESLintConfig.test.ts
@@ -148,9 +148,6 @@ describe("createESLintConfig", () => {
 				      },
 				    },
 				    rules: {
-				      // These on-by-default rules don't work well for this repo and we like them off.
-				      "jsdoc/lines-before-block": "off",
-
 				      // Stylistic concerns that don't interfere with Prettier
 				      "logical-assignment-operators": [
 				        "error",

--- a/src/steps/writing/creation/createESLintConfig.ts
+++ b/src/steps/writing/creation/createESLintConfig.ts
@@ -42,19 +42,9 @@ export async function createESLintConfig(options: Options) {
 		!options.excludeLintRegex && `	regexp.configs["flat/recommended"],`,
 	].filter(Boolean);
 
-	const rules = `{
-			${
-				options.excludeLintJSDoc
-					? ""
-					: `
-
-			// These on-by-default rules don't work well for this repo and we like them off.
-			"jsdoc/lines-before-block": "off",`
-			}${
-				options.excludeLintStylistic
-					? ""
-					: `
-
+	const rules =
+		!options.excludeLintStylistic &&
+		`{
 			// Stylistic concerns that don't interfere with Prettier
 			"logical-assignment-operators": [
 				"error",
@@ -63,8 +53,7 @@ export async function createESLintConfig(options: Options) {
 			],
 			"no-useless-rename": "error",
 			"object-shorthand": "error",
-			"operator-assignment": "error",`
-			}
+			"operator-assignment": "error",
 		}`;
 
 	return await formatTypeScript(`${imports.join("\n")}
@@ -111,10 +100,10 @@ export default tseslint.config(
 				tsconfigRootDir: import.meta.dirname
 			},
 		},${
-			rules.replaceAll(/\s+/g, "") === "{}"
-				? ""
-				: `
+			rules
+				? `
 		rules: ${rules},`
+				: ""
 		}${
 			options.excludeLintPerfectionist
 				? ""


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1698
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

🔪 