### PR TITLE
fix: don't crash reading contributors when not logged into GitHub

### DIFF
--- a/src/options/readAllContributors.test.ts
+++ b/src/options/readAllContributors.test.ts
@@ -33,7 +33,16 @@ describe(readAllContributors, () => {
 		expect(mockInputFromOctokit).not.toHaveBeenCalled();
 	});
 
-	it("returns the current user as a contributor when .all-contributorsrc cannot be read", async () => {
+	it("returns undefined when .all-contributorsrc cannot be read and GET /user resolves undefined", async () => {
+		mockInputFromFileJSON.mockResolvedValueOnce(new Error("Oh no!"));
+		mockInputFromOctokit.mockResolvedValueOnce(undefined);
+
+		const actual = await readAllContributors(take);
+
+		expect(actual).toBeUndefined();
+	});
+
+	it("returns the current user as a contributor when .all-contributorsrc cannot be read and GET /user resolves a user", async () => {
 		mockInputFromFileJSON.mockResolvedValueOnce(new Error("Oh no!"));
 		mockInputFromOctokit.mockResolvedValueOnce({
 			avatar_url: "avatar_url",

--- a/src/options/readAllContributors.ts
+++ b/src/options/readAllContributors.ts
@@ -16,15 +16,19 @@ export async function readAllContributors(take: TakeInput) {
 
 	const user = (await take(inputFromOctokit, {
 		endpoint: "GET /user",
-	})) as { avatar_url: string; blog: string; login: string; name: string };
+	})) as
+		| undefined
+		| { avatar_url: string; blog: string; login: string; name: string };
 
-	return [
-		{
-			avatar_url: user.avatar_url,
-			contributions: ownerContributions,
-			login: user.login,
-			name: user.name,
-			profile: user.blog,
-		},
-	];
+	return (
+		user && [
+			{
+				avatar_url: user.avatar_url,
+				contributions: ownerContributions,
+				login: user.login,
+				name: user.name,
+				profile: user.blog,
+			},
+		]
+	);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1971
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The `GET /user` result can be `undefined` if the user isn't logged in.

🎁 