### PR TITLE
fix: remove remaining manual cspell word additions

### DIFF
--- a/src/blocks/blockMarkdownlint.test.ts
+++ b/src/blocks/blockMarkdownlint.test.ts
@@ -15,14 +15,6 @@ describe("blockMarkdownlint", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "markdownlintignore",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "sections": {
 			          "Linting": {
 			            "contents": {
@@ -106,14 +98,6 @@ describe("blockMarkdownlint", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "markdownlintignore",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "sections": {
 			          "Linting": {
 			            "contents": {
@@ -194,14 +178,6 @@ describe("blockMarkdownlint", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "addons": [
-			    {
-			      "addons": {
-			        "words": [
-			          "markdownlintignore",
-			        ],
-			      },
-			      "block": [Function],
-			    },
 			    {
 			      "addons": {
 			        "sections": {

--- a/src/blocks/blockMarkdownlint.ts
+++ b/src/blocks/blockMarkdownlint.ts
@@ -23,9 +23,6 @@ export const blockMarkdownlint = base.createBlock({
 
 		return {
 			addons: [
-				blockCSpell({
-					words: ["markdownlintignore"],
-				}),
 				blockDevelopmentDocs({
 					sections: {
 						Linting: {

--- a/src/blocks/blockMarkdownlint.ts
+++ b/src/blocks/blockMarkdownlint.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
-import { blockCSpell } from "./blockCSpell.js";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";

--- a/src/blocks/blockReleaseIt.test.ts
+++ b/src/blocks/blockReleaseIt.test.ts
@@ -13,14 +13,6 @@ describe("blockReleaseIt", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "apexskier",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "properties": {
 			          "devDependencies": {
 			            "@release-it/conventional-changelog": "10.0.0",
@@ -168,14 +160,6 @@ describe("blockReleaseIt", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "addons": [
-			    {
-			      "addons": {
-			        "words": [
-			          "apexskier",
-			        ],
-			      },
-			      "block": [Function],
-			    },
 			    {
 			      "addons": {
 			        "properties": {

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
 import { resolveUses } from "./actions/resolveUses.js";
-import { blockCSpell } from "./blockCSpell.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockREADME } from "./blockREADME.js";
 import { blockRemoveDependencies } from "./blockRemoveDependencies.js";

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -29,9 +29,6 @@ export const blockReleaseIt = base.createBlock({
 
 		return {
 			addons: [
-				blockCSpell({
-					words: ["apexskier"],
-				}),
 				blockPackageJson({
 					properties: {
 						devDependencies: getPackageDependencies(

--- a/src/blocks/blockTemplatedWith.test.ts
+++ b/src/blocks/blockTemplatedWith.test.ts
@@ -19,14 +19,6 @@ describe("blockTemplatedWith", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "words": [
-			          "joshuakgoldberg",
-			        ],
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "notices": [
 			          "
 			<!-- You can remove this notice if you don't want it 🙂 no worries! -->",
@@ -52,14 +44,6 @@ describe("blockTemplatedWith", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "addons": [
-			    {
-			      "addons": {
-			        "words": [
-			          "joshuakgoldberg",
-			        ],
-			      },
-			      "block": [Function],
-			    },
 			    {
 			      "addons": {
 			        "notices": [

--- a/src/blocks/blockTemplatedWith.ts
+++ b/src/blocks/blockTemplatedWith.ts
@@ -1,5 +1,4 @@
 import { base } from "../base.js";
-import { blockCSpell } from "./blockCSpell.js";
 import { blockREADME } from "./blockREADME.js";
 
 export const blockTemplatedWith = base.createBlock({
@@ -9,9 +8,6 @@ export const blockTemplatedWith = base.createBlock({
 	produce({ options }) {
 		return {
 			addons: [
-				blockCSpell({
-					words: ["joshuakgoldberg"],
-				}),
 				blockREADME({
 					notices: [
 						options.owner !== "JoshuaKGoldberg" &&


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2062
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

_Setup_ mode already populated words as of #1794. I confirmed in https://github.com/JoshuaKGoldberg/eslint-fix-utils/pull/79 that `pnpm lint:spelling` passes without these.

🎁 