### PR TITLE
fix: update `resolveBin` to use `fileURLToPath` for cross-platform compatibility

### DIFF
--- a/src/utils/resolveBin.ts
+++ b/src/utils/resolveBin.ts
@@ -1,7 +1,9 @@
+import { fileURLToPath } from "node:url";
+
 // TODO: try to see if we can avoid this altogether...
 // https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1992
 export function resolveBin(bin: string) {
 	// This can't be tested yet in Vitest :(
 	// https://github.com/vitest-dev/vitest/issues/6953
-	return import.meta.resolve(bin).replace(/^file:\/\//gu, "");
+	return fileURLToPath(import.meta.resolve(bin));
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 🎁
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2064
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

### :monocle_face: The Problem

On Windows, file paths typically begin with a drive letter (e.g., `C:`). However, to conform to the `file://` URI scheme in Node.js, they must be prefixed with a slash (e.g., `/C:`), resulting in a correct file URL like `file:///C:/GHub/file.js`.

Currently, the `resolveBin` function does not properly handle this conversion and mistakenly outputs an absolute path with a leading slash, such as `/C:/GHub/file.js`. This format is invalid on Windows, where the correct absolute path should be `C:/GHub/file.js`.

Mishandling paths that start with a leading slash on Windows can cause them to be interpreted as relative to the current drive, leading to incorrect resolutions. This can result in an erroneous path with duplicated drive letters (like `C:/C:/GHub/file.js`).

### :bulb: The Solution

To resolve this issue, we should use the [`fileURLToPath` function](https://nodejs.org/api/url.html#urlfileurltopathurl-options) from the `node:url` module instead of manually handling paths via regular expressions. This approach ensures that paths are correctly converted and eliminates the risk of incorrect path handling on Windows.

### :heavy_check_mark: Testing
I have tested this change on Windows and WSL (Ubuntu 24.04.2 LTS), and it works as expected.

## Additional Info

💖
