### PR TITLE
chore: use codecov token for CI test runs internally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
       - run: pnpm run test --coverage
-      - if: always()
+      - env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: always()
         uses: codecov/codecov-action@v3
         with:
           flags: unit
@@ -77,7 +79,9 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build
       - run: pnpm run test:create
-      - if: always()
+      - env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: always()
         uses: codecov/codecov-action@v3
         with:
           files: coverage-create/lcov.info
@@ -90,7 +94,9 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build
       - run: pnpm run test:initialize
-      - if: always()
+      - env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: always()
         uses: codecov/codecov-action@v3
         with:
           files: coverage-initialize/lcov.info
@@ -103,7 +109,9 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm run build
       - run: pnpm run test:migrate
-      - if: always()
+      - env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: always()
         uses: codecov/codecov-action@v3
         with:
           files: coverage-migrate/lcov.info

--- a/script/__snapshots__/migrate-test-e2e.ts.snap
+++ b/script/__snapshots__/migrate-test-e2e.ts.snap
@@ -30,9 +30,13 @@ exports[`expected file changes > .github/workflows/ci.yml 1`] = `
      name: Build
      runs-on: ubuntu-latest
 @@ ... @@ jobs:
+       - uses: actions/checkout@v4
+       - uses: ./.github/actions/prepare
        - run: pnpm run test --coverage
-       - if: always()
-         uses: codecov/codecov-action@v3
+-      - env:
+-          CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
+-        if: always()
+-        uses: codecov/codecov-action@v3
 -        with:
 -          flags: unit
 -  test_creation_script:
@@ -43,7 +47,9 @@ exports[`expected file changes > .github/workflows/ci.yml 1`] = `
 -      - uses: ./.github/actions/prepare
 -      - run: pnpm run build
 -      - run: pnpm run test:create
--      - if: always()
+-      - env:
+-          CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
+-        if: always()
 -        uses: codecov/codecov-action@v3
 -        with:
 -          files: coverage-create/lcov.info
@@ -56,7 +62,9 @@ exports[`expected file changes > .github/workflows/ci.yml 1`] = `
 -      - uses: ./.github/actions/prepare
 -      - run: pnpm run build
 -      - run: pnpm run test:initialize
--      - if: always()
+-      - env:
+-          CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
+-        if: always()
 -        uses: codecov/codecov-action@v3
 -        with:
 -          files: coverage-initialize/lcov.info
@@ -69,8 +77,11 @@ exports[`expected file changes > .github/workflows/ci.yml 1`] = `
 -      - uses: ./.github/actions/prepare
 -      - run: pnpm run build
 -      - run: pnpm run test:migrate
--      - if: always()
--        uses: codecov/codecov-action@v3
+-      - env:
+-          CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}
+-        if: always()
++      - if: always()
+         uses: codecov/codecov-action@v3
 -        with:
 -          files: coverage-migrate/lcov.info
 -          flags: migrate


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1756
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the `env:` addition internally.

Doesn't add it to created repos, because I think most consumers aren't going to be hitting the Codecov 429 rate limits very often. I don't want them to have to add a _third_ new token to their repos.

💖 