### PR TITLE
fix: more permissive usage bounds and headings

### DIFF
--- a/src/options/readUsageFromReadme.test.ts
+++ b/src/options/readUsageFromReadme.test.ts
@@ -9,10 +9,10 @@ describe(readUsageFromReadme, () => {
 		expect(usage).toBeUndefined();
 	});
 
-	it("returns undefined when ## Usage found and ## Development is not found", () => {
+	it("returns existing content when ## Usage is found and a next important heading is not found", () => {
 		const usage = readUsageFromReadme("## Usage\n\nContents.");
 
-		expect(usage).toBeUndefined();
+		expect(usage).toBe(`\n\nContents.`);
 	});
 
 	it("returns undefined when there is no content between ## Usage and ## Development", () => {
@@ -23,6 +23,22 @@ describe(readUsageFromReadme, () => {
 
 	it("returns the content when content exists between ## Usage and ## Development", () => {
 		const usage = readUsageFromReadme("## Usage\n\n  Content.\n## Development");
+
+		expect(usage).toBe("Content.");
+	});
+
+	it("returns the content when content exists between ## Usage and ## Contributing", () => {
+		const usage = readUsageFromReadme(
+			"## Usage\n\n  Content.\n## Contributing",
+		);
+
+		expect(usage).toBe("Content.");
+	});
+
+	it("returns the content when content exists between ## Usage and ## Contributors", () => {
+		const usage = readUsageFromReadme(
+			"## Usage\n\n  Content.\n## Contributors",
+		);
 
 		expect(usage).toBe("Content.");
 	});

--- a/src/options/readUsageFromReadme.ts
+++ b/src/options/readUsageFromReadme.ts
@@ -1,4 +1,3 @@
-const startDevelopment = "## Development";
 const startUsage = "## Usage";
 
 export function readUsageFromReadme(readme: string) {
@@ -7,17 +6,15 @@ export function readUsageFromReadme(readme: string) {
 		return undefined;
 	}
 
-	const indexOfDevelopment = readme.indexOf(
-		startDevelopment,
-		indexOfUsage + startUsage.length,
-	);
-	if (indexOfDevelopment === -1) {
-		return undefined;
+	const offset = indexOfUsage + startUsage.length;
+	const indexOfNextKnownHeading = readme
+		.slice(offset)
+		.search(/## (?:Development|Contributing|Contributors)/);
+	if (indexOfNextKnownHeading === -1) {
+		return readme.slice(offset);
 	}
 
-	const usage = readme
-		.slice(indexOfUsage + startUsage.length, indexOfDevelopment)
-		.trim();
+	const usage = readme.slice(offset, indexOfNextKnownHeading + offset).trim();
 
 	return usage ? usage : undefined;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2041
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes `options.usage` parsing more permissive in two ways:

* Instead of only searching for a second heading under `## Development`, also allows `## Contributing` and `## Contributors`
* If that second heading isn't found then the rest of the README.md is returned instead of `undefined`

The fixed behavior can be seen in https://github.com/JoshuaKGoldberg/cspell-populate-words/pull/25/commits/736e48b57e27d62af8faa622964f1c80ee771c1d.

🎁 
