### PR TITLE
fix: don't word-wrap long repo descriptions in API calls

### DIFF
--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -1,4 +1,3 @@
-import * as htmlToText from "html-to-text";
 import removeUndefinedObjects from "remove-undefined-objects";
 import semver from "semver";
 import sortPackageJson from "sort-package-json";

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -7,6 +7,7 @@ import { PackageJson } from "zod-package-json";
 
 import { base } from "../base.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
+import { htmlToTextSafe } from "./html/htmlToTextSafe.js";
 import { CommandPhase } from "./phases.js";
 
 const PackageJsonWithNullableScripts = PackageJson.partial().extend({
@@ -35,9 +36,7 @@ export const blockPackageJson = base.createBlock({
 				...addons.properties.devDependencies,
 			},
 		);
-		const description = htmlToText.convert(options.description, {
-			wordwrap: false,
-		});
+		const description = htmlToTextSafe(options.description);
 
 		return {
 			files: {

--- a/src/blocks/blockRepositorySettings.test.ts
+++ b/src/blocks/blockRepositorySettings.test.ts
@@ -1,0 +1,86 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, test } from "vitest";
+
+import { blockRepositorySettings } from "./blockRepositorySettings.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe("blockRepositorySettings", () => {
+	test("with a short description", () => {
+		const creation = testBlock(blockRepositorySettings, {
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "requests": [
+			    {
+			      "endpoint": "PATCH /repos/{owner}/{repo}",
+			      "parameters": {
+			        "allow_auto_merge": true,
+			        "allow_merge_commit": false,
+			        "allow_rebase_merge": false,
+			        "allow_squash_merge": true,
+			        "delete_branch_on_merge": true,
+			        "description": "Test description",
+			        "has_wiki": false,
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			        "security_and_analysis": {
+			          "secret_scanning": {
+			            "status": "enabled",
+			          },
+			          "secret_scanning_push_protection": {
+			            "status": "enabled",
+			          },
+			        },
+			        "squash_merge_commit_message": "PR_BODY",
+			        "squash_merge_commit_title": "PR_TITLE",
+			      },
+			      "type": "octokit",
+			    },
+			  ],
+			}
+		`);
+	});
+
+	test("with a long description", () => {
+		const creation = testBlock(blockRepositorySettings, {
+			options: {
+				...optionsBase,
+				description: `A very very very very very very very very very very very very very very very very long <em><code>HTML-ish</code> description</em> ending with an emoji. 🧵`,
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "requests": [
+			    {
+			      "endpoint": "PATCH /repos/{owner}/{repo}",
+			      "parameters": {
+			        "allow_auto_merge": true,
+			        "allow_merge_commit": false,
+			        "allow_rebase_merge": false,
+			        "allow_squash_merge": true,
+			        "delete_branch_on_merge": true,
+			        "description": "A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵",
+			        "has_wiki": false,
+			        "owner": "test-owner",
+			        "repo": "test-repository",
+			        "security_and_analysis": {
+			          "secret_scanning": {
+			            "status": "enabled",
+			          },
+			          "secret_scanning_push_protection": {
+			            "status": "enabled",
+			          },
+			        },
+			        "squash_merge_commit_message": "PR_BODY",
+			        "squash_merge_commit_title": "PR_TITLE",
+			      },
+			      "type": "octokit",
+			    },
+			  ],
+			}
+		`);
+	});
+});

--- a/src/blocks/blockRepositorySettings.ts
+++ b/src/blocks/blockRepositorySettings.ts
@@ -1,13 +1,12 @@
-import * as htmlToText from "html-to-text";
-
 import { base } from "../base.js";
+import { htmlToTextSafe } from "./html/htmlToTextSafe.js";
 
 export const blockRepositorySettings = base.createBlock({
 	about: {
 		name: "Repository Settings",
 	},
 	produce({ options }) {
-		const description = htmlToText.convert(options.description);
+		const description = htmlToTextSafe(options.description);
 
 		return {
 			requests: [

--- a/src/blocks/html/htmlToTextSafe.ts
+++ b/src/blocks/html/htmlToTextSafe.ts
@@ -1,0 +1,5 @@
+import { convert } from "html-to-text";
+
+export function htmlToTextSafe(raw: string) {
+	return convert(raw, { wordwrap: false });
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2046
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Reuses the existing `wordwrap: false` logic in a new shared `htmlToTextSafe` function. The fact that I didn't do this already is an indication of why it should be centralized.

🎁 