### PR TITLE
fix: read keywords from package.json during transition

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -65,11 +65,11 @@ For example, customizing the npm author and funding source to different values t
 npx create-typescript-app --author my-npm-username --funding MyGitHubOrganization
 ```
 
-Array flags can be specified as space-delineated strings and/or multiple times.
-For example, customizing keywords to three:
+Array flags can be specified as multiple times.
+For example, customizing keywords to two:
 
 ```shell
-npx create-typescript-app --keywords eslint --keywords "javascript typescript"
+npx create-typescript-app --keywords eslint --keywords typescript
 ```
 
 ## Block Exclusion Flags

--- a/src/base.ts
+++ b/src/base.ts
@@ -22,6 +22,7 @@ import { readFileSafe } from "./options/readFileSafe.js";
 import { readFunding } from "./options/readFunding.js";
 import { readGitDefaults } from "./options/readGitDefaults.js";
 import { readGuide } from "./options/readGuide.js";
+import { readKeywords } from "./options/readKeywords.js";
 import { readLogo } from "./options/readLogo.js";
 import { readNode } from "./options/readNode.js";
 import { readNpmDefaults } from "./options/readNpmDefaults.js";
@@ -208,6 +209,10 @@ export const base = createBase({
 				),
 		);
 
+		const getKeywords = lazyValue(
+			async () => await readKeywords(getPackageData),
+		);
+
 		const getEmailFromCodeOfConduct = lazyValue(
 			async () => await readEmailFromCodeOfConduct(take),
 		);
@@ -309,6 +314,7 @@ export const base = createBase({
 			explainer: getExplainer,
 			funding: getFunding,
 			guide: getGuide,
+			keywords: getKeywords,
 			logo: getLogo,
 			node: getNode,
 			owner: getOwner,

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -142,7 +142,7 @@ describe("blockPackageJson", () => {
 		expect(creation).toMatchInlineSnapshot(`
 			{
 			  "files": {
-			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","keywords":["abc","def","ghi"],"repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","files":["README.md","package.json"],"engines":{"node":">=20.12.0"}}",
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","keywords":["abc","def ghi"],"repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"license":"MIT","author":{"email":"npm@email.com"},"type":"module","files":["README.md","package.json"],"engines":{"node":">=20.12.0"}}",
 			  },
 			  "scripts": [
 			    {

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -67,9 +67,7 @@ export const blockPackageJson = base.createBlock({
 							]
 								.filter(Boolean)
 								.sort(),
-							keywords: options.keywords?.flatMap((keyword) =>
-								keyword.split(/ /),
-							),
+							keywords: options.keywords,
 							license: "MIT",
 							name: options.repository,
 							repository: {

--- a/src/options/readKeywords.test.ts
+++ b/src/options/readKeywords.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { readKeywords } from "./readKeywords.js";
+
+describe(readKeywords, () => {
+	it("resolves with undefined when there are no existing keywords", async () => {
+		const actual = await readKeywords(() => Promise.resolve({}));
+
+		expect(actual).toBeUndefined();
+	});
+
+	it("resolves with deduplicated and sorted keywords when there are existing keywords", async () => {
+		const actual = await readKeywords(() =>
+			Promise.resolve({
+				keywords: ["b", "a", "c d", "b", "a"],
+			}),
+		);
+
+		expect(actual).toEqual(["a", "b", "c d"]);
+	});
+});

--- a/src/options/readKeywords.ts
+++ b/src/options/readKeywords.ts
@@ -1,0 +1,11 @@
+import { PartialPackageData } from "../types.js";
+
+export async function readKeywords(
+	getPackageData: () => Promise<PartialPackageData>,
+) {
+	const { keywords } = await getPackageData();
+
+	return (
+		keywords && Array.from(new Set((await getPackageData()).keywords)).sort()
+	);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface PartialPackageData {
 	devDependencies?: Record<string, string>;
 	email?: string;
 	engines?: { node?: string };
+	keywords?: string[];
 	name?: string;
 	packageManager?: string;
 	publishConfig?: PartialPublishConfig;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2094
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Removes the removal & flat-mapping from spaces because keywords actually can have spaces in them. CLI folks will have to specify them individually.

🎁 