### PR TITLE
fix: normalize yaml outputs to always use -1 lineWidth

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -26,8 +26,12 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
+
 description: Report a bug trying to run the code
+
 labels:
   - "type: bug"
+
 name: 🐛 Bug
+
 title: "🐛 Bug: <short description of the bug>"

--- a/.github/ISSUE_TEMPLATE/02-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/02-documentation.yml
@@ -18,8 +18,12 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
+
 description: Report a typo or missing area of documentation
+
 labels:
   - "area: documentation"
+
 name: 📝 Documentation
+
 title: "📝 Documentation: <short description of the request>"

--- a/.github/ISSUE_TEMPLATE/03-feature.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature.yml
@@ -18,8 +18,12 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
+
 description: Request that a new feature be added or an existing feature improved
+
 labels:
   - "type: feature"
+
 name: 🚀 Feature
+
 title: "🚀 Feature: <short description of the feature>"

--- a/.github/ISSUE_TEMPLATE/04-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/04-tooling.yml
@@ -20,8 +20,12 @@ body:
       description: Any additional info you'd like to provide.
       label: Additional Info
     type: textarea
+
 description: Report a bug or request an enhancement in repository tooling
+
 labels:
   - "area: tooling"
+
 name: 🛠 Tooling
+
 title: "🛠 Tooling: <short description of the change>"

--- a/src/blocks/blockAllContributors.test.ts
+++ b/src/blocks/blockAllContributors.test.ts
@@ -68,7 +68,9 @@ describe("blockAllContributors", () => {
 			          GITHUB_TOKEN: \${{ secrets.ACCESS_TOKEN }}
 			        uses: JoshuaKGoldberg/all-contributors-auto-action@v0.5.0
 
+
 			name: Contributors
+
 
 			on:
 			  push:
@@ -187,7 +189,9 @@ describe("blockAllContributors", () => {
 			          GITHUB_TOKEN: \${{ secrets.ACCESS_TOKEN }}
 			        uses: JoshuaKGoldberg/all-contributors-auto-action@v0.5.0
 
+
 			name: Contributors
+
 
 			on:
 			  push:
@@ -305,7 +309,9 @@ describe("blockAllContributors", () => {
 			          GITHUB_TOKEN: \${{ secrets.ACCESS_TOKEN }}
 			        uses: JoshuaKGoldberg/all-contributors-auto-action@v0.5.0
 
+
 			name: Contributors
+
 
 			on:
 			  push:

--- a/src/blocks/blockCTATransitions.test.ts
+++ b/src/blocks/blockCTATransitions.test.ts
@@ -50,21 +50,13 @@ describe("blockCTATransitions", () => {
 			      uses: mshick/add-pr-comment@v2
 			      with:
 			        issue: \${{ github.event.pull_request.number }}
-			        message: >-
-			          🤖 Beep boop! I ran \`npx create-typescript-app\` and it updated some
-			          files.
-
-			          I went ahead and checked those changes into this PR for you. Please
-			          review the latest commit to see if you want to merge it.
-
+			        message: |-
+			          🤖 Beep boop! I ran \`npx create-typescript-app\` and it updated some files.
+			          I went ahead and checked those changes into this PR for you. Please review the latest commit to see if you want to merge it.
 			          Cheers!
 			           — _The Friendly Bingo Bot_ 💝
 
-			          > ℹ️ These automatic commits keep your repository up-to-date with new
-			          versions of
-			          [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app).
-			          If you want to opt out, delete your
-			          \`.github/workflows/cta-transitions.yml\` file.
+			          > ℹ️ These automatic commits keep your repository up-to-date with new versions of [create-typescript-app](https://github.com/JoshuaKGoldberg/create-typescript-app). If you want to opt out, delete your \`.github/workflows/cta-transitions.yml\` file.
 			  using: composite
 			",
 			      },
@@ -87,12 +79,15 @@ describe("blockCTATransitions", () => {
 			      - if: steps.check.outcome == 'skipped'
 			        run: echo 'Skipping transition mode because the PR does not appear to be an automated or owner-created update to create-typescript-app.'
 
+
 			name: CTA
+
 
 			on:
 			  pull_request:
 			    branches:
 			      - main
+
 
 			permissions:
 			  pull-requests: write

--- a/src/blocks/blockCTATransitions.test.ts
+++ b/src/blocks/blockCTATransitions.test.ts
@@ -52,7 +52,9 @@ describe("blockCTATransitions", () => {
 			        issue: \${{ github.event.pull_request.number }}
 			        message: |-
 			          🤖 Beep boop! I ran \`npx create-typescript-app\` and it updated some files.
+
 			          I went ahead and checked those changes into this PR for you. Please review the latest commit to see if you want to merge it.
+
 			          Cheers!
 			           — _The Friendly Bingo Bot_ 💝
 

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -4,7 +4,7 @@ import { resolveUses } from "./actions/resolveUses.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
-import { formatYamlAction } from "./files/formatYamlAction.js";
+import { formatYaml } from "./files/formatYaml.js";
 
 export const blockCTATransitions = base.createBlock({
 	about: {
@@ -28,7 +28,7 @@ export const blockCTATransitions = base.createBlock({
 				".github": {
 					actions: {
 						transition: {
-							"action.yml": formatYamlAction({
+							"action.yml": formatYaml({
 								description: "Runs create-typescript-app in transition mode",
 								name: "Transition",
 								runs: {

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -65,7 +65,9 @@ export const blockCTATransitions = base.createBlock({
 												issue: "${{ github.event.pull_request.number }}",
 												message: [
 													"🤖 Beep boop! I ran `npx create-typescript-app` and it updated some files.",
+													"",
 													"I went ahead and checked those changes into this PR for you. Please review the latest commit to see if you want to merge it.",
+													"",
 													"Cheers!",
 													" — _The Friendly Bingo Bot_ 💝",
 													"",

--- a/src/blocks/blockGitHubActionsCI.test.ts
+++ b/src/blocks/blockGitHubActionsCI.test.ts
@@ -49,7 +49,9 @@ describe("blockGitHubActionsCI", () => {
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0
 
+
 			name: Accessibility Alt Text Bot
+
 
 			on:
 			  issue_comment:
@@ -64,6 +66,7 @@ describe("blockGitHubActionsCI", () => {
 			    types:
 			      - edited
 			      - opened
+
 
 			permissions:
 			  issues: write
@@ -82,12 +85,15 @@ describe("blockGitHubActionsCI", () => {
 			          echo "Don't worry if the previous step failed."
 			          echo "See https://github.com/actions-ecosystem/action-remove-labels/issues/221."
 
+
 			name: PR Review Requested
+
 
 			on:
 			  pull_request_target:
 			    types:
 			      - review_requested
+
 
 			permissions:
 			  pull-requests: write
@@ -153,7 +159,9 @@ describe("blockGitHubActionsCI", () => {
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0
 
+
 			name: Accessibility Alt Text Bot
+
 
 			on:
 			  issue_comment:
@@ -168,6 +176,7 @@ describe("blockGitHubActionsCI", () => {
 			    types:
 			      - edited
 			      - opened
+
 
 			permissions:
 			  issues: write
@@ -186,12 +195,15 @@ describe("blockGitHubActionsCI", () => {
 			          echo "Don't worry if the previous step failed."
 			          echo "See https://github.com/actions-ecosystem/action-remove-labels/issues/221."
 
+
 			name: PR Review Requested
+
 
 			on:
 			  pull_request_target:
 			    types:
 			      - review_requested
+
 
 			permissions:
 			  pull-requests: write
@@ -264,7 +276,9 @@ describe("blockGitHubActionsCI", () => {
 			    steps:
 			      - uses: github/accessibility-alt-text-bot@v1.4.0
 
+
 			name: Accessibility Alt Text Bot
+
 
 			on:
 			  issue_comment:
@@ -279,6 +293,7 @@ describe("blockGitHubActionsCI", () => {
 			    types:
 			      - edited
 			      - opened
+
 
 			permissions:
 			  issues: write
@@ -298,7 +313,9 @@ describe("blockGitHubActionsCI", () => {
 			        with:
 			          VAR_WITH: 'true'
 
+
 			name: CI
+
 
 			on:
 			  pull_request: ~
@@ -318,12 +335,15 @@ describe("blockGitHubActionsCI", () => {
 			          echo "Don't worry if the previous step failed."
 			          echo "See https://github.com/actions-ecosystem/action-remove-labels/issues/221."
 
+
 			name: PR Review Requested
+
 
 			on:
 			  pull_request_target:
 			    types:
 			      - review_requested
+
 
 			permissions:
 			  pull-requests: write

--- a/src/blocks/blockGitHubActionsCI.ts
+++ b/src/blocks/blockGitHubActionsCI.ts
@@ -6,7 +6,7 @@ import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { createMultiWorkflowFile } from "./files/createMultiWorkflowFile.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
-import { formatYamlAction } from "./files/formatYamlAction.js";
+import { formatYaml } from "./files/formatYaml.js";
 
 export const zActionStep = z.intersection(
 	z.object({
@@ -46,7 +46,7 @@ export const blockGitHubActionsCI = base.createBlock({
 				".github": {
 					actions: {
 						prepare: {
-							"action.yml": formatYamlAction({
+							"action.yml": formatYaml({
 								description: "Prepares the repo for a typical CI job",
 								name: "Prepare",
 								runs: {

--- a/src/blocks/blockReleaseIt.test.ts
+++ b/src/blocks/blockReleaseIt.test.ts
@@ -88,12 +88,15 @@ describe("blockReleaseIt", () => {
 
 			              Cheers! 📦🚀
 
+
 			name: Post Release
+
 
 			on:
 			  release:
 			    types:
 			      - published
+
 
 			permissions:
 			  issues: write
@@ -101,6 +104,7 @@ describe("blockReleaseIt", () => {
 			",
 			        "release.yml": "concurrency:
 			  group: \${{ github.workflow }}
+
 
 			jobs:
 			  release:
@@ -117,12 +121,15 @@ describe("blockReleaseIt", () => {
 			          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
 			        uses: JoshuaKGoldberg/release-it-action@v0.2.2
 
+
 			name: Release
+
 
 			on:
 			  push:
 			    branches:
 			      - main
+
 
 			permissions:
 			  contents: write
@@ -237,12 +244,15 @@ describe("blockReleaseIt", () => {
 
 			              Cheers! 📦🚀
 
+
 			name: Post Release
+
 
 			on:
 			  release:
 			    types:
 			      - published
+
 
 			permissions:
 			  issues: write
@@ -250,6 +260,7 @@ describe("blockReleaseIt", () => {
 			",
 			        "release.yml": "concurrency:
 			  group: \${{ github.workflow }}
+
 
 			jobs:
 			  release:
@@ -269,12 +280,15 @@ describe("blockReleaseIt", () => {
 			          NPM_TOKEN: \${{ secrets.NPM_TOKEN }}
 			        uses: JoshuaKGoldberg/release-it-action@v0.2.2
 
+
 			name: Release
+
 
 			on:
 			  push:
 			    branches:
 			      - main
+
 
 			permissions:
 			  contents: write

--- a/src/blocks/files/formatYaml.ts
+++ b/src/blocks/files/formatYaml.ts
@@ -23,5 +23,8 @@ const options: jsYaml.DumpOptions = {
 };
 
 export function formatYaml(value: unknown) {
-	return removeUsesQuotes(jsYaml.dump(value, options));
+	return removeUsesQuotes(jsYaml.dump(value, options)).replaceAll(
+		/\n(\S)/g,
+		"\n\n$1",
+	);
 }

--- a/src/blocks/files/formatYamlAction.ts
+++ b/src/blocks/files/formatYamlAction.ts
@@ -1,7 +1,0 @@
-import jsYaml from "js-yaml";
-
-import { removeUsesQuotes } from "./removeUsesQuotes.js";
-
-export function formatYamlAction(value: object) {
-	return removeUsesQuotes(jsYaml.dump(value).replaceAll(/\n(\S)/g, "\n\n$1"));
-}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2097
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Whatever reason I had for having two different calls to `jsYaml.dump` is, I think, no longer there. This normalizes all YAML printing to go through the standard `formatYaml`. YAML files now always have a blank line between root-level properties.

🎁 