### PR TITLE
chore: add remaining block migrations to migrate/update old repos

### DIFF
--- a/src/next/blocks/blockESLint.test.ts
+++ b/src/next/blocks/blockESLint.test.ts
@@ -259,7 +259,7 @@ describe("blockESLint", () => {
 			    },
 			    {
 			      "commands": [
-			        "rm .eslintrc* .eslintignore",
+			        "rm .eslintrc* .eslintignore eslint.config.*",
 			      ],
 			      "phase": 0,
 			    },

--- a/src/next/blocks/blockESLint.ts
+++ b/src/next/blocks/blockESLint.ts
@@ -67,7 +67,7 @@ export const blockESLint = base.createBlock({
 		return {
 			scripts: [
 				{
-					commands: ["rm .eslintrc* .eslintignore"],
+					commands: ["rm .eslintrc* .eslintignore eslint.config.*"],
 					phase: CommandPhase.Migrations,
 				},
 			],

--- a/src/next/blocks/blockKnip.ts
+++ b/src/next/blocks/blockKnip.ts
@@ -3,10 +3,21 @@ import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { getPackageDependencies, getPackageDependency } from "./packageData.js";
+import { CommandPhase } from "./phases.js";
 
 export const blockKnip = base.createBlock({
 	about: {
 		name: "Knip",
+	},
+	migrate() {
+		return {
+			scripts: [
+				{
+					commands: ["rm .knip* knip.*"],
+					phase: CommandPhase.Migrations,
+				},
+			],
+		};
 	},
 	produce() {
 		return {

--- a/src/next/blocks/blockVitest.test.ts
+++ b/src/next/blocks/blockVitest.test.ts
@@ -499,7 +499,7 @@ describe("blockVitest", () => {
 			  "scripts": [
 			    {
 			      "commands": [
-			        "rm .github/codecov.yml .mocha* codecov.yml jest.config.*",
+			        "rm .github/codecov.yml .mocha* codecov.yml jest.config.* vitest.config.*",
 			      ],
 			      "phase": 0,
 			    },

--- a/src/next/blocks/blockVitest.ts
+++ b/src/next/blocks/blockVitest.ts
@@ -37,7 +37,7 @@ export const blockVitest = base.createBlock({
 			scripts: [
 				{
 					commands: [
-						"rm .github/codecov.yml .mocha* codecov.yml jest.config.*",
+						"rm .github/codecov.yml .mocha* codecov.yml jest.config.* vitest.config.*",
 					],
 					phase: CommandPhase.Migrations,
 				},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1753
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per https://github.com/JoshuaKGoldberg/create/issues/24, uses the existing `migrate()` functionality to let Blocks define how to update from older versions or older tooling.

I've probably missed some config files that folks will discover in the wild. But this more than covers all my personal repos' migrations.

💖 