### PR TITLE
feat: enable ESLint settings.vitest.typecheck

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,7 +72,10 @@ export default tseslint.config(
 			"object-shorthand": "error",
 			"operator-assignment": "error",
 		},
-		settings: { perfectionist: { partitionByComment: true, type: "natural" } },
+		settings: {
+			perfectionist: { partitionByComment: true, type: "natural" },
+			vitest: { typecheck: true },
+		},
 	},
 	{ extends: [tseslint.configs.disableTypeChecked], files: ["**/*.md/*.ts"] },
 	{

--- a/src/blocks/blockESLint.ts
+++ b/src/blocks/blockESLint.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
+import { sortObject } from "../utils/sortObject.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
@@ -241,7 +242,8 @@ function printExtension(extension: z.infer<typeof zExtension>) {
 		extension.linterOptions &&
 			`linterOptions: ${JSON.stringify(extension.linterOptions)}`,
 		extension.rules && `rules: ${printExtensionRules(extension.rules)},`,
-		extension.settings && `settings: ${JSON.stringify(extension.settings)},`,
+		extension.settings &&
+			`settings: ${JSON.stringify(sortObject(extension.settings))},`,
 		"}",
 	]
 		.filter(Boolean)

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -82,6 +82,11 @@ describe("blockVitest", () => {
 			            "specifier": "vitest",
 			          },
 			        ],
+			        "settings": {
+			          "vitest": {
+			            "typecheck": true,
+			          },
+			        },
 			      },
 			      "block": [Function],
 			    },
@@ -94,7 +99,7 @@ describe("blockVitest", () => {
 
 			const message = "Yay, testing!";
 
-			describe("greet", () => {
+			describe(greet, () => {
 				it("logs to the console once when message is provided as a string", () => {
 					const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
@@ -315,6 +320,11 @@ describe("blockVitest", () => {
 			            "specifier": "vitest",
 			          },
 			        ],
+			        "settings": {
+			          "vitest": {
+			            "typecheck": true,
+			          },
+			        },
 			      },
 			      "block": [Function],
 			    },
@@ -327,7 +337,7 @@ describe("blockVitest", () => {
 
 			const message = "Yay, testing!";
 
-			describe("greet", () => {
+			describe(greet, () => {
 				it("logs to the console once when message is provided as a string", () => {
 					const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
@@ -569,6 +579,11 @@ describe("blockVitest", () => {
 			            "specifier": "vitest",
 			          },
 			        ],
+			        "settings": {
+			          "vitest": {
+			            "typecheck": true,
+			          },
+			        },
 			      },
 			      "block": [Function],
 			    },
@@ -581,7 +596,7 @@ describe("blockVitest", () => {
 
 			const message = "Yay, testing!";
 
-			describe("greet", () => {
+			describe(greet, () => {
 				it("logs to the console once when message is provided as a string", () => {
 					const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
 

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -79,6 +79,9 @@ Calls to \`console.log\`, \`console.warn\`, and other console methods will cause
 					],
 					ignores: ["coverage", "**/*.snap"],
 					imports: [{ source: "@vitest/eslint-plugin", specifier: "vitest" }],
+					settings: {
+						vitest: { typecheck: true },
+					},
 				}),
 				blockExampleFiles({
 					files: {
@@ -88,7 +91,7 @@ import { greet } from "./greet.js";
 
 const message = "Yay, testing!";
 
-describe("greet", () => {
+describe(greet, () => {
 	it("logs to the console once when message is provided as a string", () => {
 		const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
 

--- a/src/data/packageData.test.ts
+++ b/src/data/packageData.test.ts
@@ -13,7 +13,7 @@ vi.mock("node:module", () => ({
 	}),
 }));
 
-describe("getPackageDependencies", () => {
+describe(getPackageDependencies, () => {
 	it("returns a devDependency when it exists", () => {
 		const actual = getPackageDependencies("package-dev-dep");
 

--- a/src/options/getUsageFromReadme.test.ts
+++ b/src/options/getUsageFromReadme.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { getUsageFromReadme } from "./getUsageFromReadme.js";
 
-describe("getUsageFromReadme", () => {
+describe(getUsageFromReadme, () => {
 	it("returns undefined when ## Usage is not found", () => {
 		const usage = getUsageFromReadme("## Other");
 

--- a/src/options/parsePackageAuthor.test.ts
+++ b/src/options/parsePackageAuthor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parsePackageAuthor } from "./parsePackageAuthor.js";
 
-describe("parsePackageAuthor", () => {
+describe(parsePackageAuthor, () => {
 	it.each([
 		[{}, {}],
 		[{ author: "abc123" }, { author: "abc123" }],

--- a/src/options/readAllContributors.test.ts
+++ b/src/options/readAllContributors.test.ts
@@ -22,7 +22,7 @@ vi.mock("../inputs/inputFromOctokit.js", () => ({
 
 const { take } = createMockSystems();
 
-describe("readAllContributors", () => {
+describe(readAllContributors, () => {
 	it("returns contributors from .all-contributorsrc when it can be read", async () => {
 		const contributors = ["a", "b", "c"];
 		mockInputFromFileJSON.mockResolvedValueOnce({ contributors });

--- a/src/options/readDefaultsFromReadme.test.ts
+++ b/src/options/readDefaultsFromReadme.test.ts
@@ -18,7 +18,7 @@ vi.mock("./getUsageFromReadme.js", () => ({
 	},
 }));
 
-describe("readDefaultsFromReadme", () => {
+describe(readDefaultsFromReadme, () => {
 	describe("explainer", () => {
 		it("defaults to undefined when it cannot be found", async () => {
 			const explainer = await readDefaultsFromReadme(

--- a/src/options/readDescription.test.ts
+++ b/src/options/readDescription.test.ts
@@ -12,7 +12,7 @@ vi.mock("../data/packageData.js", () => ({
 	},
 }));
 
-describe("readDescription", () => {
+describe(readDescription, () => {
 	it("returns undefined when the description matches the current package.json description", async () => {
 		const existing = "Same description.";
 

--- a/src/options/readDescriptionFromReadme.test.ts
+++ b/src/options/readDescriptionFromReadme.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { readDescriptionFromReadme } from "./readDescriptionFromReadme.js";
 
-describe("readDescriptionFromReadme", () => {
+describe(readDescriptionFromReadme, () => {
 	it("returns undefined when the paragraph starter is not found", async () => {
 		const description = await readDescriptionFromReadme(() =>
 			Promise.resolve(""),

--- a/src/options/readDocumentation.test.ts
+++ b/src/options/readDocumentation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { readDocumentation } from "./readDocumentation.js";
 
-describe("finalize", () => {
+describe(readDocumentation, () => {
 	it("returns undefined when no .github/DEVELOPMENT.md exists", async () => {
 		const documentation = await readDocumentation(() =>
 			Promise.resolve(undefined),

--- a/src/options/readFileAsJson.test.ts
+++ b/src/options/readFileAsJson.test.ts
@@ -10,7 +10,7 @@ vi.mock("node:fs/promises", () => ({
 	},
 }));
 
-describe("readFileAsJson", () => {
+describe(readFileAsJson, () => {
 	it("returns the file's parsed contents when it exists", async () => {
 		const data = { abc: 123 };
 

--- a/src/options/readFileSafe.test.ts
+++ b/src/options/readFileSafe.test.ts
@@ -10,7 +10,7 @@ vi.mock("node:fs/promises", () => ({
 	},
 }));
 
-describe("readFundingIfExists", () => {
+describe(readFileSafe, () => {
 	it("outputs the file content as string when it exists", async () => {
 		mockReadFile.mockResolvedValue("File content as string");
 		const result = await readFileSafe("/path/to/file.ext", "fallback");

--- a/src/options/readGitHubEmail.test.ts
+++ b/src/options/readGitHubEmail.test.ts
@@ -10,7 +10,7 @@ vi.mock("./readFileSafe.js", () => ({
 	},
 }));
 
-describe("readGitHubEmail", () => {
+describe(readGitHubEmail, () => {
 	it("returns undefined when it cannot be found", async () => {
 		mockReadFileSafe.mockResolvedValue("nothing.");
 

--- a/src/options/readGuide.test.ts
+++ b/src/options/readGuide.test.ts
@@ -10,29 +10,27 @@ vi.mock("./readFileSafe.js", () => ({
 	},
 }));
 
-describe("readGuide", () => {
-	describe("guide", () => {
-		it("defaults to undefined when .github/DEVELOPMENT.md cannot be found", async () => {
-			mockReadFileSafe.mockResolvedValue("");
+describe(readGuide, () => {
+	it("defaults to undefined when .github/DEVELOPMENT.md cannot be found", async () => {
+		mockReadFileSafe.mockResolvedValue("");
 
-			const guide = await readGuide();
+		const guide = await readGuide();
 
-			expect(guide).toBeUndefined();
-		});
+		expect(guide).toBeUndefined();
+	});
 
-		it("reads the href and title when the tag exists", async () => {
-			mockReadFileSafe.mockResolvedValue(`# Development
+	it("reads the href and title when the tag exists", async () => {
+		mockReadFileSafe.mockResolvedValue(`# Development
 
 > If you'd like a more guided walkthrough, see [Contributing to a create-typescript-app Repository](https://www.joshuakgoldberg.com/blog/contributing-to-a-create-typescript-app-repository).
 > It'll walk you through the common activities you'll need to contribute.
 `);
 
-			const guide = await readGuide();
+		const guide = await readGuide();
 
-			expect(guide).toEqual({
-				href: "https://www.joshuakgoldberg.com/blog/contributing-to-a-create-typescript-app-repository",
-				title: "Contributing to a create-typescript-app Repository",
-			});
+		expect(guide).toEqual({
+			href: "https://www.joshuakgoldberg.com/blog/contributing-to-a-create-typescript-app-repository",
+			title: "Contributing to a create-typescript-app Repository",
 		});
 	});
 });

--- a/src/options/readLogoSizing.test.ts
+++ b/src/options/readLogoSizing.test.ts
@@ -12,7 +12,7 @@ vi.mock("image-size", () => ({
 
 const src = "img.jpg";
 
-describe("readLogoSizing", () => {
+describe(readLogoSizing, () => {
 	it("returns undefined when imageSize throws an error", () => {
 		mockImageSize.mockImplementationOnce(() => {
 			throw new Error("Oh no!");

--- a/src/utils/tryCatchLazyValueAsync.test.ts
+++ b/src/utils/tryCatchLazyValueAsync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { tryCatchLazyValueAsync } from "./tryCatchLazyValueAsync.js";
 
-describe("tryCatchLazyValueAsync", () => {
+describe(tryCatchLazyValueAsync, () => {
 	it("does not run get when it has not been called", () => {
 		const get = vi.fn();
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1847
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes quotes from all the `describe()`s I could. Blocks and Inputs unfortunately are objects, not functions, so they're still not allowed.

🎁 