### PR TITLE
fix: perserve peerDependencies, peerDependenciesMeta in transition mode

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -135,6 +135,8 @@ export const base = createBase({
 			.object({
 				dependencies: z.record(z.string(), z.string()).optional(),
 				devDependencies: z.record(z.string(), z.string()).optional(),
+				peerDependencies: z.record(z.string(), z.string()).optional(),
+				peerDependenciesMeta: z.record(z.unknown()).optional(),
 				scripts: z.record(z.string(), z.string()).optional(),
 			})
 			.optional()

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -237,6 +237,41 @@ describe("blockPackageJson", () => {
 		`);
 	});
 
+	test("with peerDependencies and peerDependenciesMeta", () => {
+		const creation = testBlock(blockPackageJson, {
+			options: {
+				...options,
+				packageData: {
+					peerDependencies: {
+						"@types/estree": ">=1",
+						eslint: ">=8",
+					},
+					peerDependenciesMeta: {
+						"@types/estree": {
+							optional: true,
+						},
+					},
+				},
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "files": {
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","files":["README.md","package.json"],"peerDependencies":{"@types/estree":">=1","eslint":">=8"},"peerDependenciesMeta":{"@types/estree":{"optional":true}}}",
+			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "pnpm install --no-frozen-lockfile",
+			      ],
+			      "phase": 1,
+			    },
+			  ],
+			}
+		`);
+	});
+
 	test("offline mode", () => {
 		const creation = testBlock(blockPackageJson, {
 			offline: true,

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -42,6 +42,7 @@ export const blockPackageJson = base.createBlock({
 				"package.json": sortPackageJson(
 					JSON.stringify(
 						removeUndefinedObjects({
+							...options.packageData,
 							...addons.properties,
 							author: { email: options.email.npm, name: options.author },
 							bin: options.bin,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2059
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Expands the `options.packageData` schema to allow them. These are the first allowlisted `package.json` properties that aren't manually combined with addons, so they're generally spread in `blockPackageJson`.

🎁 