### PR TITLE
fix: correct README.md parsing without an existing Usage h2

### DIFF
--- a/src/options/readReadmeExplainer.test.ts
+++ b/src/options/readReadmeExplainer.test.ts
@@ -37,7 +37,8 @@ describe(readReadmeExplainer, () => {
 This is my project.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual("This is my project.");
@@ -52,7 +53,8 @@ This is my project.
 It is good.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual("This is my project.\nIt is good.");
@@ -80,7 +82,8 @@ This is my project.
 It is good.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual("This is my project.\nIt is good.");
@@ -108,7 +111,8 @@ This is my project.
 It is good.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual("## What?\n\nThis is my project.\nIt is good.");
@@ -129,7 +133,8 @@ It is good.
 > See here.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual(
@@ -152,7 +157,8 @@ This is my project.
 It is good.
 
 ## Usage
-					.`),
+
+...`),
 		);
 
 		expect(actual).toEqual("## What?\n\nThis is my project.\nIt is good.");
@@ -175,7 +181,57 @@ It is good.
 > See here.
 
 ## Usage
-					.`),
+
+...`),
+		);
+
+		expect(actual).toEqual(
+			"## What?\n\nThis is my project.\nIt is good.\n\n> See here.",
+		);
+	});
+
+	it("returns existing content before a non-Usage h2 when the Usage h2 does not exist", async () => {
+		const actual = await readReadmeExplainer(() =>
+			Promise.resolve(`
+	<a href="http://npmjs.com/package/create-typescript-app"><img alt="📦 npm version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42&label=%F0%9F%93%A6%20npm" /></a>
+	<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/%F0%9F%92%AA_typescript-strict-21bb42.svg" />
+</p>
+
+<img align="right" alt="Project logo: the TypeScript blue square with rounded corners, but a plus sign instead of 'TS'" height="128" src="./docs/create-typescript-app.png" width="128">
+
+## What?
+
+This is my project.
+It is good.
+
+> See here.
+
+## Contributing
+
+...`),
+		);
+
+		expect(actual).toEqual(
+			"## What?\n\nThis is my project.\nIt is good.\n\n> See here.",
+		);
+	});
+
+	it("returns existing content until the end of the file when no subsequent h2 exists", async () => {
+		const actual = await readReadmeExplainer(() =>
+			Promise.resolve(`
+	<a href="http://npmjs.com/package/create-typescript-app"><img alt="📦 npm version" src="https://img.shields.io/npm/v/create-typescript-app?color=21bb42&label=%F0%9F%93%A6%20npm" /></a>
+	<img alt="💪 TypeScript: Strict" src="https://img.shields.io/badge/%F0%9F%92%AA_typescript-strict-21bb42.svg" />
+</p>
+
+<img align="right" alt="Project logo: the TypeScript blue square with rounded corners, but a plus sign instead of 'TS'" height="128" src="./docs/create-typescript-app.png" width="128">
+
+## What?
+
+This is my project.
+It is good.
+
+> See here.
+`),
 		);
 
 		expect(actual).toEqual(

--- a/src/options/readReadmeExplainer.ts
+++ b/src/options/readReadmeExplainer.ts
@@ -1,24 +1,24 @@
+const lastTagMatchers = [`">`, "/p>", "/>"];
+
 export async function readReadmeExplainer(getReadme: () => Promise<string>) {
 	const readme = await getReadme();
 
-	const indexOfUsageH2 = /## Usage/.exec(readme)?.index ?? readme.indexOf("##");
-	if (indexOfUsageH2 === -1) {
-		return undefined;
-	}
-
-	const beforeUsageH2 = readme.slice(0, indexOfUsageH2);
-
-	const [indexOfLastTag, lastTagMatcher] = lastLastIndexOf(beforeUsageH2, [
-		`">`,
-		"/p>",
-		"/>",
-	]);
+	const indexOfFirstH2 = readme.indexOf("##");
+	const indexOfUsageH2 = /## Usage/.exec(readme)?.index;
+	const beforeH2s = readme.slice(0, indexOfUsageH2 ?? indexOfFirstH2);
+	const [indexOfLastTag, lastTagMatcher] = lastLastIndexOf(
+		beforeH2s,
+		lastTagMatchers,
+	);
 	if (!lastTagMatcher) {
 		return undefined;
 	}
 
+	const endingIndex =
+		indexOfUsageH2 ?? /## (?:Contrib|Develop)/.exec(readme)?.index;
+
 	return readme
-		.slice(indexOfLastTag + lastTagMatcher.length, indexOfUsageH2)
+		.slice(indexOfLastTag + lastTagMatcher.length, endingIndex)
 		.trim();
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2140
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

https://github.com/JoshuaKGoldberg/prune-github-notifications didn't have a `## Usage` in its README.md, and instead of allowing all content until the next relevant h2 or end-of-file, the option was defaulting to `undefined`.

This reminds me that `blockREADME` hardcodes a `## Usage` in there - that's not an assumption I want to keep. But removing that assumption can be a followup.

🎁 