### PR TITLE
fix: correct blockCSpell intake ignorePaths

### DIFF
--- a/src/blocks/blockCSpell.test.ts
+++ b/src/blocks/blockCSpell.test.ts
@@ -78,7 +78,7 @@ describe("blockCSpell", () => {
 	test("with addons", () => {
 		const creation = testBlock(blockCSpell, {
 			addons: {
-				ignores: ["lib/"],
+				ignorePaths: ["lib/"],
 				words: ["joshuakgoldberg"],
 			},
 			options: optionsBase,
@@ -387,16 +387,16 @@ describe("blockCSpell", () => {
 		it("returns undefined when cspell.json contains invalid data", () => {
 			const actual = testIntake(blockCSpell, {
 				files: {
-					"cspell.json": [JSON.stringify({ ignores: true })],
+					"cspell.json": [JSON.stringify({ ignorePaths: true })],
 				},
 			});
 
 			expect(actual).toBeUndefined();
 		});
 
-		it("returns compilerOptions when cspell.json contains ignores and words", () => {
+		it("returns compilerOptions when cspell.json contains ignorePaths and words", () => {
 			const data = {
-				ignores: ["other"],
+				ignorePaths: ["other"],
 				words: ["abc", "def"],
 			};
 

--- a/src/blocks/blockCSpell.ts
+++ b/src/blocks/blockCSpell.ts
@@ -16,7 +16,7 @@ import { CommandPhase } from "./phases.js";
 const filesGlob = `"**" ".github/**/*"`;
 
 const addons = {
-	ignores: z.array(z.string()).default([]),
+	ignorePaths: z.array(z.string()).default([]),
 	words: z.array(z.string()).default([]),
 };
 
@@ -41,7 +41,7 @@ export const blockCSpell = base.createBlock({
 		return data;
 	},
 	produce({ addons, options }) {
-		const { ignores, words } = addons;
+		const { ignorePaths, words } = addons;
 
 		const allWords = Array.from(
 			new Set([...(options.words ?? []), ...words]),
@@ -83,14 +83,16 @@ export const blockCSpell = base.createBlock({
 			files: {
 				"cspell.json": JSON.stringify({
 					dictionaries: ["npm", "node", "typescript"],
-					ignorePaths: [
-						".github",
-						"CHANGELOG.md",
-						"lib",
-						"node_modules",
-						"pnpm-lock.yaml",
-						...ignores,
-					].sort(),
+					ignorePaths: Array.from(
+						new Set([
+							".github",
+							"CHANGELOG.md",
+							"lib",
+							"node_modules",
+							"pnpm-lock.yaml",
+							...ignorePaths,
+						]),
+					).sort(),
 					...(allWords.length && { words: allWords }),
 				}),
 			},

--- a/src/blocks/blockNcc.test.ts
+++ b/src/blocks/blockNcc.test.ts
@@ -15,7 +15,7 @@ describe("blockNcc", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "dist",
 			        ],
 			      },
@@ -126,7 +126,7 @@ describe("blockNcc", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "dist",
 			        ],
 			      },

--- a/src/blocks/blockNcc.ts
+++ b/src/blocks/blockNcc.ts
@@ -28,7 +28,7 @@ export const blockNcc = base.createBlock({
 		return {
 			addons: [
 				blockCSpell({
-					ignores: ["dist"],
+					ignorePaths: ["dist"],
 				}),
 				blockDevelopmentDocs({
 					sections: {

--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -15,7 +15,7 @@ describe("blockPrettier", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          ".all-contributorsrc",
 			        ],
 			      },
@@ -127,7 +127,7 @@ describe("blockPrettier", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          ".all-contributorsrc",
 			        ],
 			      },
@@ -277,7 +277,7 @@ describe("blockPrettier", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          ".all-contributorsrc",
 			        ],
 			      },

--- a/src/blocks/blockPrettier.ts
+++ b/src/blocks/blockPrettier.ts
@@ -38,7 +38,7 @@ export const blockPrettier = base.createBlock({
 		return {
 			addons: [
 				blockCSpell({
-					ignores: [".all-contributorsrc"],
+					ignorePaths: [".all-contributorsrc"],
 				}),
 				blockDevelopmentDocs({
 					sections: {

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -19,7 +19,7 @@ describe("blockVitest", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "coverage",
 			        ],
 			      },
@@ -265,7 +265,7 @@ describe("blockVitest", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "coverage",
 			        ],
 			      },
@@ -549,7 +549,7 @@ describe("blockVitest", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "coverage",
 			        ],
 			      },
@@ -804,7 +804,7 @@ describe("blockVitest", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "coverage",
 			        ],
 			      },

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -82,7 +82,7 @@ export const blockVitest = base.createBlock({
 		return {
 			addons: [
 				blockCSpell({
-					ignores: ["coverage"],
+					ignorePaths: ["coverage"],
 				}),
 				blockDevelopmentDocs({
 					sections: {

--- a/src/blocks/blockWebExt.test.ts
+++ b/src/blocks/blockWebExt.test.ts
@@ -15,7 +15,7 @@ describe("blockWebExt", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "ignores": [
+			        "ignorePaths": [
 			          "assets",
 			        ],
 			      },

--- a/src/blocks/blockWebExt.ts
+++ b/src/blocks/blockWebExt.ts
@@ -15,7 +15,7 @@ export const blockWebExt = base.createBlock({
 		return {
 			addons: [
 				blockCSpell({
-					ignores: ["assets"],
+					ignorePaths: ["assets"],
 				}),
 				blockDevelopmentDocs({
 					sections: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2173
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches the Addon name to `ignorePaths` so that everything is called the same.

🎁