### PR TITLE
full pnpx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpx lint-staged

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First make sure you have the following installed:
 Then in an existing repository or in your directory where you'd like to make a new repository:
 
 ```shell
-npx create-typescript-app
+pnpx create-typescript-app
 ```
 
 You can read more about the supported runtime modes in their docs pages:
@@ -51,7 +51,7 @@ You can read more about `create-typescript-app` and the tooling it supports:
 2. [**Options**](./docs/Options.md): granular options to customize how the template is run.
 3. [**FAQs**](./docs/FAQs.md): frequently asked questions
 
-> [!NOTE]  
+> [!NOTE]
 > This template is early stage, opinionated, and not endorsed by the TypeScript team.
 > It can be configured to set up a _lot_ of tooling out of the box.
 > If you don't want to use any particular tool, you can always remove it manually.

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -93,7 +93,7 @@ Here we'll outline the steps required to migrate a CTA app to a GitHub Action:
    ```diff
    +pnpm run build
    +git add dist
-   npx lint-staged
+   pnpx lint-staged
    ```
 
 2. Create an [`action.yml` metadata file](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#creating-an-action-metadata-file).

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -3,7 +3,7 @@
 `create-typescript-app` is built on top of [Bingo](https://create.bingo).
 It supports all the flags supported by [Bingo CLIs](https://www.create.bingo/cli).
 
-`npx create-typescript-app` provides three `--preset` options:
+`pnpx create-typescript-app` provides three `--preset` options:
 
 1. **Minimal**: Just bare starter tooling: building, formatting, linting, and type checking.
 2. **Common**: Bare starters plus testing and automation for all-contributors and releases.
@@ -12,7 +12,7 @@ It supports all the flags supported by [Bingo CLIs](https://www.create.bingo/cli
 For example, to create a new repository with the _Everything_ preset:
 
 ```shell
-npx create-typescript-app --preset everything
+pnpx create-typescript-app --preset everything
 ```
 
 `create-typescript-app` itself adds in two sections of flags:
@@ -35,7 +35,7 @@ Each will be prompted for when creating a new repository if not explicitly provi
 For example, pre-populating all required base options:
 
 ```shell
-npx create-typescript-app --directory my-typescript-app --description "My awesome TypeScript app! 💖" --preset everything
+pnpx create-typescript-app --directory my-typescript-app --description "My awesome TypeScript app! 💖" --preset everything
 ```
 
 That script will run completely autonomously, no prompted inputs required. ✨
@@ -58,7 +58,7 @@ They will be inferred from the running user, and if migrating an existing reposi
 For example, customizing the npm author and funding source:
 
 ```shell
-npx create-typescript-app --author my-npm-username --funding MyGitHubOrganization
+pnpx create-typescript-app --author my-npm-username --funding MyGitHubOrganization
 ```
 
 ## Block Exclusions
@@ -67,7 +67,7 @@ Per [Bingo > Stratum > Configurations > `blocks`](https://www.create.bingo/engin
 For example, initializing with all tooling except for Renovate:
 
 ```shell
-npx create-typescript-app --exclude-renovate
+pnpx create-typescript-app --exclude-renovate
 ```
 
 See [Blocks.md](./Blocks.md) for the list of blocks and their corresponding presets.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -1,9 +1,9 @@
 # Setup Mode
 
-You can run `npx create-typescript-app` in your terminal to interactively create a new repository:
+You can run `pnpx create-typescript-app` in your terminal to interactively create a new repository:
 
 ```shell
-npx create-typescript-app
+pnpx create-typescript-app
 ```
 
 The setup script will by default:
@@ -34,7 +34,7 @@ See [Options.md](./Options.md).
 For example, skipping the _"This package was templated with..."_ block:
 
 ```shell
-npx create-typescript-app --mode create --exclude-templated-with
+pnpx create-typescript-app --mode create --exclude-templated-with
 ```
 
 See [Blocks.md](./Blocks.md) for details on the tooling pieces and which presets they're included in.

--- a/docs/Transition.md
+++ b/docs/Transition.md
@@ -1,9 +1,9 @@
 # Transition Mode
 
-If you have an existing repository that you'd like to migrate to the files from this template, you can run `npx create-typescript-app` in it to "migrate" its tooling to this template's.
+If you have an existing repository that you'd like to migrate to the files from this template, you can run `pnpx create-typescript-app` in it to "migrate" its tooling to this template's.
 
 ```shell
-npx create-typescript-app
+pnpx create-typescript-app
 ```
 
 The transition script will:
@@ -46,7 +46,7 @@ See [Options.md](./Options.md).
 For example, skipping the _"This package was templated with..."_ block:
 
 ```shell
-npx create-typescript-app --exclude-templated-with
+pnpx create-typescript-app --exclude-templated-with
 ```
 
 See [Blocks.md](./Blocks.md) for details on the tooling pieces and which presets they're included in.

--- a/docs/UseThisTemplate.md
+++ b/docs/UseThisTemplate.md
@@ -1,12 +1,12 @@
 # Using the Template Repository
 
-As an alternative to [creating with `npx create-typescript-app`](./Setup.md), the [_Use this template_](https://github.com/JoshuaKGoldberg/create-typescript-app/generate) button on GitHub can be used to quickly create a new repository from the template.
+As an alternative to [creating with `pnpx create-typescript-app`](./Setup.md), the [_Use this template_](https://github.com/JoshuaKGoldberg/create-typescript-app/generate) button on GitHub can be used to quickly create a new repository from the template.
 You can set up the new repository locally by cloning it and installing packages:
 
 ```shell
 git clone https://github.com/YourUsername/YourRepositoryName
 cd YourRepositoryName
-npx create-typescript-app
+pnpx create-typescript-app
 ```
 
 You'll then need to manually go through the following two steps to set up tooling on GitHub:
@@ -29,7 +29,7 @@ See [Options.md](./Options.md).
 For example, skipping the _"This package was templated with..."_ block:
 
 ```shell
-npx create-typescript-app --exclude-templated-with
+pnpx create-typescript-app --exclude-templated-with
 ```
 
 See [Blocks.md](./Blocks.md) for details on the tooling pieces and which presets they're included in.

--- a/src/blocks/blockAreTheTypesWrong.test.ts
+++ b/src/blocks/blockAreTheTypesWrong.test.ts
@@ -23,7 +23,7 @@ describe("blockAreTheTypesWrong", () => {
 			                "run": "pnpm build",
 			              },
 			              {
-			                "run": "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
+			                "run": "pnpx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
 			              },
 			            ],
 			          },

--- a/src/blocks/blockAreTheTypesWrong.ts
+++ b/src/blocks/blockAreTheTypesWrong.ts
@@ -15,7 +15,7 @@ export const blockAreTheTypesWrong = base.createBlock({
 							steps: [
 								{ run: "pnpm build" },
 								{
-									run: "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
+									run: "pnpx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
 								},
 							],
 						},

--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -91,7 +91,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,
@@ -203,7 +203,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,
@@ -333,7 +333,7 @@ describe("blockPrettier", () => {
 			      ".gitignore": "_
 			",
 			      "pre-commit": [
-			        "npx lint-staged
+			        "pnpx lint-staged
 			",
 			        {
 			          "executable": true,

--- a/src/blocks/blockPrettier.ts
+++ b/src/blocks/blockPrettier.ts
@@ -85,7 +85,7 @@ pnpm format --write
 			files: {
 				".husky": {
 					".gitignore": "_\n",
-					"pre-commit": ["npx lint-staged\n", { executable: true }],
+					"pre-commit": ["pnpx lint-staged\n", { executable: true }],
 				},
 				".prettierignore": formatIgnoreFile(
 					["/.husky", "/lib", "/pnpm-lock.yaml", ...ignores].sort(),


### PR DESCRIPTION
- **chore(npx): migrate to pnpx**

These edge cases cause users to have both npx and pnpx installed.
`pnpx` is faster and simplifies environment setup.

<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Follow up of https://github.com/JoshuaKGoldberg/create-typescript-app/pull/1975.

I am happy to break this down further or lump into previous.

🐢
