### PR TITLE
fix: add README.md contributors section in setup

### DIFF
--- a/src/blocks/blockAllContributors.ts
+++ b/src/blocks/blockAllContributors.ts
@@ -1,6 +1,7 @@
 import _ from "lodash";
 
 import { base, Contributor } from "../base.js";
+import { ownerContributions } from "../data/contributions.js";
 import { blockREADME } from "./blockREADME.js";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
@@ -68,7 +69,7 @@ export const blockAllContributors = base.createBlock({
 			scripts: [
 				{
 					commands: [
-						`pnpx all-contributors-cli add ${options.owner} code,content,doc,ideas,infra,maintenance,projectManagement,tool`,
+						`pnpx all-contributors-cli add ${options.owner} ${ownerContributions.join(",")}`,
 					],
 					phase: CommandPhase.Process,
 				},

--- a/src/data/contributions.ts
+++ b/src/data/contributions.ts
@@ -1,0 +1,10 @@
+export const ownerContributions = [
+	"code",
+	"content",
+	"doc",
+	"ideas",
+	"infra",
+	"maintenance",
+	"projectManagement",
+	"tool",
+];

--- a/src/inputs/inputFromOctokit.ts
+++ b/src/inputs/inputFromOctokit.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 export const inputFromOctokit = createInput({
 	args: {
 		endpoint: z.string(),
-		options: z.record(z.string(), z.unknown()),
+		options: z.record(z.string(), z.unknown()).optional(),
 	},
 	// TODO: Strongly type this, then push it upstream to Bingo
 	// This will require smart types around GitHub endpoints, similar to:

--- a/src/options/readAllContributors.test.ts
+++ b/src/options/readAllContributors.test.ts
@@ -1,0 +1,57 @@
+import { createMockSystems } from "bingo-testers";
+import { describe, expect, it, vi } from "vitest";
+
+import { ownerContributions } from "../data/contributions.js";
+import { readAllContributors } from "./readAllContributors.js";
+
+const mockInputFromFileJSON = vi.fn();
+
+vi.mock("input-from-file-json", () => ({
+	get inputFromFileJSON() {
+		return mockInputFromFileJSON;
+	},
+}));
+
+const mockInputFromOctokit = vi.fn();
+
+vi.mock("../inputs/inputFromOctokit.js", () => ({
+	get inputFromOctokit() {
+		return mockInputFromOctokit;
+	},
+}));
+
+const { take } = createMockSystems();
+
+describe("readAllContributors", () => {
+	it("returns contributors from .all-contributorsrc when it can be read", async () => {
+		const contributors = ["a", "b", "c"];
+		mockInputFromFileJSON.mockResolvedValueOnce({ contributors });
+
+		const actual = await readAllContributors(take);
+
+		expect(actual).toEqual(contributors);
+		expect(mockInputFromOctokit).not.toHaveBeenCalled();
+	});
+
+	it("returns the current user as a contributor when .all-contributorsrc cannot be read", async () => {
+		mockInputFromFileJSON.mockResolvedValueOnce(new Error("Oh no!"));
+		mockInputFromOctokit.mockResolvedValueOnce({
+			avatar_url: "avatar_url",
+			blog: "blog",
+			login: "login",
+			name: "name",
+		});
+
+		const actual = await readAllContributors(take);
+
+		expect(actual).toEqual([
+			{
+				avatar_url: "avatar_url",
+				contributions: ownerContributions,
+				login: "login",
+				name: "name",
+				profile: "blog",
+			},
+		]);
+	});
+});

--- a/src/options/readAllContributors.ts
+++ b/src/options/readAllContributors.ts
@@ -1,0 +1,30 @@
+import { TakeInput } from "bingo";
+import { inputFromFileJSON } from "input-from-file-json";
+
+import { ownerContributions } from "../data/contributions.js";
+import { inputFromOctokit } from "../inputs/inputFromOctokit.js";
+import { AllContributorsData } from "../types.js";
+
+export async function readAllContributors(take: TakeInput) {
+	const contributions = (await take(inputFromFileJSON, {
+		filePath: ".all-contributorsrc",
+	})) as AllContributorsData | Error;
+
+	if (!(contributions instanceof Error)) {
+		return contributions.contributors;
+	}
+
+	const user = (await take(inputFromOctokit, {
+		endpoint: "GET /user",
+	})) as { avatar_url: string; blog: string; login: string; name: string };
+
+	return [
+		{
+			avatar_url: user.avatar_url,
+			contributions: ownerContributions,
+			login: user.login,
+			name: user.name,
+			profile: user.blog,
+		},
+	];
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1956
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The previous `pnpx all-contributors-cli` command was only enough for transition mode to pick up on existing contributors and create a README.md section. For setup mode, there needed to be a default in options if `.all-contributorsrc` doesn't yet exist. That's now pulled from the GitHub API.

🎁 