### PR TITLE
fix: use standard packages or link to issues for remaining code TODOs

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,7 +45,7 @@ Each defaults to a value based on the running system, including an repository if
 
 | Flag           | Type       | Description                                                                                                         | Default                                                                               |
 | -------------- | ---------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `--access`     | `string`   | Which [`npm publish --access`](https://docs.npmjs.com/cli/commands/npm-publish#access) to release npm packages with | `"public"` (TODO: file issue for `readAccess`)                                        |
+| `--access`     | `string`   | Which [`npm publish --access`](https://docs.npmjs.com/cli/commands/npm-publish#access) to release npm packages with | `"public"`                                                                            |
 | `--author`     | `string`   | Username on npm to publish packages under                                                                           | An existing npm author, or the currently logged in npm user, or `owner.toLowerCase()` |
 | `--bin`        | `string`   | Value to set in `package.json`'s `"bin"` property, per [FAQs > How can I use `bin`?](./FAQs.md#how-can-i-use-bin)   | _(none)_                                                                              |
 | `--email`      | `string`   | Email address to be listed as the point of contact in docs and packages (e.g. `example@joshuakgoldberg.com`)        | Yours from `gh`, `git config`, or `npm whoami`                                        |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"bingo-stratum": "^0.5.5",
 		"cspell-populate-words": "^0.3.0",
 		"execa": "^9.5.2",
-		"git-remote-origin-url": "^4.0.0",
 		"git-url-parse": "^16.0.1",
 		"github-default-labels": "^0.1.0",
 		"html-to-text": "^9.0.5",
@@ -60,9 +59,11 @@
 		"remove-dependencies": "^0.1.0",
 		"remove-undefined-objects": "^6.0.0",
 		"set-github-repository-labels": "^0.2.0",
+		"sort-keys": "^5.1.0",
 		"sort-package-json": "^3.0.0",
 		"title-case": "^4.3.2",
-		"zod": "^3.24.2"
+		"zod": "^3.24.2",
+		"zod-package-json": "^1.1.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.4.1",
@@ -77,7 +78,7 @@
 		"@types/node": "22.13.9",
 		"@types/parse-author": "2.0.3",
 		"@vitest/coverage-v8": "3.0.7",
-		"@vitest/eslint-plugin": "1.1.36",
+		"@vitest/eslint-plugin": "1.1.38",
 		"all-contributors-cli": "6.26.1",
 		"bingo-requests": "^0.5.4",
 		"bingo-stratum-testers": "0.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
-      git-remote-origin-url:
-        specifier: ^4.0.0
-        version: 4.0.0
       git-url-parse:
         specifier: ^16.0.1
         version: 16.0.1
@@ -77,6 +74,9 @@ importers:
       set-github-repository-labels:
         specifier: ^0.2.0
         version: 0.2.0
+      sort-keys:
+        specifier: ^5.1.0
+        version: 5.1.0
       sort-package-json:
         specifier: ^3.0.0
         version: 3.0.0
@@ -86,6 +86,9 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.24.2
+      zod-package-json:
+        specifier: ^1.1.0
+        version: 1.1.0
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.4.1
@@ -124,8 +127,8 @@ importers:
         specifier: 3.0.7
         version: 3.0.7(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))
       '@vitest/eslint-plugin':
-        specifier: 1.1.36
-        version: 1.1.36(@typescript-eslint/utils@8.26.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))
+        specifier: 1.1.38
+        version: 1.1.38(@typescript-eslint/utils@8.26.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))
       all-contributors-cli:
         specifier: 6.26.1
         version: 6.26.1
@@ -1449,8 +1452,8 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/eslint-plugin@1.1.36':
-    resolution: {integrity: sha512-IjBV/fcL9NJRxGw221ieaDsqKqj8qUo7rvSupDxMjTXyhsCusHC6M+jFUNqBp4PCkYFcf5bjrKxeZoCEWoPxig==}
+  '@vitest/eslint-plugin@1.1.38':
+    resolution: {integrity: sha512-KcOTZyVz8RiM5HyriiDVrP1CyBGuhRxle+lBsmSs6NTJEO/8dKVAq+f5vQzHj1/Kc7bYXSDO6yBe62Zx0t5iaw==}
     peerDependencies:
       '@typescript-eslint/utils': ^8.24.0
       eslint: '>= 8.57.0'
@@ -1479,8 +1482,8 @@ packages:
   '@vitest/pretty-format@3.0.7':
     resolution: {integrity: sha512-CiRY0BViD/V8uwuEzz9Yapyao+M9M008/9oMOSQydwbwb+CMokEq3XVaF3XK/VWaOK0Jm9z7ENhybg70Gtxsmg==}
 
-  '@vitest/pretty-format@3.0.8':
-    resolution: {integrity: sha512-BNqwbEyitFhzYMYHUVbIvepOyeQOSFA/NeJMIP9enMntkkxLgOcgABH6fjyXG85ipTgvero6noreavGIqfJcIg==}
+  '@vitest/pretty-format@3.0.9':
+    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
 
   '@vitest/runner@3.0.7':
     resolution: {integrity: sha512-WeEl38Z0S2ZcuRTeyYqaZtm4e26tq6ZFqh5y8YD9YxfWuu0OFiGFUbnxNynwLjNRHPsXyee2M9tV7YxOTPZl2g==}
@@ -2464,10 +2467,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  git-remote-origin-url@4.0.0:
-    resolution: {integrity: sha512-EAxDksNdjuWgmVW9pVvA9jQDi/dmTaiDONktIy7qiRRhBZUI4FQK1YvBvteuTSX24aNKg9lfgxNYJEeeSXe6DA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   git-semver-tags@8.0.0:
     resolution: {integrity: sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==}
     engines: {node: '>=18'}
@@ -2481,9 +2480,6 @@ packages:
 
   git-url-parse@16.0.1:
     resolution: {integrity: sha512-mcD36GrhAzX5JVOsIO52qNpgRyFzYWRbU1VSRFCvJt1IJvqfvH427wWw/CFqkWvjVPtdG5VTx4MKUeC5GeFPDQ==}
-
-  gitconfiglocal@2.1.0:
-    resolution: {integrity: sha512-qoerOEliJn3z+Zyn1HW2F6eoYJqKwS6MgC9cztTLUB/xLWX8gD/6T60pKn4+t/d6tP7JlybI7Z3z+I572CR/Vg==}
 
   github-default-labels@0.1.0:
     resolution: {integrity: sha512-vFpUWrpPKKrtL8AA9RPdsS6JDfQW+YjlVUhYvb8/et8wZUHC+L6OsJ+A8TyaqzT86wvbZxnDkw/BNGJzoz47cQ==}
@@ -4300,6 +4296,10 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  zod-package-json@1.1.0:
+    resolution: {integrity: sha512-RvEsa3W/NCqEBMtnoE09GRVelA3IqRcKaijEiM6CEGsD19qLurf0HjrYMHwOqImOszlLL0ja63DPJeeU4pm7oQ==}
+    engines: {node: '>=20'}
+
   zod-validation-error@3.4.0:
     resolution: {integrity: sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==}
     engines: {node: '>=18.0.0'}
@@ -5439,7 +5439,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.1.36(@typescript-eslint/utils@8.26.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))':
+  '@vitest/eslint-plugin@1.1.38(@typescript-eslint/utils@8.26.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2))(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)(vitest@3.0.7(@types/debug@4.1.12)(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@typescript-eslint/utils': 8.26.1(eslint@9.21.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.21.0(jiti@2.4.2)
@@ -5466,7 +5466,7 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/pretty-format@3.0.8':
+  '@vitest/pretty-format@3.0.9':
     dependencies:
       tinyrainbow: 2.0.0
 
@@ -6611,10 +6611,6 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  git-remote-origin-url@4.0.0:
-    dependencies:
-      gitconfiglocal: 2.1.0
-
   git-semver-tags@8.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0):
     dependencies:
       '@conventional-changelog/git-client': 1.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)
@@ -6635,10 +6631,6 @@ snapshots:
   git-url-parse@16.0.1:
     dependencies:
       git-up: 8.0.1
-
-  gitconfiglocal@2.1.0:
-    dependencies:
-      ini: 1.3.8
 
   github-default-labels@0.1.0: {}
 
@@ -8415,7 +8407,7 @@ snapshots:
     dependencies:
       '@vitest/expect': 3.0.7
       '@vitest/mocker': 3.0.7(vite@6.2.1(@types/node@22.13.9)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.8
+      '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
       '@vitest/spy': 3.0.7
@@ -8578,6 +8570,10 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.1: {}
+
+  zod-package-json@1.1.0:
+    dependencies:
+      zod: 3.24.2
 
   zod-validation-error@3.4.0(zod@3.24.2):
     dependencies:

--- a/src/base.ts
+++ b/src/base.ts
@@ -78,6 +78,7 @@ export const base = createBase({
 				}),
 			])
 			// TODO: Test this? Is it still working?
+			// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1991
 			.transform((email) =>
 				typeof email === "string" ? { github: email, npm: email } : email,
 			)
@@ -220,7 +221,7 @@ export const base = createBase({
 
 		const getFunding = lazyValue(async () => await readFunding(take));
 
-		const getGitDefaults = lazyValue(async () => await readGitDefaults());
+		const getGitDefaults = lazyValue(async () => await readGitDefaults(take));
 
 		const getGuide = lazyValue(async () => await readGuide(take));
 

--- a/src/blocks/blockESLint.ts
+++ b/src/blocks/blockESLint.ts
@@ -1,10 +1,10 @@
 // @ts-expect-error -- https://github.com/egoist/parse-package-name/issues/30
 import { parse as parsePackageName } from "parse-package-name";
+import sortKeys from "sort-keys";
 import { z } from "zod";
 
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
-import { sortObject } from "../utils/sortObject.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
@@ -243,7 +243,7 @@ function printExtension(extension: z.infer<typeof zExtension>) {
 			`linterOptions: ${JSON.stringify(extension.linterOptions)}`,
 		extension.rules && `rules: ${printExtensionRules(extension.rules)},`,
 		extension.settings &&
-			`settings: ${JSON.stringify(sortObject(extension.settings))},`,
+			`settings: ${JSON.stringify(sortKeys(extension.settings))},`,
 		"}",
 	]
 		.filter(Boolean)

--- a/src/blocks/blockExampleFiles.ts
+++ b/src/blocks/blockExampleFiles.ts
@@ -16,8 +16,8 @@ export const blockExampleFiles = base.createBlock({
 			},
 		};
 	},
-	// TODO: Make produce() optional
-	// This needs createBlock to be generic to know if block.produce({}) is ok
+	// TODO: Make produce() optional, so this empty-ish produce() can be removed
+	// https://github.com/JoshuaKGoldberg/bingo/issues/295
 	produce() {
 		return {};
 	},

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -2,6 +2,7 @@ import * as htmlToText from "html-to-text";
 import removeUndefinedObjects from "remove-undefined-objects";
 import sortPackageJson from "sort-package-json";
 import { z } from "zod";
+import { PackageJson } from "zod-package-json";
 
 import { base } from "../base.js";
 import { CommandPhase } from "./phases.js";
@@ -12,19 +13,7 @@ export const blockPackageJson = base.createBlock({
 	},
 	addons: {
 		cleanupCommands: z.array(z.string()).default([]),
-		// TODO: Find a zod package for this?
-		properties: z
-			.intersection(
-				z.object({
-					dependencies: z.record(z.string(), z.string()).optional(),
-					devDependencies: z.record(z.string(), z.string()).optional(),
-					files: z.array(z.string()).optional(),
-					peerDependencies: z.record(z.string(), z.string()).optional(),
-					scripts: z.record(z.string(), z.string()).optional(),
-				}),
-				z.record(z.string(), z.unknown()),
-			)
-			.default({}),
+		properties: PackageJson.partial().default({}),
 	},
 	produce({ addons, offline, options }) {
 		const dependencies = {

--- a/src/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.ts
@@ -49,8 +49,8 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 			],
 		};
 	},
-	// TODO: Make produce() optional
-	// This needs createBlock to be generic to know if block.produce({}) is ok
+	// TODO: Make produce() optional, so this empty-ish produce() can be removed
+	// https://github.com/JoshuaKGoldberg/bingo/issues/295
 	produce() {
 		return {};
 	},

--- a/src/blocks/blockVSCode.ts
+++ b/src/blocks/blockVSCode.ts
@@ -1,7 +1,7 @@
+import sortKeys from "sort-keys";
 import { z } from "zod";
 
 import { base } from "../base.js";
-import { sortObject } from "../utils/sortObject.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 
 export const blockVSCode = base.createBlock({
@@ -83,7 +83,7 @@ To launch it, open a test file, then run _Debug Current Test File_ from the VS C
 							version: "0.2.0",
 						}),
 					"settings.json": JSON.stringify(
-						sortObject({
+						sortKeys({
 							"editor.formatOnSave": true,
 							"editor.rulers": [80],
 							...settings,

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -170,7 +170,7 @@ describe("blockVitest", () => {
 			        "properties": {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "3.0.7",
-			            "@vitest/eslint-plugin": "1.1.36",
+			            "@vitest/eslint-plugin": "1.1.38",
 			            "console-fail-test": "0.5.0",
 			            "vitest": "3.0.7",
 			          },
@@ -408,7 +408,7 @@ describe("blockVitest", () => {
 			        "properties": {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "3.0.7",
-			            "@vitest/eslint-plugin": "1.1.36",
+			            "@vitest/eslint-plugin": "1.1.38",
 			            "console-fail-test": "0.5.0",
 			            "vitest": "3.0.7",
 			          },
@@ -667,7 +667,7 @@ describe("blockVitest", () => {
 			        "properties": {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "3.0.7",
-			            "@vitest/eslint-plugin": "1.1.36",
+			            "@vitest/eslint-plugin": "1.1.38",
 			            "console-fail-test": "0.5.0",
 			            "vitest": "3.0.7",
 			          },

--- a/src/docsBlocks.test.ts
+++ b/src/docsBlocks.test.ts
@@ -29,9 +29,6 @@ describe("docs/Blocks.md", () => {
 			continue;
 		}
 
-		// TODO: Enable vitest/eslint-plugin type-checking:
-		// https://github.com/vitest-dev/eslint-plugin-vitest?tab=readme-ov-file#enabling-with-type-testing
-		// eslint-disable-next-line vitest/valid-title
 		test(name, () => {
 			const actualLine = actualLines.find((line) => line.includes(`| ${name}`));
 			const expectedLine = expectedLines[i];

--- a/src/inputs/inputFromOctokit.ts
+++ b/src/inputs/inputFromOctokit.ts
@@ -7,8 +7,7 @@ export const inputFromOctokit = createInput({
 		options: z.record(z.string(), z.unknown()).optional(),
 	},
 	// TODO: Strongly type this, then push it upstream to Bingo
-	// This will require smart types around GitHub endpoints, similar to:
-	// https://github.com/JoshuaKGoldberg/bingo/issues/65
+	// https://github.com/JoshuaKGoldberg/bingo/issues/296
 	async produce({ args, fetchers }): Promise<unknown> {
 		try {
 			const response = await fetchers.octokit.request(args.endpoint, {

--- a/src/options/readGitDefaults.test.ts
+++ b/src/options/readGitDefaults.test.ts
@@ -11,20 +11,20 @@ vi.mock("git-remote-origin-url", () => ({
 }));
 
 describe(readGitDefaults, () => {
-	it("resolves undefined when fetching the origin url rejects", async () => {
-		mockGitRemoteOriginUrl.mockRejectedValueOnce(new Error("Oh no!"));
+	it("resolves undefined when get-url origin has no stdout", async () => {
+		const take = vi.fn().mockResolvedValueOnce({});
 
-		const actual = await readGitDefaults();
+		const actual = await readGitDefaults(take);
 
 		expect(actual).toBeUndefined();
 	});
 
-	it("resolves the parsed when fetching the origin url succeeds", async () => {
-		mockGitRemoteOriginUrl.mockResolvedValueOnce(
-			"git@github.com/JoshuaKGoldberg/create-typescript-app",
-		);
+	it("resolves the parsed url when get-url origin url succeeds", async () => {
+		const take = vi.fn().mockResolvedValueOnce({
+			stdout: "https://github.com/JoshuaKGoldberg/create-typescript-app.git",
+		});
 
-		const actual = await readGitDefaults();
+		const actual = await readGitDefaults(take);
 
 		expect(actual).toMatchObject({
 			name: "create-typescript-app",

--- a/src/options/readGitDefaults.ts
+++ b/src/options/readGitDefaults.ts
@@ -1,13 +1,11 @@
-import gitRemoteOriginUrl from "git-remote-origin-url";
+import { TakeInput } from "bingo";
 import gitUrlParse from "git-url-parse";
+import { inputFromScript } from "input-from-script";
 
-// TODO: gitRemoteOriginUrl does not go through take(input*), making it harder to test.
-// The next refactor here should add an input.
+export async function readGitDefaults(take: TakeInput) {
+	const url = await take(inputFromScript, {
+		command: "git remote get-url origin",
+	});
 
-export async function readGitDefaults() {
-	try {
-		return gitUrlParse(await gitRemoteOriginUrl());
-	} catch {
-		return undefined;
-	}
+	return url.stdout ? gitUrlParse(url.stdout.toString()) : undefined;
 }

--- a/src/options/readLogoSizing.ts
+++ b/src/options/readLogoSizing.ts
@@ -10,8 +10,6 @@ export interface OptionsLogoSizing {
 export function readLogoSizing(
 	src: string | Uint8Array,
 ): OptionsLogoSizing | undefined {
-	// TODO: create an input that provides the buffer data itself...
-	// ...which likely will need changes in bingo-fs/bingo-systems.
 	const size = imageSizeSafe(src);
 	if (!size) {
 		return undefined;
@@ -36,6 +34,9 @@ export function readLogoSizing(
 
 function imageSizeSafe(src: string | Uint8Array) {
 	try {
+		// TODO: imageSize does not go through take(input*), making it harder to test.
+		// It takes either a string (fs access) or buffer data (not in bingo-fs).
+		// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1993
 		return imageSize(src);
 	} catch {
 		return undefined;

--- a/src/options/readNpmDefaults.ts
+++ b/src/options/readNpmDefaults.ts
@@ -4,8 +4,7 @@ import npmUser from "npm-user";
 import { swallowErrorAsync } from "../utils/swallowErrorAsync.js";
 
 // TODO: npmUser does not go through take(input*), making it harder to test.
-// The next refactor here should add an input.
-
+// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1990
 export async function readNpmDefaults(
 	getNpmWhoami: () => Promise<ExecaError | Result | undefined>,
 ) {

--- a/src/utils/resolveBin.ts
+++ b/src/utils/resolveBin.ts
@@ -1,5 +1,5 @@
 // TODO: try to see if we can avoid this altogether...
-// ...or failing that, create a package
+// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1992
 export function resolveBin(bin: string) {
 	// This can't be tested yet in Vitest :(
 	// https://github.com/vitest-dev/vitest/issues/6953

--- a/src/utils/sortObject.ts
+++ b/src/utils/sortObject.ts
@@ -1,6 +1,0 @@
-// TODO: move to npm package?
-export function sortObject(value: object | Record<string, unknown>) {
-	return Object.fromEntries(
-		Object.entries(value).sort(([a], [b]) => a.localeCompare(b)),
-	);
-}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1987
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Cleans up some pending code TODOs:

* Bumping `@vitest/eslint-plugin` to include https://github.com/vitest-dev/eslint-plugin-vitest/pull/682
* Refactors `retGitDefaults` to execute a straightforward `git remote get-url origin` instead of the full `git-remote-origin-url`
* Uses [`sort-keys`](http://npmjs.com/package/sort-keys) instead of the ad-hoc internal `sortKeys`
* Uses [`zod-package-json`](http://npmjs.com/package/zod-package-json) instead of a manually written schema

Otherwise doesn't change behavior, instead adding links to:

* #1990
* #1991
* #1992
* #1993

🎁 