### PR TITLE
fix: don't include chore PRs in GH release page

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -3,11 +3,7 @@
 		"commitMessage": "chore: release v${version}",
 		"requireCommits": true
 	},
-	"github": {
-		"autoGenerate": true,
-		"release": true,
-		"releaseName": "v${version}"
-	},
+	"github": { "release": true, "releaseName": "v${version}" },
 	"npm": { "publishArgs": ["--access public", "--provenance"] },
 	"plugins": {
 		"@release-it/conventional-changelog": {

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -122,7 +122,6 @@ export const blockReleaseIt = base.createBlock({
 						requireCommits: true,
 					},
 					github: {
-						autoGenerate: true,
 						release: true,
 						releaseName: "v${version}",
 					},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1913 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adjusts the release-it config for both this repo, as well as what the create script generates, so that the previous changes to enhance the changelog generation flows through to the github release page too.

I discussed this here release-it/release-it#1025 (comment), and @webpro theorized it was the autoGenerate that overrode the changelog output from being applied to the GH release too.

I created a test repo to verify and confirmed that removing `autoGenerate`, indeed, fixed the issue: https://github.com/michaelfaith/mf-cta-testing/releases 2.0.2 is after this change, which included both a chore change and fix change, but changelog and GH release page only show the bug fix (notice also the group heading, which isn't in the previous releases). 2.0.1 is before the change, with the original configuration

Closes #1913 