### PR TITLE
feat: remove sourcemaps

### DIFF
--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -72,7 +72,7 @@ We strongly recommend using at least the [_"common"_ base level](#common-base-le
 ### Building
 
 [**tsup**](https://tsup.egoist.dev): Builds output definitions and JavaScript files using [esbuild](https://esbuild.github.io).
-Each `*.ts` source file within `src/` is built into `.d.ts`, `.js`, and `.js.map` output files in `lib/`.
+Each `*.ts` source file within `src/` is built into `.d.ts` and `.js` output files in `lib/`.
 
 Building once:
 

--- a/src/blocks/blockTSup.test.ts
+++ b/src/blocks/blockTSup.test.ts
@@ -87,7 +87,6 @@ describe("blockTSup", () => {
 				entry: ["src/**/*.ts"],
 				format: "esm",
 				outDir: "lib",
-				sourcemap: true,
 			});
 			",
 			  },
@@ -175,7 +174,6 @@ describe("blockTSup", () => {
 				entry: ["src/**/*.ts"],
 				format: "esm",
 				outDir: "lib",
-				sourcemap: true,
 			});
 			",
 			  },
@@ -279,7 +277,6 @@ describe("blockTSup", () => {
 				entry: ["src/**/*.ts","!src/**/*.test.ts"],
 				format: "esm",
 				outDir: "lib",
-				sourcemap: true,
 			});
 			",
 			  },

--- a/src/blocks/blockTSup.ts
+++ b/src/blocks/blockTSup.ts
@@ -76,7 +76,6 @@ export default defineConfig({
 	entry: ${JSON.stringify(["src/**/*.ts", ...entry])},
 	format: "esm",
 	outDir: "lib",
-	sourcemap: true,
 });
 `,
 			},

--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -147,7 +147,7 @@ describe("blockTypeScript", () => {
 			    },
 			  ],
 			  "files": {
-			    "tsconfig.json": "{"compilerOptions":{"declaration":true,"declarationMap":true,"esModuleInterop":true,"module":"NodeNext","moduleResolution":"NodeNext","noEmit":true,"resolveJsonModule":true,"skipLibCheck":true,"sourceMap":true,"strict":true,"target":"ES2022"},"include":["src"]}",
+			    "tsconfig.json": "{"compilerOptions":{"declaration":true,"declarationMap":true,"esModuleInterop":true,"module":"NodeNext","moduleResolution":"NodeNext","noEmit":true,"resolveJsonModule":true,"skipLibCheck":true,"strict":true,"target":"ES2022"},"include":["src"]}",
 			  },
 			}
 		`);
@@ -309,7 +309,7 @@ describe("blockTypeScript", () => {
 			    },
 			  ],
 			  "files": {
-			    "tsconfig.json": "{"compilerOptions":{"declaration":true,"declarationMap":true,"esModuleInterop":true,"module":"NodeNext","moduleResolution":"NodeNext","noEmit":true,"resolveJsonModule":true,"skipLibCheck":true,"sourceMap":true,"strict":true,"target":"ES2022"},"include":["src"]}",
+			    "tsconfig.json": "{"compilerOptions":{"declaration":true,"declarationMap":true,"esModuleInterop":true,"module":"NodeNext","moduleResolution":"NodeNext","noEmit":true,"resolveJsonModule":true,"skipLibCheck":true,"strict":true,"target":"ES2022"},"include":["src"]}",
 			  },
 			}
 		`);

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -121,7 +121,6 @@ export * from "./types.js";
 						noEmit: true,
 						resolveJsonModule: true,
 						skipLibCheck: true,
-						sourceMap: true,
 						strict: true,
 						target: "ES2022",
 					},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
 		"noEmit": true,
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
-		"sourceMap": true,
 		"strict": true,
 		"target": "ES2022"
 	},

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
 	format: "esm",
 	outDir: "lib",
-	sourcemap: true,
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1909
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Per discussions linked in the issue, removes sourcemaps to significantly reduce the size of output files.

| Target              | Package Size | Unpacked Size | Total Files |
| ------------------- | ------------ | ------------- | ----------- |
| `main`              | 106.7 kB     | 609.9 kB      | 277         |
| `remove-sourcemaps` | 54.1 kB      | 369.9 kB      | 186         |
| Comparison          | 49% smaller  | 39% smaller   | 32% smaller |

Raw `npm pack` output on `main`:

```plaintext
npm notice Tarball Details
npm notice name: create-typescript-app
npm notice version: 2.2.0
npm notice filename: create-typescript-app-2.2.0.tgz
npm notice package size: 106.7 kB
npm notice unpacked size: 609.9 kB
npm notice shasum: dd0439e3a977c55bbfaa8449f73799314b925368
npm notice integrity: sha512-Z0nBEgLroJY5p[...]yi9LJdG28f9DA==
npm notice total files: 277
```

Raw `npm pack` output with this change:

```plaintext
npm notice Tarball Details
npm notice name: create-typescript-app
npm notice version: 2.2.0
npm notice filename: create-typescript-app-2.2.0.tgz
npm notice package size: 54.1 kB
npm notice unpacked size: 369.9 kB
npm notice shasum: 8f92517ecbd9dbffdba72b5dd11aeceaf7d61b9b
npm notice integrity: sha512-OaNzBaDi41IH5[...]HospZHaW1trEQ==
npm notice total files: 186
```