### PR TITLE
feat: switch Knip entry and project to Addons

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/knip@5.46.0/schema.json",
-	"entry": ["src/index.ts", "src/**/*.test.*"],
+	"entry": ["src/**/*.test.*", "src/index.ts"],
 	"ignoreDependencies": [
 		"all-contributors-cli",
 		"cspell-populate-words",

--- a/src/blocks/blockKnip.test.ts
+++ b/src/blocks/blockKnip.test.ts
@@ -61,7 +61,7 @@ describe("blockKnip", () => {
 			    },
 			  ],
 			  "files": {
-			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","entry":["src/index.ts","src/**/*.test.*"],"ignoreExportsUsedInFile":{"interface":true,"type":true},"project":["src/**/*.ts"]}",
+			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","ignoreExportsUsedInFile":{"interface":true,"type":true}}",
 			  },
 			}
 		`);
@@ -70,7 +70,9 @@ describe("blockKnip", () => {
 	test("with addons", () => {
 		const creation = testBlock(blockKnip, {
 			addons: {
+				entry: ["src/index.ts"],
 				ignoreDependencies: ["abc", "def"],
+				project: ["src/**/*.ts"],
 			},
 			options: optionsBase,
 		});
@@ -122,7 +124,7 @@ describe("blockKnip", () => {
 			    },
 			  ],
 			  "files": {
-			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","entry":["src/index.ts","src/**/*.test.*"],"ignoreDependencies":["abc","def"],"ignoreExportsUsedInFile":{"interface":true,"type":true},"project":["src/**/*.ts"]}",
+			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","entry":["src/index.ts"],"ignoreDependencies":["abc","def"],"ignoreExportsUsedInFile":{"interface":true,"type":true},"project":["src/**/*.ts"]}",
 			  },
 			}
 		`);
@@ -201,7 +203,7 @@ describe("blockKnip", () => {
 			    },
 			  ],
 			  "files": {
-			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","entry":["src/index.ts","src/**/*.test.*"],"ignoreExportsUsedInFile":{"interface":true,"type":true},"project":["src/**/*.ts"]}",
+			    "knip.json": "{"$schema":"https://unpkg.com/knip@5.46.0/schema.json","ignoreExportsUsedInFile":{"interface":true,"type":true}}",
 			  },
 			}
 		`);

--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -92,6 +92,17 @@ describe("blockTypeScript", () => {
 			    },
 			    {
 			      "addons": {
+			        "entry": [
+			          "src/index.ts",
+			        ],
+			        "project": [
+			          "src/**/*.ts",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
 			        "ignores": [
 			          "lib/",
 			        ],
@@ -244,6 +255,17 @@ describe("blockTypeScript", () => {
 			    },
 			    {
 			      "addons": {
+			        "entry": [
+			          "src/index.ts",
+			        ],
+			        "project": [
+			          "src/**/*.ts",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
 			        "ignores": [
 			          "lib/",
 			        ],
@@ -388,6 +410,17 @@ describe("blockTypeScript", () => {
 			              },
 			            ],
 			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "entry": [
+			          "src/index.ts",
+			        ],
+			        "project": [
+			          "src/**/*.ts",
 			        ],
 			      },
 			      "block": [Function],
@@ -547,6 +580,17 @@ describe("blockTypeScript", () => {
 			              },
 			            ],
 			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "entry": [
+			          "src/index.ts",
+			        ],
+			        "project": [
+			          "src/**/*.ts",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -8,6 +8,7 @@ import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockExampleFiles } from "./blockExampleFiles.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockGitignore } from "./blockGitignore.js";
+import { blockKnip } from "./blockKnip.js";
 import { blockMarkdownlint } from "./blockMarkdownlint.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRemoveWorkflows } from "./blockRemoveWorkflows.js";
@@ -80,6 +81,10 @@ export * from "./types.js";
 				}),
 				blockGitHubActionsCI({
 					jobs: [{ name: "Type Check", steps: [{ run: "pnpm tsc" }] }],
+				}),
+				blockKnip({
+					entry: ["src/index.ts"],
+					project: ["src/**/*.ts"],
 				}),
 				blockMarkdownlint({
 					ignores: ["lib/"],

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -167,6 +167,14 @@ describe("blockVitest", () => {
 			    },
 			    {
 			      "addons": {
+			        "entry": [
+			          "src/**/*.test.*",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
 			        "properties": {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "3.0.9",
@@ -399,6 +407,14 @@ describe("blockVitest", () => {
 			              },
 			            ],
 			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "entry": [
+			          "src/**/*.test.*",
 			        ],
 			      },
 			      "block": [Function],
@@ -681,6 +697,14 @@ describe("blockVitest", () => {
 			    },
 			    {
 			      "addons": {
+			        "entry": [
+			          "src/**/*.test.*",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
 			        "properties": {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "3.0.9",
@@ -922,6 +946,14 @@ describe("blockVitest", () => {
 			              },
 			            ],
 			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "entry": [
+			          "src/**/*.test.*",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -9,6 +9,7 @@ import { blockESLint } from "./blockESLint.js";
 import { blockExampleFiles } from "./blockExampleFiles.js";
 import { blockGitHubActionsCI, zActionStep } from "./blockGitHubActionsCI.js";
 import { blockGitignore } from "./blockGitignore.js";
+import { blockKnip } from "./blockKnip.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockPrettier } from "./blockPrettier.js";
 import { blockRemoveDependencies } from "./blockRemoveDependencies.js";
@@ -192,6 +193,9 @@ describe(greet, () => {
 							steps: [{ run: "pnpm run test --coverage" }, ...actionSteps],
 						},
 					],
+				}),
+				blockKnip({
+					entry: ["src/**/*.test.*"],
 				}),
 				blockPackageJson({
 					properties: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2147
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Goes a bit beyond #2147's original intended scope of `entry` by also making `project` an Addon. This way, `blockTypeScript` and `blockVitest` fully communicate all file globs to `blockKnip`.

Also expands `blockKnip`'s `intake` to read both of those new Addon properties. This will allow customizations such as https://github.com/JoshuaKGoldberg/refined-saved-replies's `entry: ["src/content-script.ts"]` to be inferred.

🎁 