### PR TITLE
fix: bypass repository admin (id 5) in branch ruleset

### DIFF
--- a/src/next/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/next/blocks/blockRepositoryBranchRuleset.ts
@@ -16,6 +16,15 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 					id: "branch-ruleset",
 					async send({ octokit }) {
 						await octokit.request("POST /repos/{owner}/{repo}/rulesets", {
+							bypass_actors: [
+								{
+									// This *seems* to be the Repository Admin role always?
+									// https://github.com/github/rest-api-description/issues/4406
+									actor_id: 5,
+									actor_type: "RepositoryRole",
+									bypass_mode: "always",
+								},
+							],
 							conditions: {
 								ref_name: {
 									exclude: [],

--- a/src/steps/initializeBranchProtectionSettings.test.ts
+++ b/src/steps/initializeBranchProtectionSettings.test.ts
@@ -39,6 +39,13 @@ describe("migrateBranchProtectionSettings", () => {
 			  [
 			    "POST /repos/{owner}/{repo}/rulesets",
 			    {
+			      "bypass_actors": [
+			        {
+			          "actor_id": 5,
+			          "actor_type": "RepositoryRole",
+			          "bypass_mode": "always",
+			        },
+			      ],
 			      "conditions": {
 			        "ref_name": {
 			          "exclude": [],
@@ -152,6 +159,13 @@ describe("migrateBranchProtectionSettings", () => {
 			  [
 			    "POST /repos/{owner}/{repo}/rulesets",
 			    {
+			      "bypass_actors": [
+			        {
+			          "actor_id": 5,
+			          "actor_type": "RepositoryRole",
+			          "bypass_mode": "always",
+			        },
+			      ],
 			      "conditions": {
 			        "ref_name": {
 			          "exclude": [],

--- a/src/steps/initializeGitHubRepository/initializeBranchProtectionSettings.ts
+++ b/src/steps/initializeGitHubRepository/initializeBranchProtectionSettings.ts
@@ -9,6 +9,15 @@ export async function initializeBranchProtectionSettings(
 ) {
 	try {
 		await octokit.request("POST /repos/{owner}/{repo}/rulesets", {
+			bypass_actors: [
+				{
+					// This *seems* to be the Repository Admin role always?
+					// https://github.com/github/rest-api-description/issues/4406
+					actor_id: 5,
+					actor_type: "RepositoryRole",
+					bypass_mode: "always",
+				},
+			],
 			conditions: {
 				ref_name: {
 					exclude: [],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1790
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Pending being told contrary information, hardcodes `actor_id: 5` for the repository role to always be allowed to bypass branch protection ruleset. 

💖 