### PR TITLE
feat: remove legacy main branch protections in ruleset transition mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"all-contributors-cli": "6.26.1",
 		"bingo-requests": "0.5.5",
 		"bingo-stratum-testers": "0.5.6",
-		"bingo-testers": "0.5.6",
+		"bingo-testers": "0.5.7",
 		"console-fail-test": "0.5.0",
 		"cspell": "8.17.5",
 		"eslint": "9.22.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"bingo": "^0.5.8",
+		"bingo": "^0.5.10",
 		"bingo-fs": "^0.5.4",
 		"bingo-stratum": "^0.5.7",
 		"cached-factory": "^0.1.0",
@@ -84,7 +84,7 @@
 		"@vitest/coverage-v8": "3.0.9",
 		"@vitest/eslint-plugin": "1.1.38",
 		"all-contributors-cli": "6.26.1",
-		"bingo-requests": "0.5.4",
+		"bingo-requests": "0.5.5",
 		"bingo-stratum-testers": "0.5.6",
 		"bingo-testers": "0.5.6",
 		"console-fail-test": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"@vitest/eslint-plugin": "1.1.38",
 		"all-contributors-cli": "6.26.1",
 		"bingo-requests": "0.5.5",
-		"bingo-stratum-testers": "0.5.6",
+		"bingo-stratum-testers": "0.5.7",
 		"bingo-testers": "0.5.7",
 		"console-fail-test": "0.5.0",
 		"cspell": "8.17.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     dependencies:
       bingo:
-        specifier: ^0.5.8
-        version: 0.5.8
+        specifier: ^0.5.10
+        version: 0.5.10
       bingo-fs:
         specifier: ^0.5.4
         version: 0.5.4
       bingo-stratum:
         specifier: ^0.5.7
-        version: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2)
+        version: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2)
       cached-factory:
         specifier: ^0.1.0
         version: 0.1.0
@@ -40,13 +40,13 @@ importers:
         version: 1.2.0
       input-from-file:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.8)
+        version: 0.5.4(bingo@0.5.10)
       input-from-file-json:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.8)(zod@3.24.2)
+        version: 0.5.4(bingo@0.5.10)(zod@3.24.2)
       input-from-script:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.8)
+        version: 0.5.4(bingo@0.5.10)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -145,14 +145,14 @@ importers:
         specifier: 6.26.1
         version: 6.26.1
       bingo-requests:
-        specifier: 0.5.4
-        version: 0.5.4
+        specifier: 0.5.5
+        version: 0.5.5
       bingo-stratum-testers:
         specifier: 0.5.6
-        version: 0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8))(bingo@0.5.8)
+        version: 0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10)
       bingo-testers:
         specifier: 0.5.6
-        version: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)
+        version: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -1642,8 +1642,8 @@ packages:
     resolution: {integrity: sha512-0dP52RdNAff6F8MoHszk7YAZKZWes4+s9UYANNZVfr87g2KbgY56o6szVXEXytRtay6UuNIkjMHcRTGWw0ODzw==}
     engines: {node: '>=18'}
 
-  bingo-requests@0.5.4:
-    resolution: {integrity: sha512-CtibtB3C9Akh7+vQ4gA2e4FdCdh7GdODTzenPZCABYGbYM+n0olVArMH/OG0ww7wat4y7qEcCxA5f9Exqbifcw==}
+  bingo-requests@0.5.5:
+    resolution: {integrity: sha512-NQcnlAtnR72Cfn6Y9EWPS3RXAGM+4ndE3BEueLnWOQgj+/Y6kQyhGEiB7cPmi4VeJL+Kcqo/EGyzuF23aIT3Cg==}
     engines: {node: '>=18'}
 
   bingo-stratum-testers@0.5.6:
@@ -1677,8 +1677,8 @@ packages:
       bingo-fs: ^0.5.4
       bingo-systems: ^0.5.4
 
-  bingo@0.5.8:
-    resolution: {integrity: sha512-R9klG+JeU/OsbP2TKRLVKJGH9g5VkY5MzflPQvwFUCRgoqSeDFPx78JOfk8URek5X3nPsonNtOdKt1sGs6vRhQ==}
+  bingo@0.5.10:
+    resolution: {integrity: sha512-/1v+VhuDWOcISXayuEBAyNBCD0GuN5bJq2m1/dIX8SAH1SZjH2geIb/lTqmQjBQ4XDxAAevGHrhK+L779xvBbw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5749,22 +5749,22 @@ snapshots:
 
   bingo-fs@0.5.4: {}
 
-  bingo-requests@0.5.4:
+  bingo-requests@0.5.5:
     dependencies:
       '@octokit/types': 13.10.0
 
-  bingo-stratum-testers@0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8))(bingo@0.5.8):
+  bingo-stratum-testers@0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10):
     dependencies:
-      bingo: 0.5.8
+      bingo: 0.5.10
       bingo-fs: 0.5.4
-      bingo-stratum: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2)
+      bingo-stratum: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2)
       bingo-systems: 0.5.4
-      bingo-testers: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)
+      bingo-testers: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
 
-  bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8)(zod@3.24.2):
+  bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2):
     dependencies:
       all-properties-lazy: 0.1.0
-      bingo: 0.5.8
+      bingo: 0.5.10
       bingo-fs: 0.5.4
       bingo-systems: 0.5.4
       cached-factory: 0.1.0
@@ -5782,20 +5782,21 @@ snapshots:
       get-github-auth-token: 0.1.1
       octokit: 4.1.2
 
-  bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.8):
+  bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10):
     dependencies:
-      bingo: 0.5.8
+      bingo: 0.5.10
       bingo-fs: 0.5.4
       bingo-systems: 0.5.4
       diff: 7.0.0
       octokit: 4.1.2
       without-undefined-properties: 0.1.1
 
-  bingo@0.5.8:
+  bingo@0.5.10:
     dependencies:
       '@clack/prompts': 0.10.0
+      all-properties-lazy: 0.1.0
       bingo-fs: 0.5.4
-      bingo-requests: 0.5.4
+      bingo-requests: 0.5.5
       bingo-systems: 0.5.4
       cached-factory: 0.1.0
       call-id: 0.1.0
@@ -6990,20 +6991,20 @@ snapshots:
 
   ini@4.1.3: {}
 
-  input-from-file-json@0.5.4(bingo@0.5.8)(zod@3.24.2):
+  input-from-file-json@0.5.4(bingo@0.5.10)(zod@3.24.2):
     dependencies:
-      bingo: 0.5.8
-      input-from-file: 0.5.4(bingo@0.5.8)
+      bingo: 0.5.10
+      input-from-file: 0.5.4(bingo@0.5.10)
       zod: 3.24.2
 
-  input-from-file@0.5.4(bingo@0.5.8):
+  input-from-file@0.5.4(bingo@0.5.10):
     dependencies:
-      bingo: 0.5.8
+      bingo: 0.5.10
       zod: 3.24.2
 
-  input-from-script@0.5.4(bingo@0.5.8):
+  input-from-script@0.5.4(bingo@0.5.10):
     dependencies:
-      bingo: 0.5.8
+      bingo: 0.5.10
       zod: 3.24.2
 
   inquirer@12.3.0(@types/node@22.13.10):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,10 +149,10 @@ importers:
         version: 0.5.5
       bingo-stratum-testers:
         specifier: 0.5.6
-        version: 0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10)
+        version: 0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10)
       bingo-testers:
-        specifier: 0.5.6
-        version: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
+        specifier: 0.5.7
+        version: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -1669,11 +1669,11 @@ packages:
     resolution: {integrity: sha512-DZJ/OGQtGeiw9neP6pDFXOBiuGO0vr1Nqlm70WJs3NfziozE1OeFLe8E4ol5t1sIfH8AAheM4Z/YnU2ftroWzw==}
     engines: {node: '>=18'}
 
-  bingo-testers@0.5.6:
-    resolution: {integrity: sha512-hgKDmHpKM8QzJzlbFUlqT04vTZiKV6PTVHJERbnQxcXPzncFNHTTAahFDrPjS3F5fJsGLvQgTToyV0r/X5z9Rg==}
+  bingo-testers@0.5.7:
+    resolution: {integrity: sha512-tRvZIpGM8Rlh27EQ+/+eHRGFYfcD8IoIYhblzP824DJwx7IH/dtwk3XMynIqMYlZjxuPSeUDMN1LOJd3R90JFA==}
     engines: {node: '>=18'}
     peerDependencies:
-      bingo: ^0.5.6
+      bingo: ^0.5.10
       bingo-fs: ^0.5.4
       bingo-systems: ^0.5.4
 
@@ -5753,13 +5753,13 @@ snapshots:
     dependencies:
       '@octokit/types': 13.10.0
 
-  bingo-stratum-testers@0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10):
+  bingo-stratum-testers@0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10):
     dependencies:
       bingo: 0.5.10
       bingo-fs: 0.5.4
       bingo-stratum: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2)
       bingo-systems: 0.5.4
-      bingo-testers: 0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
+      bingo-testers: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
 
   bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2):
     dependencies:
@@ -5782,8 +5782,9 @@ snapshots:
       get-github-auth-token: 0.1.1
       octokit: 4.1.2
 
-  bingo-testers@0.5.6(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10):
+  bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10):
     dependencies:
+      all-properties-lazy: 0.1.0
       bingo: 0.5.10
       bingo-fs: 0.5.4
       bingo-systems: 0.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: 0.5.5
         version: 0.5.5
       bingo-stratum-testers:
-        specifier: 0.5.6
-        version: 0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10)
+        specifier: 0.5.7
+        version: 0.5.7(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10)
       bingo-testers:
         specifier: 0.5.7
         version: 0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)
@@ -1646,15 +1646,15 @@ packages:
     resolution: {integrity: sha512-NQcnlAtnR72Cfn6Y9EWPS3RXAGM+4ndE3BEueLnWOQgj+/Y6kQyhGEiB7cPmi4VeJL+Kcqo/EGyzuF23aIT3Cg==}
     engines: {node: '>=18'}
 
-  bingo-stratum-testers@0.5.6:
-    resolution: {integrity: sha512-SLcCLqseReWHQLbqyxCepwjvsDgAvfDXzrohe2NV833EVuzu1QjQ8SmXTqB+OjtjcBPsaQzrics1SVGA8OMy7A==}
+  bingo-stratum-testers@0.5.7:
+    resolution: {integrity: sha512-ei6K13xK+Dq5WPr/9zgFfFQ+k0eswuJ3IPw8hHN2UgmwZNaMmOAtJi3lWp2nvBYzT+Zra6VtwkZ52uffhLYHmA==}
     engines: {node: '>=18'}
     peerDependencies:
-      bingo: ^0.5.4
+      bingo: ^0.5.10
       bingo-fs: ^0.5.4
-      bingo-stratum: ^0.5.4
+      bingo-stratum: ^0.5.7
       bingo-systems: ^0.5.4
-      bingo-testers: ^0.5.4
+      bingo-testers: ^0.5.7
 
   bingo-stratum@0.5.7:
     resolution: {integrity: sha512-PznnKNYhGe5DobDVBvIMGn0mIXorSSwUBeG2NaCl5PI3prcGeD5NubzFDeq2O3WzH/l9MZ3wmz5a2nB7YiHKrA==}
@@ -5753,7 +5753,7 @@ snapshots:
     dependencies:
       '@octokit/types': 13.10.0
 
-  bingo-stratum-testers@0.5.6(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10):
+  bingo-stratum-testers@0.5.7(bingo-fs@0.5.4)(bingo-stratum@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.4)(bingo-systems@0.5.4)(bingo@0.5.10))(bingo@0.5.10):
     dependencies:
       bingo: 0.5.10
       bingo-fs: 0.5.4

--- a/src/base.ts
+++ b/src/base.ts
@@ -313,4 +313,4 @@ export const base = createBase({
 	},
 });
 
-export type BaseOptions = BaseOptionsFor<typeof base>;
+export type BaseOptions = BaseOptionsFor<typeof base> & { preset?: string };

--- a/src/blocks/blockCSpell.test.ts
+++ b/src/blocks/blockCSpell.test.ts
@@ -280,7 +280,7 @@ describe("blockCSpell", () => {
 			  "scripts": [
 			    {
 			      "commands": [
-			        "node path/to/cspell-populate-words/bin/index.mjs --words "access" --words "public" --words "description" --words "Test description" --words "directory" --words "." --words "email" --words "github" --words "github@email.com" --words "npm" --words "npm@email.com" --words "emoji" --words "💖" --words "owner" --words "test-owner" --words "repository" --words "test-repository" --words "title" --words "Test Title"",
+			        "node path/to/cspell-populate-words/bin/index.mjs --words "access" --words "public" --words "description" --words "Test description" --words "directory" --words "." --words "email" --words "github" --words "github@email.com" --words "npm" --words "npm@email.com" --words "emoji" --words "💖" --words "owner" --words "test-owner" --words "preset" --words "minimal" --words "repository" --words "test-repository" --words "title" --words "Test Title"",
 			      ],
 			      "phase": 3,
 			    },

--- a/src/blocks/blockRepositoryBranchRuleset.test.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.test.ts
@@ -95,6 +95,7 @@ describe("blockRepositoryBranchRuleset", () => {
 			        "owner": "test-owner",
 			        "repo": "test-repository",
 			      },
+			      "silent": true,
 			      "type": "octokit",
 			    },
 			    {
@@ -260,6 +261,7 @@ describe("blockRepositoryBranchRuleset", () => {
 			        "owner": "test-owner",
 			        "repo": "test-repository",
 			      },
+			      "silent": true,
 			      "type": "octokit",
 			    },
 			    {
@@ -345,6 +347,7 @@ describe("blockRepositoryBranchRuleset", () => {
 			        "owner": "test-owner",
 			        "repo": "test-repository",
 			      },
+			      "silent": true,
 			      "type": "octokit",
 			    },
 			    {
@@ -433,6 +436,7 @@ describe("blockRepositoryBranchRuleset", () => {
 			        "owner": "test-owner",
 			        "repo": "test-repository",
 			      },
+			      "silent": true,
 			      "type": "octokit",
 			    },
 			    {

--- a/src/blocks/blockRepositoryBranchRuleset.test.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.test.ts
@@ -89,6 +89,15 @@ describe("blockRepositoryBranchRuleset", () => {
 			{
 			  "requests": [
 			    {
+			      "endpoint": "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+			      "parameters": {
+			        "branch": "main",
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			      },
+			      "type": "octokit",
+			    },
+			    {
 			      "endpoint": "POST /repos/{owner}/{repo}/rulesets",
 			      "parameters": {
 			        "bypass_actors": [
@@ -245,6 +254,15 @@ describe("blockRepositoryBranchRuleset", () => {
 			{
 			  "requests": [
 			    {
+			      "endpoint": "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+			      "parameters": {
+			        "branch": "main",
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			      },
+			      "type": "octokit",
+			    },
+			    {
 			      "endpoint": "POST /repos/{owner}/{repo}/rulesets",
 			      "parameters": {
 			        "bypass_actors": [
@@ -320,6 +338,15 @@ describe("blockRepositoryBranchRuleset", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "requests": [
+			    {
+			      "endpoint": "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+			      "parameters": {
+			        "branch": "main",
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			      },
+			      "type": "octokit",
+			    },
 			    {
 			      "endpoint": "POST /repos/{owner}/{repo}/rulesets",
 			      "parameters": {
@@ -399,6 +426,15 @@ describe("blockRepositoryBranchRuleset", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "requests": [
+			    {
+			      "endpoint": "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+			      "parameters": {
+			        "branch": "main",
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			      },
+			      "type": "octokit",
+			    },
 			    {
 			      "endpoint": "PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}",
 			      "parameters": {

--- a/src/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.ts
@@ -28,6 +28,15 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 	transition({ addons, options }) {
 		return {
 			requests: [
+				{
+					endpoint: "DELETE /repos/{owner}/{repo}/branches/{branch}/protection",
+					parameters: {
+						branch: "main",
+						owner: options.owner,
+						repo: options.repository,
+					},
+					type: "octokit",
+				},
 				options.rulesetId
 					? {
 							endpoint: "PUT /repos/{owner}/{repo}/rulesets/{ruleset_id}",

--- a/src/blocks/blockRepositoryBranchRuleset.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.ts
@@ -35,6 +35,7 @@ export const blockRepositoryBranchRuleset = base.createBlock({
 						owner: options.owner,
 						repo: options.repository,
 					},
+					silent: true,
 					type: "octokit",
 				},
 				options.rulesetId

--- a/src/blocks/options.fakes.ts
+++ b/src/blocks/options.fakes.ts
@@ -10,6 +10,7 @@ export const optionsBase = {
 	},
 	emoji: "💖",
 	owner: "test-owner",
+	preset: "minimal",
 	repository: "test-repository",
 	title: "Test Title",
 } satisfies BaseOptions;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2016
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Includes updates to the latest Bingo packages to bring in silent requests: https://github.com/JoshuaKGoldberg/bingo/pull/313

I would have liked to go with a rename or archive kind of API, even changing the protection to be on some branch like `main-prior-to-cta`. But such a GitHub API does not exist. 🤷 

🎁 