### PR TITLE
fix(husky): use pnpx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpx lint-staged

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -93,7 +93,7 @@ Here we'll outline the steps required to migrate a CTA app to a GitHub Action:
    ```diff
    +pnpm run build
    +git add dist
-   npx lint-staged
+   pnpx lint-staged
    ```
 
 2. Create an [`action.yml` metadata file](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#creating-an-action-metadata-file).

--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -91,7 +91,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,
@@ -203,7 +203,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,
@@ -333,7 +333,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,

--- a/src/blocks/blockPrettier.ts
+++ b/src/blocks/blockPrettier.ts
@@ -85,7 +85,7 @@ pnpm format --write
 			files: {
 				".husky": {
 					".gitignore": "_\n",
-					"pre-commit": ["npx lint-staged\n", { executable: true }],
+					"pre-commit": ["pnpx lint-staged\n", { executable: true }],
 				},
 				".prettierignore": formatIgnoreFile(
 					["/.husky", "/lib", "/pnpm-lock.yaml", ...ignores].sort(),


### PR DESCRIPTION
Defaulting to npx causes users to unexpectedly also have npx installed. It caused my commit staging to break.

<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Simply replaces the `npx lint-staged` command to use `pnpx lint-staged`.

Please, let me know if I need to scale back my changes. I am trying to keep this PR minimal and just get the project working. It was not yet working for me with this dev environment:

```nix
{ ... }: {
  languages.javascript = {
    enable = true;
    # I should not have to enable `npm`, we use `pnpm` in this house!
    # npm.enable = true;
    pnpm.enable = true;
  };
}
```

I have a follow-up PR here:
https://github.com/JoshuaKGoldberg/create-typescript-app/pull/1976
It goes "full-pnpx" because I don't think we should expect users to have both `npx` and `pnpx` installed. `pnpx` in my experience is also way faster since it copies from global store, just like Nix :)))))

It also seems similar in spirit to this PR:
https://github.com/JoshuaKGoldberg/create-typescript-app/pull/1800

I am not sure why the "full-pnpx" move was not taken. Maybe I can learn why not, or just oversight.
<!-- Description of what is changed and how the code change does that. -->

🐢
