### PR TITLE
chore: use formatIgnoreFile in remaining blocks

### DIFF
--- a/src/next/blocks/blockMarkdownlint.test.ts
+++ b/src/next/blocks/blockMarkdownlint.test.ts
@@ -78,7 +78,8 @@ describe("blockMarkdownlint", () => {
 			    ".markdownlint.json": "{"extends":"markdownlint/style/prettier","first-line-h1":false,"no-inline-html":false}",
 			    ".markdownlintignore": ".github/CODE_OF_CONDUCT.md
 			CHANGELOG.md
-			node_modules/",
+			node_modules/
+			",
 			  },
 			  "scripts": [
 			    {
@@ -169,7 +170,8 @@ describe("blockMarkdownlint", () => {
 			    ".markdownlintignore": ".github/CODE_OF_CONDUCT.md
 			CHANGELOG.md
 			lib/
-			node_modules/",
+			node_modules/
+			",
 			  },
 			  "scripts": [
 			    {

--- a/src/next/blocks/blockMarkdownlint.ts
+++ b/src/next/blocks/blockMarkdownlint.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { formatIgnoreFile } from "../../steps/writing/creation/formatters/formatIgnoreFile.js";
 import { base } from "../base.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
@@ -66,14 +67,14 @@ export const blockMarkdownlint = base.createBlock({
 					"first-line-h1": false,
 					"no-inline-html": false,
 				}),
-				".markdownlintignore": [
-					".github/CODE_OF_CONDUCT.md",
-					"CHANGELOG.md",
-					"node_modules/",
-					...ignores,
-				]
-					.sort()
-					.join("\n"),
+				".markdownlintignore": formatIgnoreFile(
+					[
+						".github/CODE_OF_CONDUCT.md",
+						"CHANGELOG.md",
+						"node_modules/",
+						...ignores,
+					].sort(),
+				),
 			},
 			scripts: [
 				{

--- a/src/next/blocks/blockPrettier.test.ts
+++ b/src/next/blocks/blockPrettier.test.ts
@@ -100,7 +100,8 @@ describe("blockPrettier", () => {
 			    },
 			    ".prettierignore": "/.husky
 			/lib
-			/pnpm-lock.yaml",
+			/pnpm-lock.yaml
+			",
 			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","useTabs":true}",
 			  },
 			  "scripts": [
@@ -211,7 +212,8 @@ describe("blockPrettier", () => {
 			    },
 			    ".prettierignore": "/.husky
 			/lib
-			/pnpm-lock.yaml",
+			/pnpm-lock.yaml
+			",
 			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","useTabs":true}",
 			  },
 			  "scripts": [
@@ -340,7 +342,8 @@ describe("blockPrettier", () => {
 			    ".prettierignore": "/.husky
 			/lib
 			/pnpm-lock.yaml
-			generated",
+			generated
+			",
 			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","overrides":[{"files":".nvmrc","options":{"parser":"yaml"}}],"plugins":["prettier-plugin-curly","prettier-plugin-packagejson","prettier-plugin-sh"],"useTabs":true}",
 			  },
 			  "scripts": [

--- a/src/next/blocks/blockPrettier.ts
+++ b/src/next/blocks/blockPrettier.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { formatIgnoreFile } from "../../steps/writing/creation/formatters/formatIgnoreFile.js";
 import { base } from "../base.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
@@ -96,9 +97,9 @@ pnpm format --write
 					".gitignore": "_\n",
 					"pre-commit": ["npx lint-staged\n", { mode: 0x777 }],
 				},
-				".prettierignore": ["/.husky", "/lib", "/pnpm-lock.yaml", ...ignores]
-					.sort()
-					.join("\n"),
+				".prettierignore": formatIgnoreFile(
+					["/.husky", "/lib", "/pnpm-lock.yaml", ...ignores].sort(),
+				),
 				".prettierrc.json": JSON.stringify({
 					$schema: "http://json.schemastore.org/prettierrc",
 					...(overrides.length && { overrides: overrides.sort() }),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1853
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Resists the urge to move the common `.sort()` inside the function, since not every consumer does that.

💖 