### PR TITLE
fix: ignore known badges when reading logo

### DIFF
--- a/src/options/readLogo.test.ts
+++ b/src/options/readLogo.test.ts
@@ -24,6 +24,26 @@ describe(readLogo, () => {
 			expect(logo).toBeUndefined();
 		});
 
+		it("resolves undefined when the found image is an All Contributors badge", async () => {
+			const logo = await readLogo(() =>
+				Promise.resolve(
+					`\n<img alt="All Contributors: 1" src="https://img.shields.io/badge/all_contributors-1-21bb42.svg" />`,
+				),
+			);
+
+			expect(logo).toBeUndefined();
+		});
+
+		it("resolves undefined when the found image is a shields.io badge", async () => {
+			const logo = await readLogo(() =>
+				Promise.resolve(
+					`\n<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />`,
+				),
+			);
+
+			expect(logo).toBeUndefined();
+		});
+
 		it("parses when found in an unquoted string", async () => {
 			const logo = await readLogo(() =>
 				Promise.resolve(`

--- a/src/options/readLogo.ts
+++ b/src/options/readLogo.ts
@@ -7,19 +7,25 @@ export async function readLogo(getReadme: () => Promise<string>) {
 		return undefined;
 	}
 
+	const alt =
+		/alt=['"](.+)['"]\s*src=/.exec(tag)?.[1].split(/['"]?\s*\w+=/)[0] ??
+		"Project logo";
+
+	if (/All Contributors: \d+/.test(alt)) {
+		return undefined;
+	}
+
 	const src = /src\s*=(.+)['"/]>/
 		.exec(tag)?.[1]
 		?.split(/\s*\w+=/)[0]
 		.replaceAll(/^['"]|['"]$/g, "");
 
-	if (!src) {
+	if (!src || src.includes("//img.shields.io")) {
 		return undefined;
 	}
 
 	return {
-		alt:
-			/alt=['"](.+)['"]\s*src=/.exec(tag)?.[1].split(/['"]?\s*\w+=/)[0] ??
-			"Project logo",
+		alt,
 		src,
 		...readLogoSizing(src),
 	};


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2022
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Ignores:

* Alt text of `All Contributors: \d+`
* Source images from `img.shields.io`

🎁 