### PR TITLE
fix: support package.json bin objects

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -45,7 +45,7 @@ export const base = createBase({
 			.optional()
 			.describe("username on npm to publish packages under"),
 		bin: z
-			.string()
+			.union([z.string(), z.record(z.string())])
 			.optional()
 			.describe('value to set in `package.json`\'s `"bin"` property'),
 		contributors: z

--- a/src/blocks/bin/getPrimaryBin.test.ts
+++ b/src/blocks/bin/getPrimaryBin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { getPrimaryBin } from "./getPrimaryBin.js";
+
+const repository = "test-repository";
+
+describe(getPrimaryBin, () => {
+	test.each([
+		[undefined, undefined],
+		["bin/index.js", "bin/index.js"],
+		[{ [repository]: "bin/index.js" }, "bin/index.js"],
+		[{}, undefined],
+		[{ other: "bin/index.js" }, undefined],
+	])("%j", (bin, expected) => {
+		expect(getPrimaryBin(bin, repository)).toBe(expected);
+	});
+});

--- a/src/blocks/bin/getPrimaryBin.ts
+++ b/src/blocks/bin/getPrimaryBin.ts
@@ -1,0 +1,6 @@
+export function getPrimaryBin(
+	bin: Record<string, string | undefined> | string | undefined,
+	repository: string,
+) {
+	return typeof bin === "object" ? bin[repository] : bin;
+}

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -184,6 +184,59 @@ describe("blockPackageJson", () => {
 		`);
 	});
 
+	test("with object bin", () => {
+		const creation = testBlock(blockPackageJson, {
+			options: {
+				...options,
+				bin: "bin/index.js",
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "files": {
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","main":"lib/index.js","bin":"bin/index.js","files":["README.md","bin/index.js","package.json"]}",
+			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "pnpm install --no-frozen-lockfile",
+			      ],
+			      "phase": 1,
+			    },
+			  ],
+			}
+		`);
+	});
+
+	test("with string bin", () => {
+		const creation = testBlock(blockPackageJson, {
+			options: {
+				...options,
+				bin: {
+					absolute: "bin/absolute.js",
+					relative: "./bin/relative.js",
+				},
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "files": {
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","main":"lib/index.js","bin":{"absolute":"bin/absolute.js","relative":"./bin/relative.js"},"files":["README.md","bin/absolute.js","bin/relative.js","package.json"]}",
+			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "pnpm install --no-frozen-lockfile",
+			      ],
+			      "phase": 1,
+			    },
+			  ],
+			}
+		`);
+	});
+
 	test("offline mode", () => {
 		const creation = testBlock(blockPackageJson, {
 			offline: true,

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -63,7 +63,7 @@ export const blockPackageJson = base.createBlock({
 								packageManager: `pnpm@${options.pnpm}`,
 							}),
 							files: [
-								options.bin?.replace(/^\.\//, ""),
+								...collectBinFiles(options.bin),
 								...(addons.properties.files ?? []),
 								"package.json",
 								"README.md",
@@ -107,6 +107,16 @@ export const blockPackageJson = base.createBlock({
 		};
 	},
 });
+
+function collectBinFiles(bin: Record<string, string> | string | undefined) {
+	if (!bin) {
+		return [];
+	}
+
+	const files = typeof bin === "object" ? Object.values(bin) : [bin];
+
+	return files.map((file) => file.replace(/^\.\//, ""));
+}
 
 function removeRangePrefix(version: string) {
 	return version.replaceAll(/[\^~><=]/gu, "").split(" ")[0];

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -1,5 +1,6 @@
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
+import { getPrimaryBin } from "./bin/getPrimaryBin.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockExampleFiles } from "./blockExampleFiles.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
@@ -15,6 +16,8 @@ export const blockTypeScript = base.createBlock({
 		name: "TypeScript",
 	},
 	produce({ options }) {
+		const primaryBin = getPrimaryBin(options.bin, options.repository);
+
 		return {
 			addons: [
 				blockDevelopmentDocs({
@@ -86,12 +89,12 @@ export * from "./types.js";
 				}),
 				blockVitest({ coverage: { include: ["src"] }, exclude: ["lib"] }),
 				blockVSCode({
-					debuggers: options.bin
+					debuggers: primaryBin
 						? [
 								{
 									name: "Debug Program",
 									preLaunchTask: "build",
-									program: options.bin,
+									program: primaryBin,
 									request: "launch",
 									skipFiles: ["<node_internals>/**"],
 									type: "node",

--- a/src/blocks/blockVSCode.ts
+++ b/src/blocks/blockVSCode.ts
@@ -2,6 +2,7 @@ import sortKeys from "sort-keys";
 import { z } from "zod";
 
 import { base } from "../base.js";
+import { getPrimaryBin } from "./bin/getPrimaryBin.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 
 export const blockVSCode = base.createBlock({
@@ -30,6 +31,7 @@ export const blockVSCode = base.createBlock({
 	},
 	produce({ addons, options }) {
 		const { debuggers, extensions, settings, tasks } = addons;
+		const primaryBin = getPrimaryBin(options.bin, options.repository);
 
 		return {
 			addons: [
@@ -40,13 +42,13 @@ export const blockVSCode = base.createBlock({
 					],
 					sections: {
 						Building: {
-							innerSections: options.bin
+							innerSections: primaryBin
 								? [
 										{
 											contents: `
 This repository includes a [VS Code launch configuration](https://code.visualstudio.com/docs/editor/debugging) for debugging.
 To debug a \`bin\` app, add a breakpoint to your code, then run _Debug Program_ from the VS Code Debug panel (or press F5).
-VS Code will automatically run the \`build\` task in the background before running \`${options.bin}\`.
+VS Code will automatically run the \`build\` task in the background before running \`${primaryBin}\`.
 `,
 											heading: "Built App Debugging",
 										},

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface AllContributorsData {
 
 export interface PartialPackageData {
 	author?: string | { email: string; name: string };
-	bin?: string;
+	bin?: Record<string, string> | string;
 	dependencies?: Record<string, string>;
 	description?: string;
 	devDependencies?: Record<string, string>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2039
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the `PartialPackageData` type to note that `bin` could be a `Record<string, string>`, not just a `string`. `blockPackageJson` will collect its values if it is an object.

Also updates other references to `options.bin` to use a new `getPrimaryBin` function for determining what the main runner is. Per https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin using the same name as the repo is equivalent to using a string.

🎁 