### PR TITLE
fix: preserve GitHub Actions hashes and versions

### DIFF
--- a/docs/Configuration Files.md
+++ b/docs/Configuration Files.md
@@ -19,18 +19,19 @@ This includes the options described in [CLI](./CLI.md).
 Some of create-typescript-app's options are rich objects, typically very long strings, or otherwise not reasonable on the CLI.
 These options are generally only programmatically used internally, but can still be specified in a configuration file:
 
-| Option           | Description                                                              | Default (If Available)                                    |
-| ---------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
-| `contributors`   | AllContributors contributors to store in `.all-contributorsrc`           | Existing contributors in the file, or just your username  |
-| `documentation`  | any additional docs to add to `.github/DEVELOPMENT.md`                   | Extra content in `.github/DEVELOPMENT.md`                 |
-| `existingLabels` | existing labels to switch to the standard template labels                | Existing labels on the repository from the GitHub API     |
-| `explainer`      | additional `README.md` sentence(s) describing the package                | Extra content in `README.md` after badges and description |
-| `guide`          | link to a contribution guide to place at the top of development docs     | Block quote on top of `.github/DEVELOPMENT.md`            |
-| `logo`           | local image file and alt text to display near the top of the `README.md` | First non-badge image's `alt` and `src` in `README.md`    |
-| `node`           | Node.js engine version(s) to pin and require a minimum of                | Values from `.nvmrc` and `package.json`'s `"engines"`     |
-| `packageData`    | additional properties to include in `package.json`                       | Existing values in `package.json`                         |
-| `rulesetId`      | GitHub branch ruleset ID for main branch protections                     | Existing ruleset on the `main` branch from the GitHub API |
-| `usage`          | Markdown docs to put in `README.md` under the `## Usage` heading         | Existing usage lines in `README.md`                       |
+| Option              | Description                                                              | Default (If Available)                                    |
+| ------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `contributors`      | AllContributors contributors to store in `.all-contributorsrc`           | Existing contributors in the file, or just your username  |
+| `documentation`     | any additional docs to add to `.github/DEVELOPMENT.md`                   | Extra content in `.github/DEVELOPMENT.md`                 |
+| `existingLabels`    | existing labels to switch to the standard template labels                | Existing labels on the repository from the GitHub API     |
+| `explainer`         | additional `README.md` sentence(s) describing the package                | Extra content in `README.md` after badges and description |
+| `guide`             | link to a contribution guide to place at the top of development docs     | Block quote on top of `.github/DEVELOPMENT.md`            |
+| `logo`              | local image file and alt text to display near the top of the `README.md` | First non-badge image's `alt` and `src` in `README.md`    |
+| `node`              | Node.js engine version(s) to pin and require a minimum of                | Values from `.nvmrc` and `package.json`'s `"engines"`     |
+| `packageData`       | additional properties to include in `package.json`                       | Existing values in `package.json`                         |
+| `rulesetId`         | GitHub branch ruleset ID for main branch protections                     | Existing ruleset on the `main` branch from the GitHub API |
+| `usage`             | Markdown docs to put in `README.md` under the `## Usage` heading         | Existing usage lines in `README.md`                       |
+| `workflowsVersions` | existing versions of GitHub Actions workflows used                       | Existing action versions in `.github/workflows/*.yml`     |
 
 For example, changing `node` versions to values different from what would be inferred:
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"bingo": "^0.5.8",
 		"bingo-fs": "^0.5.4",
 		"bingo-stratum": "^0.5.7",
+		"cached-factory": "^0.1.0",
 		"cspell-populate-words": "^0.3.0",
 		"execa": "^9.5.2",
 		"git-url-parse": "^16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       bingo-stratum:
         specifier: ^0.5.7
         version: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2)
+      cached-factory:
+        specifier: ^0.1.0
+        version: 0.1.0
       cspell-populate-words:
         specifier: ^0.3.0
         version: 0.3.0

--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -53,6 +53,7 @@ describe("base", () => {
 			title: "Create TypeScript App",
 			usage: expect.any(String),
 			version: expect.any(String),
+			workflowsVersions: expect.any(Object),
 		});
 	});
 });

--- a/src/base.ts
+++ b/src/base.ts
@@ -31,16 +31,8 @@ import { readRepository } from "./options/readRepository.js";
 import { readRulesetId } from "./options/readRulesetId.js";
 import { readTitle } from "./options/readTitle.js";
 import { readUsage } from "./options/readUsage.js";
-
-const zContributor = z.object({
-	avatar_url: z.string(),
-	contributions: z.array(z.string()),
-	login: z.string(),
-	name: z.string(),
-	profile: z.string(),
-});
-
-export type Contributor = z.infer<typeof zContributor>;
+import { readWorkflowsVersions } from "./options/readWorkflowsVersions.js";
+import { zContributor, zWorkflowsVersions } from "./schemas.js";
 
 export const base = createBase({
 	options: {
@@ -166,6 +158,9 @@ export const base = createBase({
 			.string()
 			.optional()
 			.describe("package version to publish as and store in `package.json`"),
+		workflowsVersions: zWorkflowsVersions
+			.optional()
+			.describe("existing versions of GitHub Actions workflows used"),
 	},
 	prepare({ options, take }) {
 		const getAccess = lazyValue(async () => await readAccess(getPackageData));
@@ -278,6 +273,10 @@ export const base = createBase({
 
 		const getVersion = lazyValue(async () => (await getPackageData()).version);
 
+		const getWorkflowData = lazyValue(
+			async () => await readWorkflowsVersions(take),
+		);
+
 		return {
 			access: getAccess,
 			author: getAuthor,
@@ -301,6 +300,7 @@ export const base = createBase({
 			title: getTitle,
 			usage: getUsage,
 			version: getVersion,
+			workflowsVersions: getWorkflowData,
 		};
 	},
 });

--- a/src/blocks/actions/printUses.ts
+++ b/src/blocks/actions/printUses.ts
@@ -1,0 +1,36 @@
+import { CachedFactory } from "cached-factory";
+import semver from "semver";
+
+import { WorkflowsVersions } from "../../schemas.js";
+
+const coerced = new CachedFactory((version: string) => {
+	if (!semver.valid(version)) {
+		return "0.0.0";
+	}
+
+	return semver.coerce(version)?.raw ?? version;
+});
+
+export function printUses(
+	action: string,
+	version: string,
+	workflowsVersions?: WorkflowsVersions,
+) {
+	if (!workflowsVersions || !(action in workflowsVersions)) {
+		return `${action}@${version}`;
+	}
+	const workflowVersions = workflowsVersions[action];
+
+	const biggestVersion = Object.keys(workflowVersions).reduce(
+		(highestVersion, potentialVersion) =>
+			semver.gt(coerced.get(potentialVersion), coerced.get(highestVersion))
+				? potentialVersion
+				: highestVersion,
+		version,
+	);
+	const atBiggestVersion = workflowVersions[biggestVersion];
+
+	return atBiggestVersion.hash
+		? `${action}@${atBiggestVersion.hash} # ${biggestVersion}`
+		: `${action}@${biggestVersion}`;
+}

--- a/src/blocks/actions/resolveUses.test.ts
+++ b/src/blocks/actions/resolveUses.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import { resolveUses } from "./resolveUses.js";
 
 describe(resolveUses, () => {

--- a/src/blocks/actions/resolveUses.test.ts
+++ b/src/blocks/actions/resolveUses.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { resolveUses } from "./resolveUses.js";
+
+describe(resolveUses, () => {
+	it("returns action@version when workflowsVersions is undefined", () => {
+		const actual = resolveUses("test-action", "v1.2.3");
+
+		expect(actual).toBe("test-action@v1.2.3");
+	});
+
+	it("returns action@version when workflowsVersions does not contain the action", () => {
+		const actual = resolveUses("test-action", "v1.2.3", { other: {} });
+
+		expect(actual).toBe("test-action@v1.2.3");
+	});
+
+	it("uses the provided version when it is greater than all the action versions in workflowsVersions", () => {
+		const actual = resolveUses("test-action", "v1.2.3", {
+			"test-action": {
+				"v0.1.2": {
+					pinned: true,
+				},
+				"v1.1.4": {
+					pinned: true,
+				},
+			},
+		});
+
+		expect(actual).toBe("test-action@v1.2.3");
+	});
+
+	it("prefers a provided valid semver version when an action also has a non-semver tag", () => {
+		const actual = resolveUses("test-action", "v1.2.3", {
+			"test-action": {
+				main: {
+					pinned: true,
+				},
+			},
+		});
+
+		expect(actual).toBe("test-action@v1.2.3");
+	});
+
+	it("prefers an action's semver tag when the provided version is a non-semver tag", () => {
+		const actual = resolveUses("test-action", "main", {
+			"test-action": {
+				"v1.2.3": {
+					pinned: true,
+				},
+			},
+		});
+
+		expect(actual).toBe("test-action@v1.2.3");
+	});
+
+	it("uses the greatest version when the provided version is not bigger than all the action versions in workflowsVersions", () => {
+		const actual = resolveUses("test-action", "v1.2.3", {
+			"test-action": {
+				"v0.1.2": {
+					pinned: true,
+				},
+				"v1.3.5": {
+					pinned: true,
+				},
+			},
+		});
+
+		expect(actual).toBe("test-action@v1.3.5");
+	});
+
+	it("uses a pinned hash when the greatest version contains a hash", () => {
+		const actual = resolveUses("test-action", "v1.2.3", {
+			"test-action": {
+				"v0.1.2": {
+					pinned: true,
+				},
+				"v1.3.5": {
+					hash: "abc",
+					pinned: true,
+				},
+			},
+		});
+
+		expect(actual).toBe("test-action@abc # v1.3.5");
+	});
+});

--- a/src/blocks/blockAllContributors.ts
+++ b/src/blocks/blockAllContributors.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import { base } from "../base.js";
 import { ownerContributions } from "../data/contributions.js";
 import { Contributor } from "../schemas.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { blockPrettier } from "./blockPrettier.js";
 import { blockREADME } from "./blockREADME.js";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
@@ -62,7 +62,7 @@ export const blockAllContributors = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"actions/checkout",
 										"v4",
 										options.workflowsVersions,
@@ -72,7 +72,7 @@ export const blockAllContributors = base.createBlock({
 								{ uses: "./.github/actions/prepare" },
 								{
 									env: { GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}" },
-									uses: printUses(
+									uses: resolveUses(
 										"JoshuaKGoldberg/all-contributors-auto-action",
 										"v0.5.0",
 										options.workflowsVersions,

--- a/src/blocks/blockAllContributors.ts
+++ b/src/blocks/blockAllContributors.ts
@@ -1,7 +1,9 @@
 import _ from "lodash";
 
-import { base, Contributor } from "../base.js";
+import { base } from "../base.js";
 import { ownerContributions } from "../data/contributions.js";
+import { Contributor } from "../schemas.js";
+import { printUses } from "./actions/printUses.js";
 import { blockPrettier } from "./blockPrettier.js";
 import { blockREADME } from "./blockREADME.js";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
@@ -59,11 +61,22 @@ export const blockAllContributors = base.createBlock({
 								},
 							},
 							steps: [
-								{ uses: "actions/checkout@v4", with: { "fetch-depth": 0 } },
+								{
+									uses: printUses(
+										"actions/checkout",
+										"v4",
+										options.workflowsVersions,
+									),
+									with: { "fetch-depth": 0 },
+								},
 								{ uses: "./.github/actions/prepare" },
 								{
 									env: { GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}" },
-									uses: `JoshuaKGoldberg/all-contributors-auto-action@v0.5.0`,
+									uses: printUses(
+										"JoshuaKGoldberg/all-contributors-auto-action",
+										"v0.5.0",
+										options.workflowsVersions,
+									),
 								},
 							],
 						}),

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -1,6 +1,6 @@
 import { base } from "../base.js";
 import { packageData } from "../data/packageData.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 
@@ -26,7 +26,7 @@ export const blockCTATransitions = base.createBlock({
 							steps: [
 								{ run: "pnpx create-typescript-app" },
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"stefanzweifel/git-auto-commit-action",
 										"v5",
 										options.workflowsVersions,
@@ -40,7 +40,7 @@ export const blockCTATransitions = base.createBlock({
 									},
 								},
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"mshick/add-pr-comment",
 										"v2",
 										options.workflowsVersions,

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -1,5 +1,6 @@
 import { base } from "../base.js";
 import { packageData } from "../data/packageData.js";
+import { printUses } from "./actions/printUses.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 
@@ -7,7 +8,7 @@ export const blockCTATransitions = base.createBlock({
 	about: {
 		name: "CTA Transitions",
 	},
-	produce() {
+	produce({ options }) {
 		return {
 			addons: [
 				blockGitHubActionsCI({
@@ -25,7 +26,11 @@ export const blockCTATransitions = base.createBlock({
 							steps: [
 								{ run: "pnpx create-typescript-app" },
 								{
-									uses: "stefanzweifel/git-auto-commit-action@v5",
+									uses: printUses(
+										"stefanzweifel/git-auto-commit-action",
+										"v5",
+										options.workflowsVersions,
+									),
 									with: {
 										commit_author: "The Friendly Bingo Bot <bot@create.bingo>",
 										commit_message:
@@ -35,7 +40,11 @@ export const blockCTATransitions = base.createBlock({
 									},
 								},
 								{
-									uses: "mshick/add-pr-comment@v2",
+									uses: printUses(
+										"mshick/add-pr-comment",
+										"v2",
+										options.workflowsVersions,
+									),
 									with: {
 										issue: "${{ github.event.pull_request.number }}",
 										message: [

--- a/src/blocks/blockCodecov.ts
+++ b/src/blocks/blockCodecov.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { base } from "../base.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { blockGitHubApps } from "./blockGitHubApps.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockVitest } from "./blockVitest.js";
@@ -28,7 +28,7 @@ export const blockCodecov = base.createBlock({
 						{
 							...(env && { env }),
 							if: "always()",
-							uses: printUses(
+							uses: resolveUses(
 								"codecov/codecov-action",
 								"v3",
 								options.workflowsVersions,

--- a/src/blocks/blockCodecov.ts
+++ b/src/blocks/blockCodecov.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { base } from "../base.js";
+import { printUses } from "./actions/printUses.js";
 import { blockGitHubApps } from "./blockGitHubApps.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockVitest } from "./blockVitest.js";
@@ -10,7 +11,7 @@ export const blockCodecov = base.createBlock({
 		name: "Codecov",
 	},
 	addons: { env: z.record(z.string(), z.string()).optional() },
-	produce({ addons }) {
+	produce({ addons, options }) {
 		const { env } = addons;
 		return {
 			addons: [
@@ -27,7 +28,11 @@ export const blockCodecov = base.createBlock({
 						{
 							...(env && { env }),
 							if: "always()",
-							uses: "codecov/codecov-action@v3",
+							uses: printUses(
+								"codecov/codecov-action",
+								"v3",
+								options.workflowsVersions,
+							),
 						},
 					],
 				}),

--- a/src/blocks/blockGitHubActionsCI.ts
+++ b/src/blocks/blockGitHubActionsCI.ts
@@ -2,12 +2,12 @@ import jsYaml from "js-yaml";
 import { z } from "zod";
 
 import { base } from "../base.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { createMultiWorkflowFile } from "./files/createMultiWorkflowFile.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
-import { removeUsesQuotes } from "./files/formatYaml.js";
+import { removeUsesQuotes } from "./files/removeUsesQuotes.js";
 
 export const zActionStep = z.intersection(
 	z.object({
@@ -56,14 +56,14 @@ export const blockGitHubActionsCI = base.createBlock({
 										runs: {
 											steps: [
 												{
-													uses: printUses(
+													uses: resolveUses(
 														"pnpm/action-setup",
 														"v4",
 														options.workflowsVersions,
 													),
 												},
 												{
-													uses: printUses(
+													uses: resolveUses(
 														"actions/setup-node",
 														"v4",
 														options.workflowsVersions,
@@ -103,7 +103,7 @@ export const blockGitHubActionsCI = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"github/accessibility-alt-text-bot",
 										"v1.4.0",
 										options.workflowsVersions,
@@ -130,7 +130,7 @@ export const blockGitHubActionsCI = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"actions-ecosystem/action-remove-labels",
 										"v1",
 										options.workflowsVersions,

--- a/src/blocks/blockPRCompliance.ts
+++ b/src/blocks/blockPRCompliance.ts
@@ -1,11 +1,12 @@
 import { base } from "../base.js";
+import { printUses } from "./actions/printUses.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
 
 export const blockPRCompliance = base.createBlock({
 	about: {
 		name: "PR Compliance",
 	},
-	produce() {
+	produce({ options }) {
 		return {
 			files: {
 				".github": {
@@ -23,7 +24,11 @@ export const blockPRCompliance = base.createBlock({
 							},
 							steps: [
 								{
-									uses: "mtfoley/pr-compliance-action@main",
+									uses: printUses(
+										"mtfoley/pr-compliance-action",
+										"main",
+										options.workflowsVersions,
+									),
 									with: {
 										"body-auto-close": false,
 										"ignore-authors": [

--- a/src/blocks/blockPRCompliance.ts
+++ b/src/blocks/blockPRCompliance.ts
@@ -1,5 +1,5 @@
 import { base } from "../base.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
 
 export const blockPRCompliance = base.createBlock({
@@ -24,7 +24,7 @@ export const blockPRCompliance = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"mtfoley/pr-compliance-action",
 										"main",
 										options.workflowsVersions,

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -1,5 +1,6 @@
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
+import { printUses } from "./actions/printUses.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRemoveDependencies } from "./blockRemoveDependencies.js";
@@ -61,12 +62,23 @@ export const blockReleaseIt = base.createBlock({
 								"pull-requests": "write",
 							},
 							steps: [
-								{ uses: "actions/checkout@v4", with: { "fetch-depth": 0 } },
+								{
+									uses: printUses(
+										"actions/checkout",
+										"v4",
+										options.workflowsVersions,
+									),
+									with: { "fetch-depth": 0 },
+								},
 								{
 									run: `echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"`,
 								},
 								{
-									uses: "apexskier/github-release-commenter@v1",
+									uses: printUses(
+										"apexskier/github-release-commenter",
+										"v1",
+										options.workflowsVersions,
+									),
 									with: {
 										"comment-template": `
 							:tada: This is included in version {release_link} :tada:
@@ -99,7 +111,11 @@ export const blockReleaseIt = base.createBlock({
 							},
 							steps: [
 								{
-									uses: "actions/checkout@v4",
+									uses: printUses(
+										"actions/checkout",
+										"v4",
+										options.workflowsVersions,
+									),
 									with: {
 										"fetch-depth": 0,
 										ref: "main",
@@ -117,7 +133,11 @@ export const blockReleaseIt = base.createBlock({
 										GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}",
 										NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
 									},
-									uses: "JoshuaKGoldberg/release-it-action@v0.2.2",
+									uses: printUses(
+										"JoshuaKGoldberg/release-it-action",
+										"v0.2.2",
+										options.workflowsVersions,
+									),
 								},
 							],
 						}),

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -1,6 +1,6 @@
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
-import { printUses } from "./actions/printUses.js";
+import { resolveUses } from "./actions/resolveUses.js";
 import { blockCSpell } from "./blockCSpell.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRemoveDependencies } from "./blockRemoveDependencies.js";
@@ -63,7 +63,7 @@ export const blockReleaseIt = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"actions/checkout",
 										"v4",
 										options.workflowsVersions,
@@ -74,7 +74,7 @@ export const blockReleaseIt = base.createBlock({
 									run: `echo "npm_version=$(npm pkg get version | tr -d '"')" >> "$GITHUB_ENV"`,
 								},
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"apexskier/github-release-commenter",
 										"v1",
 										options.workflowsVersions,
@@ -111,7 +111,7 @@ export const blockReleaseIt = base.createBlock({
 							},
 							steps: [
 								{
-									uses: printUses(
+									uses: resolveUses(
 										"actions/checkout",
 										"v4",
 										options.workflowsVersions,
@@ -133,7 +133,7 @@ export const blockReleaseIt = base.createBlock({
 										GITHUB_TOKEN: "${{ secrets.ACCESS_TOKEN }}",
 										NPM_TOKEN: "${{ secrets.NPM_TOKEN }}",
 									},
-									uses: printUses(
+									uses: resolveUses(
 										"JoshuaKGoldberg/release-it-action",
 										"v0.2.2",
 										options.workflowsVersions,

--- a/src/blocks/files/createMultiWorkflowFile.ts
+++ b/src/blocks/files/createMultiWorkflowFile.ts
@@ -1,9 +1,12 @@
+import { WorkflowsVersions } from "../../schemas.js";
+import { printUses } from "../actions/printUses.js";
 import { createJobName } from "./createJobName.js";
 import { formatWorkflowYaml } from "./formatWorkflowYaml.js";
 
 export interface MultiWorkflowFileOptions {
 	jobs: MultiWorkflowJobOptions[];
 	name: string;
+	workflowsVersions: undefined | WorkflowsVersions;
 }
 
 export interface MultiWorkflowJobOptions {
@@ -21,6 +24,7 @@ export type MultiWorkflowJobStep = { if?: string } & (
 export function createMultiWorkflowFile({
 	jobs,
 	name,
+	workflowsVersions,
 }: MultiWorkflowFileOptions) {
 	return formatWorkflowYaml({
 		jobs: Object.fromEntries(
@@ -31,7 +35,10 @@ export function createMultiWorkflowFile({
 					name: job.name,
 					"runs-on": "ubuntu-latest",
 					steps: [
-						{ uses: "actions/checkout@v4", with: job.checkoutWith },
+						{
+							uses: printUses("actions/checkout", "v4", workflowsVersions),
+							with: job.checkoutWith,
+						},
 						{ uses: "./.github/actions/prepare" },
 						...job.steps,
 					],

--- a/src/blocks/files/createMultiWorkflowFile.ts
+++ b/src/blocks/files/createMultiWorkflowFile.ts
@@ -1,5 +1,5 @@
 import { WorkflowsVersions } from "../../schemas.js";
-import { printUses } from "../actions/printUses.js";
+import { resolveUses } from "../actions/resolveUses.js";
 import { createJobName } from "./createJobName.js";
 import { formatWorkflowYaml } from "./formatWorkflowYaml.js";
 
@@ -36,7 +36,7 @@ export function createMultiWorkflowFile({
 					"runs-on": "ubuntu-latest",
 					steps: [
 						{
-							uses: printUses("actions/checkout", "v4", workflowsVersions),
+							uses: resolveUses("actions/checkout", "v4", workflowsVersions),
 							with: job.checkoutWith,
 						},
 						{ uses: "./.github/actions/prepare" },

--- a/src/blocks/files/formatYaml.ts
+++ b/src/blocks/files/formatYaml.ts
@@ -21,5 +21,11 @@ const options: jsYaml.DumpOptions = {
 };
 
 export function formatYaml(value: unknown) {
-	return jsYaml.dump(value, options);
+	return removeUsesQuotes(jsYaml.dump(value, options));
+}
+
+export function removeUsesQuotes(original: string) {
+	return original.replaceAll(/ uses: '.+'/gu, (line) =>
+		line.replaceAll("'", ""),
+	);
 }

--- a/src/blocks/files/formatYaml.ts
+++ b/src/blocks/files/formatYaml.ts
@@ -1,5 +1,7 @@
 import jsYaml from "js-yaml";
 
+import { removeUsesQuotes } from "./removeUsesQuotes.js";
+
 const options: jsYaml.DumpOptions = {
 	lineWidth: -1,
 	noCompatMode: true,
@@ -22,10 +24,4 @@ const options: jsYaml.DumpOptions = {
 
 export function formatYaml(value: unknown) {
 	return removeUsesQuotes(jsYaml.dump(value, options));
-}
-
-export function removeUsesQuotes(original: string) {
-	return original.replaceAll(/ uses: '.+'/gu, (line) =>
-		line.replaceAll("'", ""),
-	);
 }

--- a/src/blocks/files/removeUsesQuotes.test.ts
+++ b/src/blocks/files/removeUsesQuotes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { removeUsesQuotes } from "./removeUsesQuotes.js";
+
+describe(removeUsesQuotes, () => {
+	test.each([
+		[""],
+		["run: pnpm run build"],
+		["- uses: actions/checkout@v4"],
+		["- uses: 'actions/checkout@v4'", "- uses: actions/checkout@v4"],
+		["- uses: actions/checkout@abc # v4"],
+		[
+			"- uses: 'actions/checkout@abc # v4'",
+			"- uses: actions/checkout@abc # v4",
+		],
+	])("%s", (input, expected = input) => {
+		expect(removeUsesQuotes(input)).toBe(expected);
+	});
+});

--- a/src/blocks/files/removeUsesQuotes.test.ts
+++ b/src/blocks/files/removeUsesQuotes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+
 import { removeUsesQuotes } from "./removeUsesQuotes.js";
 
 describe(removeUsesQuotes, () => {

--- a/src/blocks/files/removeUsesQuotes.ts
+++ b/src/blocks/files/removeUsesQuotes.ts
@@ -1,0 +1,5 @@
+export function removeUsesQuotes(original: string) {
+	return original.replaceAll(/ uses: '.+'/gu, (line) =>
+		line.replaceAll("'", ""),
+	);
+}

--- a/src/inputs/inputFromDirectory.ts
+++ b/src/inputs/inputFromDirectory.ts
@@ -1,0 +1,11 @@
+import { createInput } from "bingo";
+import { z } from "zod";
+
+export const inputFromDirectory = createInput({
+	args: {
+		directoryPath: z.string(),
+	},
+	async produce({ args, fs }) {
+		return await fs.readDirectory(args.directoryPath);
+	},
+});

--- a/src/options/readWorkflowsVersions.ts
+++ b/src/options/readWorkflowsVersions.ts
@@ -1,0 +1,70 @@
+import { TakeInput } from "bingo";
+import { inputFromFile } from "input-from-file";
+
+import { inputFromDirectory } from "../inputs/inputFromDirectory.js";
+import { WorkflowsVersions } from "../schemas.js";
+
+export async function readWorkflowsVersions(
+	take: TakeInput,
+): Promise<WorkflowsVersions> {
+	const collection: WorkflowsVersions = {};
+
+	const compositeNames = await take(inputFromDirectory, {
+		directoryPath: ".github/actions",
+	});
+
+	for (const compositeName of compositeNames) {
+		const compositeFileNames = await take(inputFromDirectory, {
+			directoryPath: `.github/actions/${compositeName}`,
+		});
+
+		for (const compositeFileName of compositeFileNames) {
+			await collectFile(
+				`.github/actions/${compositeName}/${compositeFileName}`,
+			);
+		}
+	}
+
+	const workflowFileNames = await take(inputFromDirectory, {
+		directoryPath: ".github/workflows",
+	});
+
+	await Promise.all(
+		workflowFileNames.map(async (workflowFileName) => {
+			await collectFile(`.github/workflows/${workflowFileName}`);
+		}),
+	);
+
+	async function collectFile(filePath: string) {
+		const raw = await take(inputFromFile, { filePath });
+		if (raw instanceof Error) {
+			return;
+		}
+
+		for (const match of raw.matchAll(/uses:\s*(\w.+)/g)) {
+			const [, uses] = match;
+			collectUses(uses);
+		}
+	}
+
+	function collectUses(uses: string) {
+		const matched = /([^#@]+)@([^ #]+)(?: # ([a-z\d.]+))?/.exec(uses);
+		if (!matched) {
+			return;
+		}
+
+		const [, action, actual, commented] = matched;
+
+		collection[action] ??= {};
+
+		if (commented) {
+			collection[action][commented] ??= {};
+			collection[action][commented].hash = actual;
+		} else {
+			collection[action][actual] ??= {};
+			collection[action][actual].pinned = true;
+		}
+	}
+
+	return collection;
+}

--- a/src/options/readWorkflowsVersions.ts
+++ b/src/options/readWorkflowsVersions.ts
@@ -10,6 +10,8 @@ export async function readWorkflowsVersions(
 	const workflowsVersions: WorkflowsVersions = {};
 
 	// TODO: This would be more straightforward if bingo-fs provided globbing...
+	// If you want to increase test coverage here, please do that first :)
+	// https://github.com/JoshuaKGoldberg/bingo/issues/308
 
 	async function collectCompositeUses() {
 		const compositeNames = await take(inputFromDirectory, {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const zContributor = z.object({
+	avatar_url: z.string(),
+	contributions: z.array(z.string()),
+	login: z.string(),
+	name: z.string(),
+	profile: z.string(),
+});
+
+export type Contributor = z.infer<typeof zContributor>;
+
+export const zWorkflowVersion = z.object({
+	hash: z.string().optional(),
+	pinned: z.boolean().optional(),
+});
+
+export type WorkflowVersion = z.infer<typeof zWorkflowVersion>;
+
+export const zWorkflowVersions = z.record(zWorkflowVersion);
+
+export type WorkflowVersions = z.infer<typeof zWorkflowVersions>;
+
+export const zWorkflowsVersions = z.record(zWorkflowVersions);
+
+export type WorkflowsVersions = z.infer<typeof zWorkflowsVersions>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1998
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a new `workflowsVersions` option that reads in any existing pins and comment hashes.

Printing out comment hashes is actually tricky: they're not part of the AST, so I had to add a post-processing step after YAMl printing to turn any `uses:` string ending with a `#` comment back from `uses: '... # ...'` to `uses: ... # ...`.

Skips adding tests for `readWorkflowVersions` pending https://github.com/JoshuaKGoldberg/bingo/issues/308.

🎁 
