### PR TITLE
fix: allow linterOptions in blockESLintIntake

### DIFF
--- a/src/blocks/blockESLintIntake.test.ts
+++ b/src/blocks/blockESLintIntake.test.ts
@@ -94,6 +94,49 @@ describe(blockESLintIntake, () => {
 
 	it.each([
 		[
+			"rules group after linterOptions and member expression extends",
+			`
+export default tseslint.config(
+	{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
+	eslint.configs.recommended,
+	comments.recommended,
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			"@typescript-eslint/prefer-nullish-coalescing": [
+				"error",
+				{ ignorePrimitives: true },
+			],
+			"@typescript-eslint/restrict-template-expressions": [
+				"error",
+				{ allowBoolean: true },
+			],
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib", "node_modules", "pnpm-lock.yaml"],
+				rules: [
+					{
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": [
+								"error",
+								{ ignorePrimitives: true },
+							],
+							"@typescript-eslint/restrict-template-expressions": [
+								"error",
+								{ allowBoolean: true },
+							],
+						},
+					},
+				],
+			},
+		],
+		[
 			"non-commented group in rules",
 			`
 export default tseslint.config(

--- a/src/blocks/eslint/blockESLintIntake.ts
+++ b/src/blocks/eslint/blockESLintIntake.ts
@@ -139,27 +139,19 @@ export function blockESLintIntake(sourceText: string) {
 
 	function getConfigRulesObject(nodes: TSESTree.Node[]) {
 		const configObject = nodes.find(
-			(node) => node.type === AST_NODE_TYPES.ObjectExpression,
+			(node): node is TSESTree.ObjectExpression =>
+				node.type === AST_NODE_TYPES.ObjectExpression &&
+				areArraysEqual(
+					node.properties.map((property) =>
+						property.type === AST_NODE_TYPES.Property &&
+						property.key.type === AST_NODE_TYPES.Identifier
+							? property.key.name
+							: undefined,
+					),
+					["extends", "files", "languageOptions", "rules", "settings"],
+				),
 		);
 		if (!configObject) {
-			return undefined;
-		}
-
-		const configPropertyKeys = configObject.properties.map((property) =>
-			property.type === AST_NODE_TYPES.Property &&
-			property.key.type === AST_NODE_TYPES.Identifier
-				? property.key.name
-				: undefined,
-		);
-		if (
-			!areArraysEqual(configPropertyKeys, [
-				"extends",
-				"files",
-				"languageOptions",
-				"rules",
-				"settings",
-			])
-		) {
 			return undefined;
 		}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2168
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously the logic was to check if the first object expression after `ignores` has the five expected properties. Now it searches for the first matching object expression.

🎁 