### PR TITLE
chore: correct missing release-it dependencies for blockReleaseIt

### DIFF
--- a/src/next/blocks/blockReleaseIt.ts
+++ b/src/next/blocks/blockReleaseIt.ts
@@ -2,6 +2,7 @@ import { createSoloWorkflowFile } from "../../steps/writing/creation/dotGitHub/c
 import { base } from "../base.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockPackageJson } from "./blockPackageJson.js";
+import { getPackageDependencies } from "./packageData.js";
 
 export const blockReleaseIt = base.createBlock({
 	about: {
@@ -15,6 +16,10 @@ export const blockReleaseIt = base.createBlock({
 				}),
 				blockPackageJson({
 					properties: {
+						devDependencies: getPackageDependencies(
+							"@release-it/conventional-changelog",
+							"release-it",
+						),
 						publishConfig: {
 							provenance: true,
 						},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1769
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Marking as a `chore:` because this only impacts when opting into the new `create` engine with the undocumented `CTA_CREATE_ENGINE` flag.

💖