### PR TITLE
fix: deduplicate Vitest excludes entries

### DIFF
--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -236,7 +236,7 @@ describe("blockVitest", () => {
 						include: undefined,
 						reporter: ["html", "lcov"],
 					},
-					exclude: [, "node_modules"],
+					exclude: ["node_modules"],
 					setupFiles: ["console-fail-test/setup"],
 				},
 			});
@@ -504,7 +504,7 @@ describe("blockVitest", () => {
 						include: undefined,
 						reporter: ["html", "lcov"],
 					},
-					exclude: [, "node_modules"],
+					exclude: ["node_modules"],
 					setupFiles: ["console-fail-test/setup"],
 				},
 			});
@@ -750,7 +750,253 @@ describe("blockVitest", () => {
 						include: ["src/"],
 						reporter: ["html", "lcov"],
 					},
-					exclude: ["lib/", "node_modules"],
+					exclude: ["lib/","node_modules"],
+					setupFiles: ["console-fail-test/setup"],
+				},
+			});
+				",
+			  },
+			}
+		`);
+	});
+
+	test("with duplicate excludes addons", () => {
+		const creation = testBlock(blockVitest, {
+			addons: {
+				coverage: {
+					exclude: ["other"],
+					include: ["src/"],
+				},
+				exclude: ["lib/", "node_modules", "node_modules"],
+				flags: ["--typecheck"],
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "ignores": [
+			          "coverage",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "sections": {
+			          "Testing": {
+			            "contents": "
+			[Vitest](https://vitest.dev) is used for tests.
+			You can run it locally on the command-line:
+
+			\`\`\`shell
+			pnpm run test
+			\`\`\`
+
+			Add the \`--coverage\` flag to compute test coverage and place reports in the \`coverage/\` directory:
+
+			\`\`\`shell
+			pnpm run test --coverage
+			\`\`\`
+
+			Note that [console-fail-test](https://github.com/JoshuaKGoldberg/console-fail-test) is enabled for all test runs.
+			Calls to \`console.log\`, \`console.warn\`, and other console methods will cause a test to fail.
+
+
+					",
+			          },
+			        },
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "extensions": [
+			          {
+			            "extends": [
+			              "vitest.configs.recommended",
+			            ],
+			            "files": [
+			              "**/*.test.*",
+			            ],
+			            "rules": [
+			              {
+			                "entries": {
+			                  "@typescript-eslint/no-unsafe-assignment": "off",
+			                },
+			              },
+			            ],
+			          },
+			        ],
+			        "ignores": [
+			          "coverage",
+			          "**/*.snap",
+			        ],
+			        "imports": [
+			          {
+			            "source": "@vitest/eslint-plugin",
+			            "specifier": "vitest",
+			          },
+			        ],
+			        "settings": {
+			          "vitest": {
+			            "typecheck": true,
+			          },
+			        },
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "files": {
+			          "greet.test.ts": "import { describe, expect, it, vi } from "vitest";
+
+			import { greet } from "./greet.js";
+
+			const message = "Yay, testing!";
+
+			describe(greet, () => {
+				it("logs to the console once when message is provided as a string", () => {
+					const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+					greet(message);
+
+					expect(logger).toHaveBeenCalledWith(message);
+					expect(logger).toHaveBeenCalledTimes(1);
+				});
+
+				it("logs to the console once when message is provided as an object", () => {
+					const logger = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+					greet({ message });
+
+					expect(logger).toHaveBeenCalledWith(message);
+					expect(logger).toHaveBeenCalledTimes(1);
+				});
+
+				it("logs once when times is not provided in an object", () => {
+					const logger = vi.fn();
+
+					greet({ logger, message });
+
+					expect(logger).toHaveBeenCalledWith(message);
+					expect(logger).toHaveBeenCalledTimes(1);
+				});
+
+				it("logs a specified number of times when times is provided", () => {
+					const logger = vi.fn();
+					const times = 7;
+
+					greet({ logger, message, times });
+
+					expect(logger).toHaveBeenCalledWith(message);
+					expect(logger).toHaveBeenCalledTimes(7);
+				});
+			});
+			",
+			        },
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "ignores": [
+			          "/coverage",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "jobs": [
+			          {
+			            "name": "Test",
+			            "steps": [
+			              {
+			                "run": "pnpm run test --coverage",
+			              },
+			            ],
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "properties": {
+			          "devDependencies": {
+			            "@vitest/coverage-v8": "3.0.9",
+			            "@vitest/eslint-plugin": "1.1.38",
+			            "console-fail-test": "0.5.0",
+			            "vitest": "3.0.9",
+			          },
+			          "scripts": {
+			            "test": "vitest --typecheck",
+			          },
+			        },
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "ignores": [
+			          "/coverage",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "entry": [
+			          "!src/**/*.test.*",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "debuggers": [
+			          {
+			            "args": [
+			              "run",
+			              "\${relativeFile}",
+			            ],
+			            "autoAttachChildProcesses": true,
+			            "console": "integratedTerminal",
+			            "name": "Debug Current Test File",
+			            "program": "\${workspaceRoot}/node_modules/vitest/vitest.mjs",
+			            "request": "launch",
+			            "skipFiles": [
+			              "<node_internals>/**",
+			              "**/node_modules/**",
+			            ],
+			            "smartStep": true,
+			            "type": "node",
+			          },
+			        ],
+			        "extensions": [
+			          "vitest.explorer",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			  "files": {
+			    "vitest.config.ts": "import { defineConfig } from "vitest/config";
+
+			export default defineConfig({
+				test: {
+					clearMocks: true,
+					coverage: {
+						all: true,
+						exclude: ["other"],
+						include: ["src/"],
+						reporter: ["html", "lcov"],
+					},
+					exclude: ["lib/","node_modules"],
 					setupFiles: ["console-fail-test/setup"],
 				},
 			});

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -78,7 +78,9 @@ export const blockVitest = base.createBlock({
 	},
 	produce({ addons }) {
 		const { actionSteps, coverage, exclude = [] } = addons;
-		const excludeText = JSON.stringify(exclude);
+		const excludeText = JSON.stringify(
+			Array.from(new Set(["node_modules", ...exclude])).sort(),
+		);
 
 		return {
 			addons: [
@@ -242,7 +244,7 @@ export default defineConfig({
 			}include: ${JSON.stringify(coverage.include)},
 			reporter: ["html", "lcov"],
 		},
-		exclude: [${excludeText.slice(1, excludeText.length - 1)}, "node_modules"],
+		exclude: [${excludeText.slice(1, excludeText.length - 1)}],
 		setupFiles: ["console-fail-test/setup"],
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2082
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also fixes a yet-to-be-hit-by-users bug where only having `"node_modules"` there results in `[, "node_modules"]`.

🎁 