### PR TITLE
fix: correct readme templated-by parsing for multiple indicators

### DIFF
--- a/src/options/readReadmeAdditional.test.ts
+++ b/src/options/readReadmeAdditional.test.ts
@@ -107,4 +107,24 @@ After.
 
 		expect(result).toBe("After.");
 	});
+
+	it("excludes templated notices contributors when there are comment and quote template notices", async () => {
+		const getReadme = () =>
+			Promise.resolve(`# My Package
+
+Usage.
+
+<!-- spellchecker:enable -->
+
+After.
+
+<!-- You can remove this notice if you don't want it 🙂 no worries! -->
+
+> 💝 This package was templated with ...
+`);
+
+		const result = await readReadmeAdditional(getReadme);
+
+		expect(result).toBe("After.");
+	});
 });

--- a/src/options/readReadmeAdditional.ts
+++ b/src/options/readReadmeAdditional.ts
@@ -1,4 +1,4 @@
-import { indicatorTemplatedBy } from "./readReadmeFootnotes.js";
+import { indicatorsTemplatedBy } from "./readReadmeFootnotes.js";
 
 const indicatorAfterAllContributors = /<!--\s*ALL-CONTRIBUTORS-LIST:END\s*-->/;
 const indicatorAfterAllContributorsSpellCheck =
@@ -17,12 +17,18 @@ export async function readReadmeAdditional(getReadme: () => Promise<string>) {
 		return undefined;
 	}
 
-	const templatedByMatch = indicatorTemplatedBy.exec(readme);
+	const indexOfFirstTemplatedBy = indicatorsTemplatedBy.reduce(
+		(smallest, indicator) => {
+			const indexOf = indicator.exec(readme)?.index;
+			return indexOf ? Math.min(smallest, indexOf) : smallest;
+		},
+		readme.length,
+	);
 
 	return readme
 		.slice(
 			indexAfterContributors.index + indexAfterContributors[0].length,
-			templatedByMatch?.index,
+			indexOfFirstTemplatedBy,
 		)
 		.trim();
 }

--- a/src/options/readReadmeFootnotes.test.ts
+++ b/src/options/readReadmeFootnotes.test.ts
@@ -19,7 +19,7 @@ describe(readReadmeFootnotes, () => {
 		expect(result).toBeUndefined();
 	});
 
-	it("resolves undefined when there is no content after a templated by notice", async () => {
+	it("resolves undefined when there is no content after a quote templated by notice", async () => {
 		const getReadme = () =>
 			Promise.resolve(`# My Package
 			
@@ -32,7 +32,7 @@ describe(readReadmeFootnotes, () => {
 		expect(result).toBeUndefined();
 	});
 
-	it("resolves the content when there plain text content after a templated by notice", async () => {
+	it("resolves the content when there plain text content after a quote templated by notice", async () => {
 		const getReadme = () =>
 			Promise.resolve(`# My Package
 			
@@ -46,10 +46,26 @@ After.
 		expect(result).toBe("After.");
 	});
 
-	it("resolves the content when there are footnotes after a templated by notice", async () => {
+	it("resolves the content when there are footnotes after a quote templated by notice", async () => {
 		const getReadme = () =>
 			Promise.resolve(`# My Package
 			
+> 💖 This package was templated with etc. etc.
+
+[^1]: After.
+`);
+
+		const result = await readReadmeFootnotes(getReadme);
+
+		expect(result).toBe("[^1]: After.");
+	});
+
+	it("resolves the content when there are footnotes after a comment and quote templated by notice", async () => {
+		const getReadme = () =>
+			Promise.resolve(`# My Package
+
+<!-- You can remove this notice etc. etc. -->
+
 > 💖 This package was templated with etc. etc.
 
 [^1]: After.

--- a/src/options/readReadmeFootnotes.ts
+++ b/src/options/readReadmeFootnotes.ts
@@ -1,5 +1,7 @@
-export const indicatorTemplatedBy =
-	/> .* This package (?:is|was) (?:based|build|templated) (?:on|with) |<!-- You can remove this notice/;
+export const indicatorsTemplatedBy = [
+	/> .* This package (?:is|was) (?:based|build|templated) (?:on|with)/,
+	/<!-- You can remove this notice/,
+];
 
 export async function readReadmeFootnotes(getReadme: () => Promise<string>) {
 	const readme = await getReadme();
@@ -7,12 +9,18 @@ export async function readReadmeFootnotes(getReadme: () => Promise<string>) {
 		return undefined;
 	}
 
-	const indexOfTemplatedBy = indicatorTemplatedBy.exec(readme)?.index;
-	if (!indexOfTemplatedBy) {
+	const indexOfLastTemplatedBy = indicatorsTemplatedBy.reduce(
+		(largest, indicator) => {
+			const indexOf = indicator.exec(readme)?.index;
+			return indexOf ? Math.max(largest, indexOf) : largest;
+		},
+		0,
+	);
+	if (!indexOfLastTemplatedBy) {
 		return undefined;
 	}
 
-	const indexOfNextLine = readme.indexOf("\n", indexOfTemplatedBy);
+	const indexOfNextLine = readme.indexOf("\n", indexOfLastTemplatedBy);
 
 	return readme.slice(indexOfNextLine).trim() || undefined;
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2141
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The two parts of README.md parsing for documentation that care about these notices are:

* `additional`: which cares about the _first_ notice
* `footnotes`: which cares about the _last_ notice

I considered merging the two `read*` functions into a single one, but figured I could save that refactor for if this gets even more complicated / intertwined.

🎁 