### PR TITLE
fix: pass job names from blockGitHubActionCI to blockRepositoryBranchRuleset

### DIFF
--- a/src/next/blocks/blockGitHubActionsCI.test.ts
+++ b/src/next/blocks/blockGitHubActionsCI.test.ts
@@ -12,6 +12,14 @@ describe("blockGitHubActionsCI", () => {
 
 		expect(creation).toMatchInlineSnapshot(`
 			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "requiredStatusChecks": undefined,
+			      },
+			      "block": [Function],
+			    },
+			  ],
 			  "files": {
 			    ".github": {
 			      "actions": {
@@ -101,6 +109,14 @@ describe("blockGitHubActionsCI", () => {
 
 		expect(creation).toMatchInlineSnapshot(`
 			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "requiredStatusChecks": undefined,
+			      },
+			      "block": [Function],
+			    },
+			  ],
 			  "files": {
 			    ".github": {
 			      "actions": {
@@ -213,6 +229,16 @@ describe("blockGitHubActionsCI", () => {
 
 		expect(creation).toMatchInlineSnapshot(`
 			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "requiredStatusChecks": [
+			          "Validate",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			  ],
 			  "files": {
 			    ".github": {
 			      "actions": {

--- a/src/next/blocks/blockGitHubActionsCI.ts
+++ b/src/next/blocks/blockGitHubActionsCI.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { createMultiWorkflowFile } from "../../steps/writing/creation/dotGitHub/createMultiWorkflowFile.js";
 import { createSoloWorkflowFile } from "../../steps/writing/creation/dotGitHub/createSoloWorkflowFile.js";
 import { base } from "../base.js";
+import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { CommandPhase } from "./phases.js";
 
 export const zActionStep = z.intersection(
@@ -33,7 +34,6 @@ export const blockGitHubActionsCI = base.createBlock({
 		return {
 			scripts: [
 				{
-					silent: true,
 					commands: ["rm -rf .circleci travis.yml"],
 					phase: CommandPhase.Migrations,
 					silent: true,
@@ -45,6 +45,11 @@ export const blockGitHubActionsCI = base.createBlock({
 		const { jobs } = addons;
 
 		return {
+			addons: [
+				blockRepositoryBranchRuleset({
+					requiredStatusChecks: jobs?.map((job) => job.name),
+				}),
+			],
 			files: {
 				".github": {
 					actions: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1887
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

💖 
