### PR TITLE
fix: remove automerge, tseslint from cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -13,7 +13,6 @@
 		"Anson",
 		"apexskier",
 		"attw",
-		"automerge",
 		"boop",
 		"dbaeumer",
 		"infile",
@@ -22,7 +21,6 @@
 		"mshick",
 		"mtfoley",
 		"npmjs",
-		"stefanzweifel",
-		"tseslint"
+		"stefanzweifel"
 	]
 }

--- a/src/blocks/blockESLint.test.ts
+++ b/src/blocks/blockESLint.test.ts
@@ -15,14 +15,6 @@ describe("blockESLint", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "tseslint",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "sections": {
 			          "Linting": {
 			            "contents": {
@@ -142,14 +134,6 @@ describe("blockESLint", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "addons": [
-			    {
-			      "addons": {
-			        "words": [
-			          "tseslint",
-			        ],
-			      },
-			      "block": [Function],
-			    },
 			    {
 			      "addons": {
 			        "sections": {
@@ -342,14 +326,6 @@ describe("blockESLint", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "tseslint",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "sections": {
 			          "Linting": {
 			            "contents": {
@@ -486,14 +462,6 @@ describe("blockESLint", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "tseslint",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "sections": {
 			          "Linting": {
 			            "contents": {
@@ -618,14 +586,6 @@ describe("blockESLint", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "addons": [
-			    {
-			      "addons": {
-			        "words": [
-			          "tseslint",
-			        ],
-			      },
-			      "block": [Function],
-			    },
 			    {
 			      "addons": {
 			        "sections": {

--- a/src/blocks/blockESLint.ts
+++ b/src/blocks/blockESLint.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
-import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
@@ -132,9 +131,6 @@ export const blockESLint = base.createBlock({
 
 		return {
 			addons: [
-				blockCSpell({
-					words: ["tseslint"],
-				}),
 				blockDevelopmentDocs({
 					sections: {
 						Linting: {

--- a/src/blocks/blockRenovate.ts
+++ b/src/blocks/blockRenovate.ts
@@ -1,5 +1,4 @@
 import { base } from "../base.js";
-import { blockCSpell } from "./blockCSpell.js";
 import { blockGitHubApps } from "./blockGitHubApps.js";
 
 export const blockRenovate = base.createBlock({
@@ -9,9 +8,6 @@ export const blockRenovate = base.createBlock({
 	produce() {
 		return {
 			addons: [
-				blockCSpell({
-					words: ["automerge"],
-				}),
 				blockGitHubApps({
 					apps: [
 						{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2056
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

These used to not be in cspell-dicts. They are now.

🎁 