### PR TITLE
fix: infer author email from package.json if available

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -206,6 +206,7 @@ export const base = createBase({
 					getEmailFromCodeOfConduct,
 					getEmailFromGit,
 					getEmailFromNpm,
+					getPackageAuthor,
 				),
 		);
 

--- a/src/options/readAuthor.test.ts
+++ b/src/options/readAuthor.test.ts
@@ -4,16 +4,16 @@ import { readAuthor } from "./readAuthor.js";
 
 describe(readAuthor, () => {
 	it("returns package author when it exists", async () => {
-		const author = "test-author";
+		const name = "test-author";
 		const getNpmDefaults = vi.fn();
 
 		const actual = await readAuthor(
-			() => Promise.resolve({ author }),
+			() => Promise.resolve({ name }),
 			getNpmDefaults,
 			undefined,
 		);
 
-		expect(actual).toBe(author);
+		expect(actual).toBe(name);
 		expect(getNpmDefaults).not.toHaveBeenCalled();
 	});
 

--- a/src/options/readAuthor.ts
+++ b/src/options/readAuthor.ts
@@ -1,9 +1,11 @@
+import { PackageAuthor } from "./readPackageAuthor.js";
+
 export async function readAuthor(
-	getPackageAuthor: () => Promise<{ author?: string }>,
+	getPackageAuthor: () => Promise<PackageAuthor>,
 	getNpmDefaults: () => Promise<undefined | { name?: string }>,
 	owner: string | undefined,
 ) {
 	return (
-		(await getPackageAuthor()).author ?? (await getNpmDefaults())?.name ?? owner
+		(await getPackageAuthor()).name ?? (await getNpmDefaults())?.name ?? owner
 	);
 }

--- a/src/options/readEmailFromNpm.ts
+++ b/src/options/readEmailFromNpm.ts
@@ -1,8 +1,10 @@
 import { UserInfo } from "npm-user";
 
+import { PackageAuthor } from "./readPackageAuthor.js";
+
 export async function readEmailFromNpm(
 	getNpmDefaults: () => Promise<undefined | UserInfo>,
-	getPackageAuthor: () => Promise<{ email: string | undefined }>,
+	getPackageAuthor: () => Promise<PackageAuthor>,
 ) {
 	return (await getNpmDefaults())?.email ?? (await getPackageAuthor()).email;
 }

--- a/src/options/readEmails.test.ts
+++ b/src/options/readEmails.test.ts
@@ -12,6 +12,7 @@ describe(readEmails, () => {
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(undefined),
+			() => Promise.resolve({}),
 		);
 
 		expect(actual).toBeUndefined();
@@ -22,6 +23,7 @@ describe(readEmails, () => {
 			() => Promise.resolve(emailCoC),
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(undefined),
+			() => Promise.resolve({}),
 		);
 
 		expect(actual).toEqual({ github: emailCoC, npm: emailCoC });
@@ -32,6 +34,7 @@ describe(readEmails, () => {
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(emailNpm),
+			() => Promise.resolve({}),
 		);
 
 		expect(actual).toEqual({ github: emailNpm, npm: emailNpm });
@@ -42,6 +45,7 @@ describe(readEmails, () => {
 			() => Promise.resolve(emailCoC),
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(emailNpm),
+			() => Promise.resolve({}),
 		);
 
 		expect(actual).toEqual({ github: emailCoC, npm: emailNpm });
@@ -52,8 +56,20 @@ describe(readEmails, () => {
 			() => Promise.resolve(undefined),
 			() => Promise.resolve(emailGit),
 			() => Promise.resolve(emailNpm),
+			() => Promise.resolve({}),
 		);
 
 		expect(actual).toEqual({ github: emailGit, npm: emailNpm });
+	});
+
+	it("resolves package author email as the github and npm emails when only the package author email exists", async () => {
+		const actual = await readEmails(
+			() => Promise.resolve(undefined),
+			() => Promise.resolve(undefined),
+			() => Promise.resolve(undefined),
+			() => Promise.resolve({ email: emailNpm }),
+		);
+
+		expect(actual).toEqual({ github: emailNpm, npm: emailNpm });
 	});
 });

--- a/src/options/readEmails.ts
+++ b/src/options/readEmails.ts
@@ -1,11 +1,15 @@
+import { PackageAuthor } from "./readPackageAuthor.js";
+
 export async function readEmails(
 	getEmailFromCodeOfConduct: () => Promise<string | undefined>,
 	getEmailFromGit: () => Promise<string | undefined>,
 	getEmailFromNpm: () => Promise<string | undefined>,
+	getPackageAuthor: () => Promise<PackageAuthor>,
 ) {
 	const github =
 		(await getEmailFromCodeOfConduct()) ?? (await getEmailFromGit());
-	const npm = (await getEmailFromNpm()) ?? github;
+	const npm =
+		(await getPackageAuthor()).email ?? (await getEmailFromNpm()) ?? github;
 
 	return npm ? { github: github || npm, npm } : undefined;
 }

--- a/src/options/readOwner.test.ts
+++ b/src/options/readOwner.test.ts
@@ -7,24 +7,24 @@ describe(readOwner, () => {
 		const take = vi.fn();
 		const organization = "test-organization";
 		const getGitDefaults = vi.fn().mockResolvedValueOnce({ organization });
-		const getPackageDataFull = vi.fn();
+		const getPackageAuthor = vi.fn();
 
-		const actual = await readOwner(take, getGitDefaults, getPackageDataFull);
+		const actual = await readOwner(take, getGitDefaults, getPackageAuthor);
 
 		expect(actual).toBe(organization);
 		expect(take).not.toHaveBeenCalled();
-		expect(getPackageDataFull).not.toHaveBeenCalled();
+		expect(getPackageAuthor).not.toHaveBeenCalled();
 	});
 
 	it("returns package data author when only it exists", async () => {
 		const take = vi.fn();
-		const author = "test-author";
+		const name = "test-author";
 		const getGitDefaults = vi.fn();
-		const getPackageDataFull = vi.fn().mockResolvedValueOnce({ author });
+		const getPackageAuthor = vi.fn().mockResolvedValueOnce({ name });
 
-		const actual = await readOwner(take, getGitDefaults, getPackageDataFull);
+		const actual = await readOwner(take, getGitDefaults, getPackageAuthor);
 
-		expect(actual).toBe(author);
+		expect(actual).toBe(name);
 		expect(take).not.toHaveBeenCalled();
 	});
 
@@ -32,9 +32,9 @@ describe(readOwner, () => {
 		const user = "test-user";
 		const take = vi.fn().mockResolvedValueOnce({ stdout: user });
 		const getGitDefaults = vi.fn();
-		const getPackageDataFull = vi.fn().mockResolvedValueOnce({});
+		const getPackageAuthor = vi.fn().mockResolvedValueOnce({});
 
-		const actual = await readOwner(take, getGitDefaults, getPackageDataFull);
+		const actual = await readOwner(take, getGitDefaults, getPackageAuthor);
 
 		expect(actual).toBe(user);
 	});
@@ -42,9 +42,9 @@ describe(readOwner, () => {
 	it("returns undefined when no values exist", async () => {
 		const take = vi.fn().mockResolvedValueOnce({});
 		const getGitDefaults = vi.fn();
-		const getPackageDataFull = vi.fn().mockResolvedValueOnce({});
+		const getPackageAuthor = vi.fn().mockResolvedValueOnce({});
 
-		const actual = await readOwner(take, getGitDefaults, getPackageDataFull);
+		const actual = await readOwner(take, getGitDefaults, getPackageAuthor);
 
 		expect(actual).toBe(undefined);
 	});

--- a/src/options/readOwner.ts
+++ b/src/options/readOwner.ts
@@ -2,14 +2,16 @@ import { TakeInput } from "bingo";
 import { GitUrl } from "git-url-parse";
 import { inputFromScript } from "input-from-script";
 
+import { PackageAuthor } from "./readPackageAuthor.js";
+
 export async function readOwner(
 	take: TakeInput,
 	getGitDefaults: () => Promise<GitUrl | undefined>,
-	getPackageAuthor: () => Promise<{ author?: string }>,
+	getPackageAuthor: () => Promise<PackageAuthor>,
 ) {
 	return (
 		(await getGitDefaults())?.organization ??
-		(await getPackageAuthor()).author ??
+		(await getPackageAuthor()).name ??
 		(
 			await take(inputFromScript, {
 				command: "gh config get user -h github.com",

--- a/src/options/readPackageAuthor.test.ts
+++ b/src/options/readPackageAuthor.test.ts
@@ -5,17 +5,17 @@ import { readPackageAuthor } from "./readPackageAuthor.js";
 describe(readPackageAuthor, () => {
 	it.each([
 		[{}, {}],
-		[{ author: "abc123" }, { author: "abc123" }],
+		[{ name: "abc123" }, { author: "abc123" }],
 		[
-			{ author: "abc123", email: "def@ghi.com" },
+			{ email: "def@ghi.com", name: "abc123" },
 			{ author: "abc123 <def@ghi.com>" },
 		],
 		[
-			{ author: "abc123", email: "def@ghi.com" },
+			{ email: "def@ghi.com", name: "abc123" },
 			{ author: "abc123 <def@ghi.com>" },
 		],
 		[
-			{ author: "abc123", email: "def@ghi.com" },
+			{ email: "def@ghi.com", name: "abc123" },
 			{ author: { email: "def@ghi.com", name: "abc123" } },
 		],
 	])("returns %s when given %s", async (expected, packageDataFull) => {

--- a/src/options/readPackageAuthor.ts
+++ b/src/options/readPackageAuthor.ts
@@ -2,24 +2,24 @@ import parse from "parse-author";
 
 import { PartialPackageData } from "../types.js";
 
+export interface PackageAuthor {
+	email?: string | undefined;
+	name?: string | undefined;
+}
+
 export async function readPackageAuthor(
 	getPackageDataFull: () => Promise<PartialPackageData>,
-) {
+): Promise<PackageAuthor> {
 	const packageData = await getPackageDataFull();
-	let packageAuthor: string | undefined;
-	let packageEmail: string | undefined;
 
-	if (typeof packageData.author === "string") {
-		const parsedAuthor = parse(packageData.author);
-		packageAuthor = parsedAuthor.name;
-		packageEmail = parsedAuthor.email;
-	} else if (packageData.author) {
-		packageAuthor = packageData.author.name;
-		packageEmail = packageData.author.email;
+	switch (typeof packageData.author) {
+		case "object":
+			return packageData.author;
+
+		case "string":
+			return parse(packageData.author);
+
+		default:
+			return {};
 	}
-
-	return {
-		author: packageAuthor,
-		email: packageEmail,
-	};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface AllContributorsData {
 }
 
 export interface PartialPackageData {
-	author?: string | { email: string; name: string };
+	author?: string | { email?: string; name?: string };
 	bin?: Record<string, string> | string;
 	dependencies?: Record<string, string>;
 	description?: string;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2093
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Also renames the internal author data field's `author` to `name` so we can directly return `package.json` author data.

🎁 