### PR TITLE
feat: support parsing existing package.json descriptions as markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"json5": "^2.2.3",
 		"lazy-value": "^3.0.0",
 		"lodash": "^4.17.21",
+		"marked": "^15.0.7",
 		"npm-user": "^6.1.1",
 		"object-strings-deep": "^0.1.1",
 		"parse-author": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      marked:
+        specifier: ^15.0.7
+        version: 15.0.7
       npm-user:
         specifier: ^6.1.1
         version: 6.1.1
@@ -3097,6 +3100,11 @@ packages:
   markdownlint@0.37.4:
     resolution: {integrity: sha512-u00joA/syf3VhWh6/ybVFkib5Zpj2e5KB/cfCei8fkSRuums6nyisTWGqjTWIOFoFwuXoTBQQiqlB4qFKp8ncQ==}
     engines: {node: '>=18'}
+
+  marked@15.0.7:
+    resolution: {integrity: sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
@@ -7402,6 +7410,8 @@ snapshots:
       micromark-util-types: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  marked@15.0.7: {}
 
   mdast-util-from-markdown@0.8.5:
     dependencies:

--- a/src/base.ts
+++ b/src/base.ts
@@ -185,7 +185,8 @@ export const base = createBase({
 		const getEmoji = lazyValue(async () => await readEmoji(getDescription));
 
 		const getDescription = lazyValue(
-			async () => await readDescription(getPackageData, getReadme),
+			async () =>
+				await readDescription(getPackageData, getReadme, getRepository),
 		);
 
 		const getDevelopmentDocumentation = lazyValue(

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -6,7 +6,7 @@ import { PackageJson } from "zod-package-json";
 
 import { base } from "../base.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
-import { htmlToTextSafe } from "./html/htmlToTextSafe.js";
+import { htmlToTextSafe } from "../utils/htmlToTextSafe.js";
 import { CommandPhase } from "./phases.js";
 
 const PackageJsonWithNullableScripts = PackageJson.partial().extend({

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { PackageJson } from "zod-package-json";
 
 import { base } from "../base.js";
-import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { htmlToTextSafe } from "../utils/htmlToTextSafe.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { CommandPhase } from "./phases.js";
 
 const PackageJsonWithNullableScripts = PackageJson.partial().extend({

--- a/src/blocks/blockRepositorySettings.test.ts
+++ b/src/blocks/blockRepositorySettings.test.ts
@@ -43,7 +43,7 @@ describe("blockRepositorySettings", () => {
 		`);
 	});
 
-	test("with a long description", () => {
+	test("with a long HTML description", () => {
 		const creation = testBlock(blockRepositorySettings, {
 			options: {
 				...optionsBase,

--- a/src/blocks/blockRepositorySettings.ts
+++ b/src/blocks/blockRepositorySettings.ts
@@ -1,5 +1,5 @@
 import { base } from "../base.js";
-import { htmlToTextSafe } from "./html/htmlToTextSafe.js";
+import { htmlToTextSafe } from "../utils/htmlToTextSafe.js";
 
 export const blockRepositorySettings = base.createBlock({
 	about: {

--- a/src/blocks/html/htmlToTextSafe.ts
+++ b/src/blocks/html/htmlToTextSafe.ts
@@ -1,5 +1,0 @@
-import { convert } from "html-to-text";
-
-export function htmlToTextSafe(raw: string) {
-	return convert(raw, { wordwrap: false });
-}

--- a/src/options/readDescription.test.ts
+++ b/src/options/readDescription.test.ts
@@ -23,7 +23,7 @@ describe(readDescription, () => {
 		expect(mockPackageDataDescription).not.toHaveBeenCalled();
 	});
 
-	it("returns undefined when the description matches the current package.json description", async () => {
+	it("returns the README.md description when it matches the current package.json description", async () => {
 		const existing = "Same description.";
 
 		mockPackageDataDescription.mockReturnValueOnce(existing);
@@ -33,10 +33,10 @@ describe(readDescription, () => {
 			() => Promise.resolve(""),
 		);
 
-		expect(description).toBeUndefined();
+		expect(description).toBe(existing);
 	});
 
-	it("returns the updated description when neither description nor name match the current package.json", async () => {
+	it("returns the updated package.json description when neither description nor name match the current package.json", async () => {
 		const updated = "Updated description.";
 
 		mockPackageDataDescription.mockReturnValueOnce("Existing description");
@@ -49,7 +49,7 @@ describe(readDescription, () => {
 		expect(description).toBe(updated);
 	});
 
-	it("uses the README.md HTML description when it matches what's inferred from package.json plus HTML tags", async () => {
+	it("uses a README.md HTML description when it matches plain text from package.json plus HTML tags", async () => {
 		const plaintext = "Updated description.";
 		const encoded = "Updated <code>description</code>.";
 
@@ -63,7 +63,21 @@ describe(readDescription, () => {
 		expect(description).toBe(encoded);
 	});
 
-	it("uses the package.json description when the README.md HTML description doesn't match what's inferred from package.json plus HTML tags", async () => {
+	it("uses a README.md HTML description when it matches markdown from package.json plus HTML tags", async () => {
+		const markdown = "Before `inner` after.";
+		const html = `Before <a href="https://create.bingo"><code>inner</code></a> after.`;
+
+		mockPackageDataDescription.mockReturnValueOnce("Existing description");
+
+		const description = await readDescription(
+			() => Promise.resolve({ description: markdown }),
+			() => Promise.resolve(`<p align="center">${html}</p>`),
+		);
+
+		expect(description).toBe(html);
+	});
+
+	it("uses a plain text package.json description when the README.md HTML description doesn't match what's inferred from package.json plus HTML tags", async () => {
 		const plaintext = "Updated description.";
 		const encoded = "Incorrect <code>description</code>.";
 
@@ -75,5 +89,19 @@ describe(readDescription, () => {
 		);
 
 		expect(description).toBe(plaintext);
+	});
+
+	it("uses a markdown package.json description parsed to HTML when the README.md does not have a description and the package.json description is markdown", async () => {
+		const inPackageJson = "Updated _description_.";
+		const inReadme = "Incorrect <code>description</code>.";
+
+		mockPackageDataDescription.mockReturnValueOnce("Existing description");
+
+		const description = await readDescription(
+			() => Promise.resolve({ description: inPackageJson }),
+			() => Promise.resolve(`<p align="center">${inReadme}</p>`),
+		);
+
+		expect(description).toBe("Updated <em>description</em>.");
 	});
 });

--- a/src/options/readDescription.ts
+++ b/src/options/readDescription.ts
@@ -8,26 +8,41 @@ import { readDescriptionFromReadme } from "./readDescriptionFromReadme.js";
 export async function readDescription(
 	getPackageData: () => Promise<PartialPackageData>,
 	getReadme: () => Promise<string>,
+	getRepository: () => Promise<string | undefined>,
 ) {
+	// If we there is no package.json yet, this is probably setup mode.
 	const { description: fromPackageJson } = await getPackageData();
 	if (!fromPackageJson) {
 		return undefined;
 	}
 
+	// If only a a package.json exists, this is probably transition mode.
+	// We can use the package.json's description as the only source of truth.
 	const fromReadme = await readDescriptionFromReadme(getReadme);
 	if (!fromReadme) {
-		return fromPackageJson;
+		return marked.parseInline(fromPackageJson);
+	}
+
+	// If the package.json is create-typescript-app's but the repository isn't,
+	// we're almost certainly in transition mode after cloning the template.
+	if (
+		(await getRepository()) !== "create-typescript-app" &&
+		fromPackageJson === packageData.description
+	) {
+		return undefined;
 	}
 
 	const fromPackageJsonNormalized = htmlToTextSafe(
 		await marked.parseInline(fromPackageJson),
 	);
 	const fromReadmeNormalized = htmlToTextSafe(fromReadme);
-	if (fromReadmeNormalized === fromPackageJsonNormalized) {
-		return fromReadme;
+
+	// If the package.json and README.md don't match, we prefer the package.json,
+	// as it's what is used in publishing to npm.
+	if (fromReadmeNormalized !== fromPackageJsonNormalized) {
+		return await marked.parseInline(fromPackageJson);
 	}
 
-	return fromPackageJson === packageData.description
-		? undefined
-		: await marked.parseInline(fromPackageJson);
+	// Otherwise, if they do match, the README.md may have more rich HTML text.
+	return fromReadme;
 }

--- a/src/utils/htmlToTextSafe.ts
+++ b/src/utils/htmlToTextSafe.ts
@@ -1,0 +1,13 @@
+import { convert } from "html-to-text";
+
+export function htmlToTextSafe(raw: string) {
+	return convert(raw, {
+		selectors: [
+			{
+				options: { ignoreHref: true },
+				selector: "a",
+			},
+		],
+		wordwrap: false,
+	});
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1934
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes parsing around HTML (`README.md`) vs. markdown (`package.json`) descriptions smarter. [`marked`](https://marked.js.org) in inline mode is used to parse existing `package.json` descriptions, before they're checked against the README.md one.

Also normalizes the output `package.json`'s `description` to be plain text, since neither GitHub nor npm support rich text (https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1934#issuecomment-2776616064). Example improvement: https://github.com/JoshuaKGoldberg/eslint-plugin-erasable-syntax-only/pull/51/commits/c43f07b11c8bc42036c626900dc88743cdfbcb4c

🎁 