### PR TITLE
fix: coerce dependency versions in semver parsing

### DIFF
--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -260,7 +260,7 @@ describe("blockPackageJson", () => {
 		`);
 	});
 
-	it("preserves an existing dependency when the addon has an older pinned version", () => {
+	it("preserves an existing dependency when the addon has an invalid version", () => {
 		const dependency = "test-dependency";
 		const creation = testBlock(blockPackageJson, {
 			addons: {
@@ -314,6 +314,36 @@ describe("blockPackageJson", () => {
 		).toMatchInlineSnapshot(`
 			{
 			  "test-dependency": "1.1.0",
+			}
+		`);
+	});
+
+	it("uses the addon's version when the existing equivalent is invalid semver", () => {
+		const dependency = "test-dependency";
+		const creation = testBlock(blockPackageJson, {
+			addons: {
+				properties: {
+					dependencies: {
+						[dependency]: "1.0.0",
+					},
+				},
+			},
+			options: {
+				...optionsBase,
+				packageData: {
+					dependencies: {
+						[dependency]: "next",
+					},
+				},
+			},
+		});
+
+		expect(
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unsafe-member-access
+			JSON.parse(creation.files!["package.json"] as string).dependencies,
+		).toMatchInlineSnapshot(`
+			{
+			  "test-dependency": "1.0.0",
 			}
 		`);
 	});

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -119,15 +119,20 @@ function collectBinFiles(bin: Record<string, string> | string | undefined) {
 }
 
 function removeRangePrefix(version: string) {
-	return version.replaceAll(/[\^~><=]/gu, "").split(" ")[0];
+	const raw = version.replaceAll(/[\^~><=]/gu, "").split(" ")[0];
+
+	return semver.coerce(raw) ?? raw;
 }
 
 function useLargerVersion(existing: string | undefined, replacement: string) {
-	if (!existing) {
+	if (!existing || existing === replacement) {
 		return replacement;
 	}
 
-	return semver.gt(removeRangePrefix(existing), removeRangePrefix(replacement))
+	const existingCoerced = semver.coerce(removeRangePrefix(existing));
+
+	return existingCoerced &&
+		semver.gt(existingCoerced, removeRangePrefix(replacement))
 		? existing
 		: replacement;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2043
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I couldn't figure out how to get the exact failure case from #2043, weirdly enough. But this PR's invalid semver handling happens to fix that failure in `debug-for-file` locally for me.

🎁 