### PR TITLE
docs: correct pre(-)commit typo

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -27,7 +27,6 @@
 		"npmpackagejsonlintrc",
 		"outro",
 		"packagejson",
-		"precommit",
 		"tada",
 		"tseslint",
 		"tsup",

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -88,7 +88,7 @@ Here we'll outline the steps required to migrate a CTA app to a GitHub Action:
    +dist
    ```
 
-   - Rather than having to remember to compile each time, we'll update our precommit hook in `.husky/precommit` to build for us on each commit:
+   - Rather than having to remember to compile each time, we'll update our pre-commit hook in `.husky/pre-commit` to build for us on each commit:
 
    ```diff
    +pnpm run build

--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -96,7 +96,6 @@ exports[`expected file changes > cspell.json 1`] = `
  		"npmpackagejsonlintrc",
  		"outro",
  		"packagejson",
--		"precommit",
  		"tada",
  		"tseslint",
  		"tsup",

--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -93,7 +93,9 @@ exports[`expected file changes > cspell.json 1`] = `
  		"markdownlintignore",
  		"mtfoley",
  		"npmignore",
-@@ ... @@
+-		"npmpackagejsonlintrc",
+ 		"outro",
+-		"packagejson",
  		"tada",
  		"tseslint",
  		"tsup",

--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -93,9 +93,7 @@ exports[`expected file changes > cspell.json 1`] = `
  		"markdownlintignore",
  		"mtfoley",
  		"npmignore",
- 		"npmpackagejsonlintrc",
- 		"outro",
- 		"packagejson",
+@@ ... @@
  		"tada",
  		"tseslint",
  		"tsup",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1713
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes `precommit` from `cspell.json`, hooray.

💖 