### PR TITLE
fix: update existing ruleset when in transition mode

### DIFF
--- a/src/blocks/blockRepositoryBranchRuleset.test.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.test.ts
@@ -5,8 +5,20 @@ import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js"
 import { optionsBase } from "./options.fakes.js";
 
 describe("blockRepositoryBranchRuleset", () => {
-	test("without addons", () => {
+	test("without addons when mode is undefined", () => {
 		const creation = testBlock(blockRepositoryBranchRuleset, {
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`{}`);
+	});
+
+	// TODO for improving the "requests" snapshots:
+	// https://github.com/JoshuaKGoldberg/create/issues/65
+
+	test("without addons when mode is setup", () => {
+		const creation = testBlock(blockRepositoryBranchRuleset, {
+			mode: "setup",
 			options: optionsBase,
 		});
 
@@ -14,7 +26,7 @@ describe("blockRepositoryBranchRuleset", () => {
 			{
 			  "requests": [
 			    {
-			      "id": "branch-ruleset",
+			      "id": "branch-ruleset-create",
 			      "send": [Function],
 			    },
 			  ],
@@ -22,14 +34,9 @@ describe("blockRepositoryBranchRuleset", () => {
 		`);
 	});
 
-	// TODO for improving the "requests" snapshots:
-	// https://github.com/JoshuaKGoldberg/create/issues/65
-
-	test("with addons", () => {
+	test("without addons when mode is transition", () => {
 		const creation = testBlock(blockRepositoryBranchRuleset, {
-			addons: {
-				requiredStatusChecks: ["build", "test"],
-			},
+			mode: "transition",
 			options: optionsBase,
 		});
 
@@ -37,7 +44,60 @@ describe("blockRepositoryBranchRuleset", () => {
 			{
 			  "requests": [
 			    {
-			      "id": "branch-ruleset",
+			      "id": "branch-ruleset-update",
+			      "send": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
+
+	test("with addons when mode is undefined", () => {
+		const creation = testBlock(blockRepositoryBranchRuleset, {
+			addons: {
+				requiredStatusChecks: ["build", "test"],
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`{}`);
+	});
+
+	test("with addons when mode is setup", () => {
+		const creation = testBlock(blockRepositoryBranchRuleset, {
+			addons: {
+				requiredStatusChecks: ["build", "test"],
+			},
+			mode: "setup",
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "requests": [
+			    {
+			      "id": "branch-ruleset-create",
+			      "send": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
+
+	test("with addons when mode is transition", () => {
+		const creation = testBlock(blockRepositoryBranchRuleset, {
+			addons: {
+				requiredStatusChecks: ["build", "test"],
+			},
+			mode: "setup",
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "requests": [
+			    {
+			      "id": "branch-ruleset-create",
 			      "send": [Function],
 			    },
 			  ],

--- a/src/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.ts
@@ -1,6 +1,7 @@
+import { BlockCreation } from "bingo-stratum";
 import { z } from "zod";
 
-import { base } from "../base.js";
+import { base, BaseOptions } from "../base.js";
 
 export const blockRepositoryBranchRuleset = base.createBlock({
 	about: {
@@ -9,60 +10,91 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 	addons: {
 		requiredStatusChecks: z.array(z.string()).default([]),
 	},
-	produce({ addons, options }) {
-		return {
-			requests: [
-				{
-					id: "branch-ruleset",
-					async send({ octokit }) {
-						await octokit.request("POST /repos/{owner}/{repo}/rulesets", {
-							bypass_actors: [
-								{
-									// This *seems* to be the Repository Admin role always?
-									// https://github.com/github/rest-api-description/issues/4406
-									actor_id: 5,
-									actor_type: "RepositoryRole",
-									bypass_mode: "always",
-								},
-							],
-							conditions: {
-								ref_name: {
-									exclude: [],
-									include: ["refs/heads/main"],
-								},
-							},
-							enforcement: "active",
-							name: "Branch protection for main",
-							owner: options.owner,
-							repo: options.repository,
-							rules: [
-								{ type: "deletion" },
-								{
-									parameters: {
-										allowed_merge_methods: ["squash"],
-										dismiss_stale_reviews_on_push: false,
-										require_code_owner_review: false,
-										require_last_push_approval: false,
-										required_approving_review_count: 0,
-										required_review_thread_resolution: false,
-									},
-									type: "pull_request",
-								},
-								{
-									parameters: {
-										required_status_checks: addons.requiredStatusChecks.map(
-											(context) => ({ context }),
-										),
-										strict_required_status_checks_policy: false,
-									},
-									type: "required_status_checks",
-								},
-							],
-							target: "branch",
-						});
-					},
-				},
-			],
-		};
+	setup({ addons, options }) {
+		return createRequestSend(
+			addons.requiredStatusChecks,
+			"POST /repos/{owner}/{repo}/rulesets",
+			options,
+			"branch-ruleset-create",
+			undefined,
+		);
+	},
+	transition({ addons, options }) {
+		return createRequestSend(
+			addons.requiredStatusChecks,
+			`PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}`,
+			options,
+			"branch-ruleset-update",
+			options.rulesetId,
+		);
+	},
+	// TODO: Make produce() optional
+	// This needs createBlock to be generic to know if block.produce({}) is ok
+	produce() {
+		return {};
 	},
 });
+
+function createRequestSend(
+	contexts: string[],
+	endpoint: string,
+	options: BaseOptions,
+	requestId: string,
+	rulesetId: string | undefined,
+): Partial<BlockCreation<BaseOptions>> {
+	return {
+		requests: [
+			{
+				id: requestId,
+				async send({ octokit }) {
+					await octokit.request(endpoint, {
+						bypass_actors: [
+							{
+								// This *seems* to be the Repository Admin role always?
+								// https://github.com/github/rest-api-description/issues/4406
+								actor_id: 5,
+								actor_type: "RepositoryRole",
+								bypass_mode: "always",
+							},
+						],
+						conditions: {
+							ref_name: {
+								exclude: [],
+								include: ["refs/heads/main"],
+							},
+						},
+						enforcement: "active",
+						name: "Branch protection for main",
+						owner: options.owner,
+						repo: options.repository,
+						rules: [
+							{ type: "deletion" },
+							{
+								parameters: {
+									allowed_merge_methods: ["squash"],
+									dismiss_stale_reviews_on_push: false,
+									require_code_owner_review: false,
+									require_last_push_approval: false,
+									required_approving_review_count: 0,
+									required_review_thread_resolution: false,
+								},
+								type: "pull_request",
+							},
+							{
+								parameters: {
+									required_status_checks: contexts.map((context) => ({
+										context,
+									})),
+									strict_required_status_checks_policy: false,
+								},
+								type: "required_status_checks",
+							},
+						],
+						ruleset_id: rulesetId,
+						target: "branch",
+					});
+				},
+			},
+		],
+	};
+}

--- a/src/inputs/inputFromGitHub.ts
+++ b/src/inputs/inputFromGitHub.ts
@@ -1,0 +1,22 @@
+import { createInput } from "bingo";
+import { z } from "zod";
+
+export const inputFromOctokit = createInput({
+	args: {
+		endpoint: z.string(),
+		options: z.record(z.string(), z.unknown()),
+	},
+	// TODO: Strongly type this, then push it upstream to Bingo
+	// This will require smart types around GitHub endpoints, similar to:
+	// https://github.com/JoshuaKGoldberg/bingo/issues/65
+	async produce({ args, fetchers }): Promise<unknown> {
+		const response = await fetchers.octokit.request(args.endpoint, {
+			headers: {
+				"X-GitHub-Api-Version": "2022-11-28",
+			},
+			...args.options,
+		});
+
+		return response.data;
+	},
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1950
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, `blockRepositoryBranchRuleset` would _always_ create a ruleset on `main` with the hardcoded name. This is fine for _setup_ mode but crashes on a duplicate ID creation error in _transition_ mode.

Now, its creations are split between the two modes:

* Setup mode `POST` creates the ruleset as before
* Transition mode `PUT` updates the existing ruleset

The `PUT` update requires a `ruleset_id`, so I added that as a new option in the Base populated by a new `inputFromOctkit`. 

🎁 