### PR TITLE
feat: add packageManager back to package.json, and set to pnpm 10.4.0 in CI

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,8 +5,6 @@ name: Prepare
 runs:
   steps:
     - uses: pnpm/action-setup@v4
-      with:
-        version: 9
     - uses: actions/setup-node@v4
       with:
         cache: pnpm

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"typescript-eslint": "8.26.0",
 		"vitest": "3.0.7"
 	},
+	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=18.3.0"
 	},

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -47,6 +47,7 @@ describe("base", () => {
 			},
 			owner: "JoshuaKGoldberg",
 			packageData: expect.any(Object),
+			pnpm: expect.any(String),
 			repository: "create-typescript-app",
 			title: "Create TypeScript App",
 			usage: expect.any(String),

--- a/src/base.ts
+++ b/src/base.ts
@@ -8,7 +8,6 @@ import lazyValue from "lazy-value";
 import npmUser from "npm-user";
 import { z } from "zod";
 
-import { packageData as ctaPackageData } from "./data/packageData.js";
 import { inputFromOctokit } from "./inputs/inputFromOctokit.js";
 import { parsePackageAuthor } from "./options/parsePackageAuthor.js";
 import { readAllContributors } from "./options/readAllContributors.js";
@@ -20,6 +19,7 @@ import { readFileSafe } from "./options/readFileSafe.js";
 import { readFunding } from "./options/readFunding.js";
 import { readGuide } from "./options/readGuide.js";
 import { readPackageData } from "./options/readPackageData.js";
+import { readPnpm } from "./options/readPnpm.js";
 import { swallowError } from "./utils/swallowError.js";
 import { tryCatchLazyValueAsync } from "./utils/tryCatchLazyValueAsync.js";
 
@@ -212,13 +212,7 @@ export const base = createBase({
 			};
 		});
 
-		const pnpm = lazyValue(async () => {
-			const { packageManager } = await packageData();
-
-			return packageManager?.startsWith("pnpm@")
-				? packageManager.slice("pnpm@".length)
-				: "10.4.0";
-		});
+		const pnpm = lazyValue(async () => readPnpm(packageData));
 
 		const version = lazyValue(async () => (await packageData()).version);
 

--- a/src/blocks/blockGitHubActionsCI.test.ts
+++ b/src/blocks/blockGitHubActionsCI.test.ts
@@ -31,8 +31,6 @@ describe("blockGitHubActionsCI", () => {
 			runs:
 			  steps:
 			    - uses: pnpm/action-setup@v4
-			      with:
-			        version: 9
 			    - uses: actions/setup-node@v4
 			      with:
 			        cache: pnpm
@@ -128,8 +126,6 @@ describe("blockGitHubActionsCI", () => {
 			runs:
 			  steps:
 			    - uses: pnpm/action-setup@v4
-			      with:
-			        version: 9
 			    - uses: actions/setup-node@v4
 			      with:
 			        cache: pnpm
@@ -250,8 +246,6 @@ describe("blockGitHubActionsCI", () => {
 			runs:
 			  steps:
 			    - uses: pnpm/action-setup@v4
-			      with:
-			        version: 9
 			    - uses: actions/setup-node@v4
 			      with:
 			        cache: pnpm

--- a/src/blocks/blockGitHubActionsCI.ts
+++ b/src/blocks/blockGitHubActionsCI.ts
@@ -51,7 +51,6 @@ export const blockGitHubActionsCI = base.createBlock({
 										steps: [
 											{
 												uses: "pnpm/action-setup@v4",
-												with: { version: 9 },
 											},
 											{
 												uses: "actions/setup-node@v4",

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -126,4 +126,32 @@ describe("blockPackageJson", () => {
 			}
 		`);
 	});
+
+	test("with node and pnpm versions", () => {
+		const creation = testBlock(blockPackageJson, {
+			options: {
+				...options,
+				node: {
+					minimum: "22.0.0",
+				},
+				pnpm: "10.4.0",
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "files": {
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","main":"lib/index.js","files":["README.md","package.json"],"packageManager":"pnpm@10.4.0","engines":{"node":">=22.0.0"}}",
+			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "pnpm install",
+			      ],
+			      "phase": 1,
+			    },
+			  ],
+			}
+		`);
+	});
 });

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -59,6 +59,9 @@ export const blockPackageJson = base.createBlock({
 									node: `>=${options.node.minimum}`,
 								},
 							}),
+							...(options.pnpm && {
+								packageManager: `pnpm@${options.pnpm}`,
+							}),
 							files: [
 								options.bin?.replace(/^\.\//, ""),
 								...(addons.properties.files ?? []),

--- a/src/options/readPnpm.test.ts
+++ b/src/options/readPnpm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { readPnpm } from "./readPnpm.js";
 

--- a/src/options/readPnpm.test.ts
+++ b/src/options/readPnpm.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { readPnpm } from "./readPnpm.js";
+
+describe(readPnpm, () => {
+	it("returns 10.4.0 when there is no existing packageManager", async () => {
+		const actual = await readPnpm(() => Promise.resolve({}));
+
+		expect(actual).toEqual("10.4.0");
+	});
+
+	it("returns 10.4.0 when an existing packageManager is not pnpm", async () => {
+		const actual = await readPnpm(() =>
+			Promise.resolve({
+				packageManager: "yarn@1.2.3",
+			}),
+		);
+
+		expect(actual).toEqual("10.4.0");
+	});
+
+	it("returns the existing pnpm version when an existing packageManager is pnpm", async () => {
+		const actual = await readPnpm(() =>
+			Promise.resolve({
+				packageManager: "pnpm@10.11.12",
+			}),
+		);
+
+		expect(actual).toEqual("10.11.12");
+	});
+});

--- a/src/options/readPnpm.ts
+++ b/src/options/readPnpm.ts
@@ -1,0 +1,9 @@
+import { PartialPackageData } from "../types.js";
+
+export async function readPnpm(packageData: () => Promise<PartialPackageData>) {
+	const { packageManager } = await packageData();
+
+	return packageManager?.startsWith("pnpm@")
+		? packageManager.slice("pnpm@".length)
+		: "10.4.0";
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface PartialPackageData {
 	email?: string;
 	engines?: { node?: string };
 	name?: string;
+	packageManager?: string;
 	repository?: string | { type: string; url: string };
 	scripts?: Record<string, string>;
 	version?: string;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1906
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `pnpm` option to the Base, which defaults to the existing `packageManager`'s pnpm version if it exists.

🎁 