### PR TITLE
fix: correct blockESLint intake multi-line comment parsing

### DIFF
--- a/src/blocks/blockESLintIntake.test.ts
+++ b/src/blocks/blockESLintIntake.test.ts
@@ -313,6 +313,36 @@ export default tseslint.config(
 				],
 			},
 		],
+		[
+			"multi-line custom commented group in rules",
+			`
+export default tseslint.config(
+	{ ignores: ["lib"] },
+	{
+		extends: [tseslint.configs.strictTypeChecked],
+		files: ["**/*.{js,ts}"],
+		languageOptions: { /* ... */ },
+		rules: {
+			// First line.
+			// Second line.
+			// Third line.
+			"@typescript-eslint/prefer-nullish-coalescing": "error"
+		},
+		settings: { /* ... */ }
+	}
+);`,
+			{
+				ignores: ["lib"],
+				rules: [
+					{
+						comment: "First line.\nSecond line.\nThird line.",
+						entries: {
+							"@typescript-eslint/prefer-nullish-coalescing": "error",
+						},
+					},
+				],
+			},
+		],
 	])("returns data when given %s", (_, sourceText, expected) => {
 		const actual = blockESLintIntake(sourceText);
 

--- a/src/blocks/eslint/blockESLintIntake.ts
+++ b/src/blocks/eslint/blockESLintIntake.ts
@@ -94,7 +94,7 @@ export function blockESLintIntake(sourceText: string) {
 				property.range[0],
 			);
 			const comment =
-				precedingText.replaceAll(/\/\/|\n/g, "").trim() || undefined;
+				precedingText.replaceAll(/\/\/ ?|\t\s*/g, "").trim() || undefined;
 
 			// blockESLintMoreStyling's comment always gets pushed to the end.
 			if (comment === stylisticComment) {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2171
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

🎁