### PR TITLE
feat: include URLs in GitHub app and secret suggestions

### DIFF
--- a/src/blocks/blockGitHubApps.test.ts
+++ b/src/blocks/blockGitHubApps.test.ts
@@ -1,0 +1,47 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, test } from "vitest";
+
+import { blockGitHubApps } from "./blockGitHubApps.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe("blockGitHubApps", () => {
+	test("without addons", () => {
+		const creation = testBlock(blockGitHubApps, {
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "suggestions": undefined,
+			}
+		`);
+	});
+
+	test("with addons", () => {
+		const creation = testBlock(blockGitHubApps, {
+			addons: {
+				apps: [
+					{
+						name: "Secret A.",
+						url: "https://example.com?a",
+					},
+					{
+						name: "Secret B.",
+						url: "https://example.com?b",
+					},
+				],
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "suggestions": [
+			    "- enable the GitHub apps on https://github.com/test-owner/test-repository/settings/installations:
+			   - Secret A. (https://example.com?a)
+			   - Secret B. (https://example.com?b)",
+			  ],
+			}
+		`);
+	});
+});

--- a/src/blocks/blockGitHubApps.ts
+++ b/src/blocks/blockGitHubApps.ts
@@ -1,34 +1,29 @@
 import { z } from "zod";
 
 import { base } from "../base.js";
+import { getInstallationSuggestions } from "./getInstallationSuggestions.js";
 
-const zApp = z.object({
-	name: z.string(),
-	url: z.string(),
-});
 export const blockGitHubApps = base.createBlock({
 	about: {
 		name: "GitHub Apps",
 	},
 	addons: {
-		apps: z.array(zApp).default([]),
+		apps: z
+			.array(
+				z.object({
+					name: z.string(),
+					url: z.string(),
+				}),
+			)
+			.default([]),
 	},
-	produce({ addons }) {
+	produce({ addons, options }) {
 		return {
-			suggestions: addons.apps.length
-				? [
-						[
-							`- enable the GitHub app`,
-							addons.apps.length === 1 ? "" : "s",
-							`:\n`,
-							addons.apps.map(printApp).join("\n"),
-						].join(""),
-					]
-				: undefined,
+			suggestions: getInstallationSuggestions(
+				"enable the GitHub app",
+				addons.apps.map((app) => `${app.name} (${app.url})`),
+				`https://github.com/${options.owner}/${options.repository}/settings/installations`,
+			),
 		};
 	},
 });
-
-function printApp(app: z.infer<typeof zApp>) {
-	return `   - ${app.name} (${app.url})`;
-}

--- a/src/blocks/blockRepositorySecrets.test.ts
+++ b/src/blocks/blockRepositorySecrets.test.ts
@@ -1,0 +1,47 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, test } from "vitest";
+
+import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe("blockRepositorySecrets", () => {
+	test("without addons", () => {
+		const creation = testBlock(blockRepositorySecrets, {
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "suggestions": undefined,
+			}
+		`);
+	});
+
+	test("with addons", () => {
+		const creation = testBlock(blockRepositorySecrets, {
+			addons: {
+				secrets: [
+					{
+						description: "Secret description a.",
+						name: "Secret Name A",
+					},
+					{
+						description: "Secret description b.",
+						name: "Secret Name B",
+					},
+				],
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "suggestions": [
+			    "- populate the secrets on https://github.com/test-owner/test-repository/settings/secrets/actions:
+			   - Secret Name A (Secret description a.)
+			   - Secret Name B (Secret description b.)",
+			  ],
+			}
+		`);
+	});
+});

--- a/src/blocks/blockRepositorySecrets.ts
+++ b/src/blocks/blockRepositorySecrets.ts
@@ -1,34 +1,31 @@
 import { z } from "zod";
 
 import { base } from "../base.js";
+import { getInstallationSuggestions } from "./getInstallationSuggestions.js";
 
-const zSecret = z.object({
-	description: z.string(),
-	name: z.string(),
-});
 export const blockRepositorySecrets = base.createBlock({
 	about: {
 		name: "Repository Secrets",
 	},
 	addons: {
-		secrets: z.array(zSecret).default([]),
+		secrets: z
+			.array(
+				z.object({
+					description: z.string(),
+					name: z.string(),
+				}),
+			)
+			.default([]),
 	},
-	produce({ addons }) {
+	produce({ addons, options }) {
 		return {
-			suggestions: addons.secrets.length
-				? [
-						[
-							`- populate the secret`,
-							addons.secrets.length === 1 ? "" : "s",
-							`:\n`,
-							addons.secrets.map(printSecret).join("\n"),
-						].join(""),
-					]
-				: undefined,
+			suggestions: getInstallationSuggestions(
+				"populate the secret",
+				addons.secrets.map(
+					(secret) => `${secret.name} (${secret.description})`,
+				),
+				`https://github.com/${options.owner}/${options.repository}/settings/secrets/actions`,
+			),
 		};
 	},
 });
-
-function printSecret(app: z.infer<typeof zSecret>) {
-	return `   - ${app.name} (${app.description})`;
-}

--- a/src/blocks/getInstallationSuggestions.test.ts
+++ b/src/blocks/getInstallationSuggestions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { getInstallationSuggestions } from "./getInstallationSuggestions.js";
+
+const description = "do the action";
+const url = "https://example.com";
+
+describe(getInstallationSuggestions, () => {
+	it("returns undefined when there are no entries", () => {
+		const actual = getInstallationSuggestions(description, [], url);
+
+		expect(actual).toBeUndefined();
+	});
+
+	it("returns a non-plural list when there is one entry", () => {
+		const actual = getInstallationSuggestions(description, ["entry"], url);
+
+		expect(actual).toMatchInlineSnapshot(`
+			[
+			  "- do the action on https://example.com:
+			   - entry",
+			]
+		`);
+	});
+
+	it("returns a plural list when there are multiple entries", () => {
+		const actual = getInstallationSuggestions(
+			description,
+			["entry a", "entry b"],
+			url,
+		);
+
+		expect(actual).toMatchInlineSnapshot(`
+			[
+			  "- do the actions on https://example.com:
+			   - entry a
+			   - entry b",
+			]
+		`);
+	});
+});

--- a/src/blocks/getInstallationSuggestions.ts
+++ b/src/blocks/getInstallationSuggestions.ts
@@ -1,0 +1,16 @@
+export function getInstallationSuggestions(
+	description: string,
+	entries: string[],
+	url: string,
+) {
+	return entries.length
+		? [
+				[
+					`- ${description}`,
+					entries.length === 1 ? "" : "s",
+					` on ${url}:\n`,
+					entries.map((entry) => `   - ${entry}`).join("\n"),
+				].join(""),
+			]
+		: undefined;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1621
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Refactors the two blocks to use a shared `getInstallationSuggestions` function because I didn't want to keep updating both.

🎁 