### PR TITLE
feat: add intake method to blockESLint

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
 	],
 	"words": [
 		"Anson",
+		"TSESTree",
 		"apexskier",
 		"attw",
 		"boop",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"@typescript-eslint/typescript-estree": "^8.29.1",
 		"bingo": "^0.5.14",
 		"bingo-fs": "^0.5.5",
 		"bingo-stratum": "^0.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6576,7 +6576,7 @@ snapshots:
 
   eslint-plugin-perfectionist@4.10.1(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2):
     dependencies:
-      '@typescript-eslint/types': 8.27.0
+      '@typescript-eslint/types': 8.29.1
       '@typescript-eslint/utils': 8.27.0(eslint@9.22.0(jiti@2.4.2))(typescript@5.8.2)
       eslint: 9.22.0(jiti@2.4.2)
       natural-orderby: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@typescript-eslint/typescript-estree':
+        specifier: ^8.29.1
+        version: 8.29.1(typescript@5.8.2)
       bingo:
         specifier: ^0.5.14
         version: 0.5.14
@@ -1447,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-/6cp9yL72yUHAYq9g6DsAU+vVfvQmd1a8KyA81uvfDE21O2DwQ/qxlM4AR8TSdAu+kJLBDrEHKC5/W2/nxsY0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.29.1':
+    resolution: {integrity: sha512-VT7T1PuJF1hpYC3AGm2rCgJBjHL3nc+A/bhOp9sGMKfi5v0WufsX/sHCFBfNTx2F+zA6qBc/PD0/kLRLjdt8mQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.26.1':
     resolution: {integrity: sha512-yUwPpUHDgdrv1QJ7YQal3cMVBGWfnuCdKbXw1yyjArax3353rEJP1ZA+4F8nOlQ3RfS2hUN/wze3nlY+ZOhvoA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1455,6 +1462,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.27.0':
     resolution: {integrity: sha512-BnKq8cqPVoMw71O38a1tEb6iebEgGA80icSxW7g+kndx0o6ot6696HjG7NdgfuAVmVEtwXUr3L8R9ZuVjoQL6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.9.0'
+
+  '@typescript-eslint/typescript-estree@8.29.1':
+    resolution: {integrity: sha512-l1enRoSaUkQxOQnbi0KPUtqeZkSiFlqrx9/3ns2rEDhGKfTa+88RmXqedC1zmVTOWrLc2e6DEJrTA51C9iLH5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.9.0'
@@ -1479,6 +1492,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.27.0':
     resolution: {integrity: sha512-WsXQwMkILJvffP6z4U3FYJPlbf/j07HIxmDjZpbNvBJkMfvwXj5ACRkkHwBDvLBbDbtX5TdU64/rcvKJ/vuInQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.29.1':
+    resolution: {integrity: sha512-RGLh5CRaUEf02viP5c1Vh1cMGffQscyHe7HPAzGpfmfflFg1wUz2rYxd+OZqwpeypYvZ8UxSxuIpF++fmOzEcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/coverage-v8@3.0.9':
@@ -5538,6 +5555,8 @@ snapshots:
 
   '@typescript-eslint/types@8.27.0': {}
 
+  '@typescript-eslint/types@8.29.1': {}
+
   '@typescript-eslint/typescript-estree@8.26.1(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/types': 8.26.1
@@ -5556,6 +5575,20 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.27.0
       '@typescript-eslint/visitor-keys': 8.27.0
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      ts-api-utils: 2.1.0(typescript@5.8.2)
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.29.1(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.29.1
+      '@typescript-eslint/visitor-keys': 8.29.1
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -5596,6 +5629,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.27.0':
     dependencies:
       '@typescript-eslint/types': 8.27.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.29.1':
+    dependencies:
+      '@typescript-eslint/types': 8.29.1
       eslint-visitor-keys: 4.2.0
 
   '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.4.2)(tsx@4.19.2)(yaml@2.7.0))':

--- a/src/blocks/blockESLint.ts
+++ b/src/blocks/blockESLint.ts
@@ -12,56 +12,17 @@ import { blockRemoveDependencies } from "./blockRemoveDependencies.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRemoveWorkflows } from "./blockRemoveWorkflows.js";
 import { blockVSCode } from "./blockVSCode.js";
+import { blockESLintIntake } from "./eslint/blockESLintIntake.js";
+import {
+	Extension,
+	ExtensionRuleGroup,
+	ExtensionRules,
+	zExtension,
+	zExtensionRules,
+	zPackageImport,
+} from "./eslint/schemas.js";
+import { intakeFile } from "./intake/intakeFile.js";
 import { CommandPhase } from "./phases.js";
-
-const zRuleOptions = z.union([
-	z.literal("error"),
-	z.literal("off"),
-	z.literal("warn"),
-	z.union([
-		z.tuple([z.union([z.literal("error"), z.literal("warn")]), z.unknown()]),
-		z.tuple([
-			z.union([z.literal("error"), z.literal("warn")]),
-			z.unknown(),
-			z.unknown(),
-		]),
-	]),
-]);
-
-const zExtensionRuleGroup = z.object({
-	comment: z.string().optional(),
-	entries: z.record(z.string(), zRuleOptions),
-});
-
-type ExtensionRuleGroup = z.infer<typeof zExtensionRuleGroup>;
-
-const zExtensionRules = z.union([
-	z.record(z.string(), zRuleOptions),
-	z.array(zExtensionRuleGroup),
-]);
-
-type ExtensionRules = z.infer<typeof zExtensionRules>;
-
-const zExtension = z.object({
-	extends: z.array(z.string()).optional(),
-	files: z.array(z.string()).optional(),
-	languageOptions: z.unknown().optional(),
-	linterOptions: z.unknown().optional(),
-	plugins: z.record(z.string(), z.string()).optional(),
-	rules: zExtensionRules.optional(),
-	settings: z.record(z.string(), z.unknown()).optional(),
-});
-
-type Extension = z.infer<typeof zExtension>;
-
-const zPackageImport = z.object({
-	source: z.union([
-		z.string(),
-		z.object({ packageName: z.string(), version: z.string() }),
-	]),
-	specifier: z.string(),
-	types: z.boolean().optional(),
-});
 
 export const blockESLint = base.createBlock({
 	about: {
@@ -75,6 +36,13 @@ export const blockESLint = base.createBlock({
 		imports: z.array(zPackageImport).default([]),
 		rules: zExtensionRules.optional(),
 		settings: z.record(z.string(), z.unknown()).optional(),
+	},
+	intake({ files }) {
+		const eslintConfigRaw = intakeFile(files, [
+			["eslint.config.js", "eslint.config.mjs"],
+		]);
+
+		return eslintConfigRaw ? blockESLintIntake(eslintConfigRaw[0]) : undefined;
 	},
 	produce({ addons, options }) {
 		const { explanations, extensions, ignores, imports, rules, settings } =

--- a/src/blocks/blockESLintIntake.test.ts
+++ b/src/blocks/blockESLintIntake.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+
+import { blockESLintIntake } from "./eslint/blockESLintIntake.js";
+
+describe(blockESLintIntake, () => {
+	it.each([
+		["an empty string", ""],
+		["unrelated text", "other;"],
+		["raw export default", "export default {}"],
+		["config without arguments", "export default tseslint.config()"],
+		["config with too few arguments", "export default tseslint.config({})"],
+		[
+			"config with a first argument that is not ignores",
+			`
+				export default tseslint.config(
+					{ rules: {} },
+					{ settings: {} },
+				);
+			`,
+		],
+		[
+			"config with non-object argument",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					other,
+				);
+			`,
+		],
+		[
+			"config with object argument containing unknown properties",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					{ other },
+				);
+			`,
+		],
+		[
+			"config with object argument containing unknown computed properties",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					{ ['other']: {} },
+				);
+			`,
+		],
+		[
+			"config with object argument containing incomplete properties",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					{ rules: {} },
+				);
+			`,
+		],
+		[
+			"config with object argument containing misnamed properties",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					{ 
+						extends: {},
+						files: {},
+						other: {},
+						rules: {},
+						settings: {},
+					},
+				);
+			`,
+		],
+		[
+			"config with object argument containing computed rules",
+			`
+				export default tseslint.config(
+					{ ignores: [] },
+					{ 
+						extends: {},
+						files: {},
+						languageOptions: {},
+						rules: {
+							[other]: {},
+						},
+						settings: {},
+					},
+				);
+			`,
+		],
+	])("returns undefined when given %s", (_, sourceText) => {
+		const actual = blockESLintIntake(sourceText);
+
+		expect(actual).toBeUndefined();
+	});
+
+	it.each([
+		[
+			"non-commented group in rules",
+			`
+export default tseslint.config(
+	{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			"@typescript-eslint/prefer-nullish-coalescing": [
+				"error",
+				{ ignorePrimitives: true },
+			],
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{ allowBoolean: true },
+			],
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib", "node_modules", "pnpm-lock.yaml"],
+				rules: [
+					{
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": [
+								"error",
+								{ ignorePrimitives: true },
+							],
+							"@typescript-eslint/restrict-template-expressions": [
+								"error",
+								{ allowBoolean: true },
+							],
+						},
+					},
+				],
+			},
+		],
+		[
+			"one custom commented group in rules",
+			`
+export default tseslint.config(
+	{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			// These on-by-default rules work well for this repo if configured
+			"@typescript-eslint/prefer-nullish-coalescing": [
+				"error",
+				{ ignorePrimitives: true },
+			],
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{ allowBoolean: true },
+			],
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib", "node_modules", "pnpm-lock.yaml"],
+				rules: [
+					{
+						comment:
+							"These on-by-default rules work well for this repo if configured",
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": [
+								"error",
+								{ ignorePrimitives: true },
+							],
+							"@typescript-eslint/restrict-template-expressions": [
+								"error",
+								{ allowBoolean: true },
+							],
+						},
+					},
+				],
+			},
+		],
+		[
+			"one non-commented group and one commented group in rules",
+			`
+export default tseslint.config(
+	{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{ allowBoolean: true },
+			],
+
+			// These on-by-default rules work well for this repo if configured
+			"@typescript-eslint/prefer-nullish-coalescing": [
+				"error",
+				{ ignorePrimitives: true },
+			],
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib", "node_modules", "pnpm-lock.yaml"],
+				rules: [
+					{
+						entries: {
+							"@typescript-eslint/restrict-template-expressions": [
+								"error",
+								{ allowBoolean: true },
+							],
+						},
+					},
+					{
+						comment:
+							"These on-by-default rules work well for this repo if configured",
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": [
+								"error",
+								{ ignorePrimitives: true },
+							],
+						},
+					},
+				],
+			},
+		],
+		[
+			"one custom commented group in rules before the stylistic comment",
+			`
+export default tseslint.config(
+	{ ignores: ["lib"] },
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			// These on-by-default rules work well for this repo if configured
+			"@typescript-eslint/prefer-nullish-coalescing": [
+				"error",
+				{ ignorePrimitives: true },
+			],
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{ allowBoolean: true },
+			],
+
+			// Stylistic concerns that don't interfere with Prettier
+			"operator-assignment": "error",
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib"],
+				rules: [
+					{
+						comment:
+							"These on-by-default rules work well for this repo if configured",
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": [
+								"error",
+								{ ignorePrimitives: true },
+							],
+							"@typescript-eslint/restrict-template-expressions": [
+								"error",
+								{ allowBoolean: true },
+							],
+						},
+					},
+				],
+			},
+		],
+	])("returns data when given %s", (_, sourceText, expected) => {
+		const actual = blockESLintIntake(sourceText);
+
+		expect(actual).toEqual(expected);
+	});
+});

--- a/src/blocks/blockESLintMoreStyling.ts
+++ b/src/blocks/blockESLintMoreStyling.ts
@@ -1,6 +1,9 @@
 import { base } from "../base.js";
 import { blockESLint } from "./blockESLint.js";
 
+export const stylisticComment =
+	"Stylistic concerns that don't interfere with Prettier";
+
 export const blockESLintMoreStyling = base.createBlock({
 	about: {
 		name: "ESLint More Styling",
@@ -11,7 +14,7 @@ export const blockESLintMoreStyling = base.createBlock({
 				blockESLint({
 					rules: [
 						{
-							comment: "Stylistic concerns that don't interfere with Prettier",
+							comment: stylisticComment,
 							entries: {
 								"logical-assignment-operators": [
 									"error",

--- a/src/blocks/eslint/blockESLintIntake.ts
+++ b/src/blocks/eslint/blockESLintIntake.ts
@@ -1,0 +1,191 @@
+import {
+	AST_NODE_TYPES,
+	parse as parseAST,
+	TSESTree,
+} from "@typescript-eslint/typescript-estree";
+import JSON5 from "json5";
+
+import { tryCatch } from "../../utils/tryCatch.js";
+import { stylisticComment } from "../blockESLintMoreStyling.js";
+import { type ExtensionRuleGroup, zRuleOptions } from "./schemas.js";
+
+type ConfigExport = TSESTree.ExportDefaultDeclaration & {
+	declaration: TSESTree.CallExpression;
+};
+
+export function blockESLintIntake(sourceText: string) {
+	const ast = tryCatch(() =>
+		parseAST(sourceText, {
+			comment: true,
+			loc: true,
+			range: true,
+		}),
+	);
+	const configExport = ast?.body.find(nodeIsConfigExport);
+	if (!configExport) {
+		return undefined;
+	}
+
+	const configArguments = configExport.declaration.arguments;
+	if (configArguments.length < 2) {
+		return undefined;
+	}
+
+	const ignores = getConfigIgnores(configArguments[0]);
+	if (!ignores) {
+		return undefined;
+	}
+
+	const rulesObject = getConfigRulesObject(configArguments.slice(1));
+	if (!rulesObject) {
+		return undefined;
+	}
+
+	const rules = collectRulesObjectGroups(sourceText, rulesObject);
+	if (!rules) {
+		return undefined;
+	}
+
+	return { ignores, rules };
+
+	function areArraysEqual<T>(a: T[], b: T[]) {
+		if (a.length !== b.length) {
+			return false;
+		}
+
+		for (let i = 0; i < a.length; i++) {
+			if (a[i] !== b[i]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	function collectRuleFromProperty(property: TSESTree.ObjectLiteralElement) {
+		if (
+			property.type !== AST_NODE_TYPES.Property ||
+			property.key.type !== AST_NODE_TYPES.Literal ||
+			typeof property.key.value !== "string"
+		) {
+			return undefined;
+		}
+
+		const name = property.key.value;
+
+		const { data } = zRuleOptions.safeParse(
+			JSON5.parse(sourceText.slice(...property.value.range)),
+		);
+
+		return data && { entry: data, name };
+	}
+
+	function collectRulesObjectGroups(
+		sourceText: string,
+		rulesObject: TSESTree.ObjectExpression,
+	) {
+		let previousNode: TSESTree.Node | undefined;
+		let currentGroup: ExtensionRuleGroup | undefined;
+		const groups: ExtensionRuleGroup[] = [];
+
+		for (const property of rulesObject.properties) {
+			const precedingText = sourceText.slice(
+				(previousNode?.range[1] ?? rulesObject.range[0]) + 1,
+				property.range[0],
+			);
+			const comment =
+				precedingText.replaceAll(/\/\/|\n/g, "").trim() || undefined;
+
+			// blockESLintMoreStyling's comment always gets pushed to the end.
+			if (comment === stylisticComment) {
+				break;
+			}
+
+			const rule = collectRuleFromProperty(property);
+			if (!rule) {
+				return undefined;
+			}
+
+			if (!currentGroup || comment) {
+				currentGroup = { comment, entries: {} };
+				groups.push(currentGroup);
+			}
+
+			currentGroup.entries[rule.name] = rule.entry;
+			previousNode = property;
+		}
+
+		return groups;
+	}
+
+	function getConfigIgnores(node: TSESTree.Node) {
+		return (
+			node.type === AST_NODE_TYPES.ObjectExpression &&
+			node.properties.length === 1 &&
+			node.properties[0].type === AST_NODE_TYPES.Property &&
+			node.properties[0].key.type === AST_NODE_TYPES.Identifier &&
+			node.properties[0].key.name === "ignores" &&
+			node.properties[0].value.type === AST_NODE_TYPES.ArrayExpression &&
+			node.properties[0].value.elements.every(
+				(element): element is TSESTree.Literal & { value: string } =>
+					element?.type === AST_NODE_TYPES.Literal &&
+					typeof element.value === "string",
+			) &&
+			node.properties[0].value.elements.map(
+				(element) => element.value as string,
+			)
+		);
+	}
+
+	function getConfigRulesObject(nodes: TSESTree.Node[]) {
+		const configObject = nodes.find(
+			(node) => node.type === AST_NODE_TYPES.ObjectExpression,
+		);
+		if (!configObject) {
+			return undefined;
+		}
+
+		const configPropertyKeys = configObject.properties.map((property) =>
+			property.type === AST_NODE_TYPES.Property &&
+			property.key.type === AST_NODE_TYPES.Identifier
+				? property.key.name
+				: undefined,
+		);
+		if (
+			!areArraysEqual(configPropertyKeys, [
+				"extends",
+				"files",
+				"languageOptions",
+				"rules",
+				"settings",
+			])
+		) {
+			return undefined;
+		}
+
+		const rulesObject = configObject.properties[3];
+		return (
+			rulesObject.type === AST_NODE_TYPES.Property &&
+			rulesObject.value.type === AST_NODE_TYPES.ObjectExpression &&
+			rulesObject.value
+		);
+	}
+
+	function nodeIsConfigExport(node: TSESTree.Node): node is ConfigExport {
+		return (
+			node.type === AST_NODE_TYPES.ExportDefaultDeclaration &&
+			node.declaration.type === AST_NODE_TYPES.CallExpression &&
+			nodeIsConfigFunction(node.declaration.callee)
+		);
+	}
+
+	function nodeIsConfigFunction(node: TSESTree.Node) {
+		return (
+			node.type === AST_NODE_TYPES.MemberExpression &&
+			node.object.type === AST_NODE_TYPES.Identifier &&
+			node.object.name === "tseslint" &&
+			node.property.type === AST_NODE_TYPES.Identifier &&
+			node.property.name === "config"
+		);
+	}
+}

--- a/src/blocks/eslint/schemas.ts
+++ b/src/blocks/eslint/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+export const zRuleOptions = z.union([
+	z.literal("error"),
+	z.literal("off"),
+	z.literal("warn"),
+	z.tuple([z.union([z.literal("error"), z.literal("warn")]), z.unknown()]),
+	z.tuple([
+		z.union([z.literal("error"), z.literal("warn")]),
+		z.unknown(),
+		z.unknown(),
+	]),
+]);
+
+export type RuleOptions = z.infer<typeof zRuleOptions>;
+
+export const zExtensionRuleGroup = z.object({
+	comment: z.string().optional(),
+	entries: z.record(z.string(), zRuleOptions),
+});
+
+export type ExtensionRuleGroup = z.infer<typeof zExtensionRuleGroup>;
+
+export const zExtensionRules = z.union([
+	z.record(z.string(), zRuleOptions),
+	z.array(zExtensionRuleGroup),
+]);
+
+export type ExtensionRules = z.infer<typeof zExtensionRules>;
+
+export const zExtension = z.object({
+	extends: z.array(z.string()).optional(),
+	files: z.array(z.string()).optional(),
+	languageOptions: z.unknown().optional(),
+	linterOptions: z.unknown().optional(),
+	plugins: z.record(z.string(), z.string()).optional(),
+	rules: zExtensionRules.optional(),
+	settings: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type Extension = z.infer<typeof zExtension>;
+
+export const zPackageImport = z.object({
+	source: z.union([
+		z.string(),
+		z.object({ packageName: z.string(), version: z.string() }),
+	]),
+	specifier: z.string(),
+	types: z.boolean().optional(),
+});

--- a/src/blocks/intake/intakeFile.ts
+++ b/src/blocks/intake/intakeFile.ts
@@ -2,13 +2,22 @@ import { IntakeDirectory, IntakeFileEntry } from "bingo-fs";
 
 export function intakeFile(
 	files: IntakeDirectory,
-	filePath: string[],
+	filePath: (string | string[])[],
 ): IntakeFileEntry | undefined {
 	if (!filePath.length) {
 		return undefined;
 	}
 
-	const entry = files[filePath[0]];
+	const nextPathCandidates =
+		typeof filePath[0] === "string" ? [filePath[0]] : filePath[0];
+	const nextFilePath = nextPathCandidates.find(
+		(candidate) => candidate in files,
+	);
+	if (!nextFilePath) {
+		return undefined;
+	}
+
+	const entry = files[nextFilePath];
 
 	if (filePath.length === 1) {
 		return Array.isArray(entry) ? entry : undefined;

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -55,6 +55,7 @@ test("Producing the everything preset matches the files in this repository", asy
 				blockCSpell({
 					words: [
 						"Anson",
+						"TSESTree",
 						"apexskier",
 						"attw",
 						"boop",

--- a/src/utils/tryCatch.ts
+++ b/src/utils/tryCatch.ts
@@ -1,0 +1,7 @@
+export function tryCatch<T>(task: () => T | undefined) {
+	try {
+		return task();
+	} catch {
+		return undefined;
+	}
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2158
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is one of the more ridiculous things I've written recently. It:

1. Attempts to parse existing `eslint.config.{js,mjs}` content as a [`@typescript-eslint/typescript-estree`](https://typescript-eslint.io/packages/typescript-estree) tree
2. Find the `{ ignores: [...] }` from its first argument
3. Find the next `{ rules: ... }` from its remaining arguments
4. Parse rules groups using [JSON5.parse](https://www.npmjs.com/package/json5)

...and only if all steps return something looking like what we expect do we give back some data.

This is really beyond what I'd want folks to have to write in `intake`. I really wish for this all to be done automatically and reliably: https://github.com/JoshuaKGoldberg/bingo/issues/128. But that's going to be a lot more work I don't have time for soon.

🎁 