### PR TITLE
fix: only PUT a ruleset when an ID already exists

### DIFF
--- a/src/blocks/blockRepositoryBranchRuleset.test.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.test.ts
@@ -104,4 +104,28 @@ describe("blockRepositoryBranchRuleset", () => {
 			}
 		`);
 	});
+
+	test("with addons and a ruleset_id option when mode is transition", () => {
+		const creation = testBlock(blockRepositoryBranchRuleset, {
+			addons: {
+				requiredStatusChecks: ["build", "test"],
+			},
+			mode: "setup",
+			options: {
+				...optionsBase,
+				rulesetId: "1234",
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "requests": [
+			    {
+			      "id": "branch-ruleset-create",
+			      "send": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
 });

--- a/src/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.ts
@@ -1,4 +1,3 @@
-import { BlockCreation } from "bingo-stratum";
 import { z } from "zod";
 
 import { base, BaseOptions } from "../base.js";
@@ -11,22 +10,45 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 		requiredStatusChecks: z.array(z.string()).default([]),
 	},
 	setup({ addons, options }) {
-		return createRequestSend(
-			addons.requiredStatusChecks,
-			"POST /repos/{owner}/{repo}/rulesets",
-			options,
-			"branch-ruleset-create",
-			undefined,
-		);
+		return {
+			requests: [
+				{
+					id: "branch-ruleset-create",
+					async send({ octokit }) {
+						await octokit.request(
+							"POST /repos/{owner}/{repo}/rulesets",
+							createInnerSend(addons.requiredStatusChecks, options),
+						);
+					},
+				},
+			],
+		};
 	},
 	transition({ addons, options }) {
-		return createRequestSend(
-			addons.requiredStatusChecks,
-			`PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}`,
-			options,
-			"branch-ruleset-update",
-			options.rulesetId,
-		);
+		return {
+			requests: [
+				{
+					id: "branch-ruleset-update",
+					async send({ octokit }) {
+						if (options.rulesetId) {
+							await octokit.request(
+								`PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}`,
+								createInnerSend(
+									addons.requiredStatusChecks,
+									options,
+									options.rulesetId,
+								),
+							);
+						} else {
+							await octokit.request(
+								`POST /repos/{owner}/{repo}/rulesets/{ruleset_id}`,
+								createInnerSend(addons.requiredStatusChecks, options),
+							);
+						}
+					},
+				},
+			],
+		};
 	},
 	// TODO: Make produce() optional
 	// This needs createBlock to be generic to know if block.produce({}) is ok
@@ -35,66 +57,57 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 	},
 });
 
-function createRequestSend(
+function createInnerSend(
 	contexts: string[],
-	endpoint: string,
 	options: BaseOptions,
-	requestId: string,
-	rulesetId: string | undefined,
-): Partial<BlockCreation<BaseOptions>> {
+	rulesetId?: string,
+) {
 	return {
-		requests: [
+		bypass_actors: [
 			{
-				id: requestId,
-				async send({ octokit }) {
-					await octokit.request(endpoint, {
-						bypass_actors: [
-							{
-								// This *seems* to be the Repository Admin role always?
-								// https://github.com/github/rest-api-description/issues/4406
-								actor_id: 5,
-								actor_type: "RepositoryRole",
-								bypass_mode: "always",
-							},
-						],
-						conditions: {
-							ref_name: {
-								exclude: [],
-								include: ["refs/heads/main"],
-							},
-						},
-						enforcement: "active",
-						name: "Branch protection for main",
-						owner: options.owner,
-						repo: options.repository,
-						rules: [
-							{ type: "deletion" },
-							{
-								parameters: {
-									allowed_merge_methods: ["squash"],
-									dismiss_stale_reviews_on_push: false,
-									require_code_owner_review: false,
-									require_last_push_approval: false,
-									required_approving_review_count: 0,
-									required_review_thread_resolution: false,
-								},
-								type: "pull_request",
-							},
-							{
-								parameters: {
-									required_status_checks: contexts.map((context) => ({
-										context,
-									})),
-									strict_required_status_checks_policy: false,
-								},
-								type: "required_status_checks",
-							},
-						],
-						ruleset_id: rulesetId,
-						target: "branch",
-					});
-				},
+				// This *seems* to be the Repository Admin role always?
+				// https://github.com/github/rest-api-description/issues/4406
+				actor_id: 5,
+				actor_type: "RepositoryRole" as const,
+				bypass_mode: "always" as const,
 			},
 		],
+		conditions: {
+			ref_name: {
+				exclude: [],
+				include: ["refs/heads/main"],
+			},
+		},
+		enforcement: "active" as const,
+		name: "Branch protection for main",
+		owner: options.owner,
+		repo: options.repository,
+		rules: [
+			{ type: "deletion" as const },
+			{
+				parameters: {
+					allowed_merge_methods: ["squash"],
+					dismiss_stale_reviews_on_push: false,
+					require_code_owner_review: false,
+					require_last_push_approval: false,
+					required_approving_review_count: 0,
+					required_review_thread_resolution: false,
+				},
+				type: "pull_request" as const,
+			},
+			{
+				parameters: {
+					required_status_checks: contexts.map((context) => ({
+						context,
+					})),
+					strict_required_status_checks_policy: false,
+				},
+				type: "required_status_checks" as const,
+			},
+		],
+		// Type fun because the GitHub Octokit APIs don't provide named types...
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		ruleset_id: (rulesetId === undefined ? rulesetId : Number(rulesetId))!,
+		target: "branch" as const,
 	};
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1967
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If `options.rulesetId` doesn't exist, then transition mode should still `POST` a new ruleset, not `PUT` to update an existing one.

🎁 