### PR TITLE
fix: print .all-contributorsrc with two spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"dependencies": {
 		"@typescript-eslint/typescript-estree": "^8.29.1",
-		"bingo": "^0.5.14",
+		"bingo": "^0.5.15",
 		"bingo-fs": "^0.5.5",
 		"bingo-stratum": "^0.5.11",
 		"cached-factory": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^8.29.1
         version: 8.29.1(typescript@5.8.2)
       bingo:
-        specifier: ^0.5.14
-        version: 0.5.14
+        specifier: ^0.5.15
+        version: 0.5.15
       bingo-fs:
         specifier: ^0.5.5
         version: 0.5.5
       bingo-stratum:
         specifier: ^0.5.11
-        version: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)(zod@3.24.2)
+        version: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)(zod@3.24.2)
       cached-factory:
         specifier: ^0.1.0
         version: 0.1.0
@@ -43,13 +43,13 @@ importers:
         version: 1.2.0
       input-from-file:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.14)
+        version: 0.5.4(bingo@0.5.15)
       input-from-file-json:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.14)(zod@3.24.2)
+        version: 0.5.4(bingo@0.5.15)(zod@3.24.2)
       input-from-script:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.14)
+        version: 0.5.4(bingo@0.5.15)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -161,10 +161,10 @@ importers:
         version: 0.5.5
       bingo-stratum-testers:
         specifier: 0.5.9
-        version: 0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14))(bingo@0.5.14)
+        version: 0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15))(bingo@0.5.15)
       bingo-testers:
         specifier: 0.5.7
-        version: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)
+        version: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -1703,8 +1703,8 @@ packages:
       bingo-fs: ^0.5.4
       bingo-systems: ^0.5.4
 
-  bingo@0.5.14:
-    resolution: {integrity: sha512-ZoQqP5Wly2o5BNLPF7uwwBZPM7GJuRJ0t2K3m2r62yWYm2oMg8SP1wAvu2oVWjGKB5zM9fLw9M26v3NlCvwK1g==}
+  bingo@0.5.15:
+    resolution: {integrity: sha512-aqOK7IfB8oEp7tPFgC+CrQ26/DryarkLOBgOiW6+wbMYVC37ddFIHdrNm7v7J2rPaNxqyBgpuaOZtwCZxcxNIw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5814,18 +5814,18 @@ snapshots:
     dependencies:
       '@octokit/types': 13.10.0
 
-  bingo-stratum-testers@0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14))(bingo@0.5.14):
+  bingo-stratum-testers@0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)(zod@3.24.2))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15))(bingo@0.5.15):
     dependencies:
-      bingo: 0.5.14
+      bingo: 0.5.15
       bingo-fs: 0.5.5
-      bingo-stratum: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)(zod@3.24.2)
+      bingo-stratum: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)(zod@3.24.2)
       bingo-systems: 0.5.4
-      bingo-testers: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)
+      bingo-testers: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)
 
-  bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14)(zod@3.24.2):
+  bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15)(zod@3.24.2):
     dependencies:
       all-properties-lazy: 0.1.0
-      bingo: 0.5.14
+      bingo: 0.5.15
       bingo-fs: 0.5.5
       bingo-systems: 0.5.4
       cached-factory: 0.1.0
@@ -5843,17 +5843,17 @@ snapshots:
       get-github-auth-token: 0.1.1
       octokit: 4.1.2
 
-  bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.14):
+  bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.15):
     dependencies:
       all-properties-lazy: 0.1.0
-      bingo: 0.5.14
+      bingo: 0.5.15
       bingo-fs: 0.5.5
       bingo-systems: 0.5.4
       diff: 7.0.0
       octokit: 4.1.2
       without-undefined-properties: 0.1.1
 
-  bingo@0.5.14:
+  bingo@0.5.15:
     dependencies:
       '@clack/prompts': 0.10.0
       all-properties-lazy: 0.1.0
@@ -5867,7 +5867,6 @@ snapshots:
       hash-object: 5.0.1
       hosted-git-info: 8.0.2
       new-github-repository: 0.2.1
-      prettier: 3.5.3
       read-package-up: 11.0.0
       read-pkg: 9.0.1
       slugify: 1.6.6
@@ -7053,20 +7052,20 @@ snapshots:
 
   ini@4.1.3: {}
 
-  input-from-file-json@0.5.4(bingo@0.5.14)(zod@3.24.2):
+  input-from-file-json@0.5.4(bingo@0.5.15)(zod@3.24.2):
     dependencies:
-      bingo: 0.5.14
-      input-from-file: 0.5.4(bingo@0.5.14)
+      bingo: 0.5.15
+      input-from-file: 0.5.4(bingo@0.5.15)
       zod: 3.24.2
 
-  input-from-file@0.5.4(bingo@0.5.14):
+  input-from-file@0.5.4(bingo@0.5.15):
     dependencies:
-      bingo: 0.5.14
+      bingo: 0.5.15
       zod: 3.24.2
 
-  input-from-script@0.5.4(bingo@0.5.14):
+  input-from-script@0.5.4(bingo@0.5.15):
     dependencies:
-      bingo: 0.5.14
+      bingo: 0.5.15
       zod: 3.24.2
 
   inquirer@12.3.0(@types/node@22.13.10):

--- a/src/blocks/blockAllContributors.test.ts
+++ b/src/blocks/blockAllContributors.test.ts
@@ -53,7 +53,13 @@ describe("blockAllContributors", () => {
 			    },
 			  ],
 			  "files": {
-			    ".all-contributorsrc": "{"badgeTemplate":"\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>","contributors":[],"contributorsSortAlphabetically":true,"projectName":"test-repository","projectOwner":"test-owner"}",
+			    ".all-contributorsrc": "{
+			  "badgeTemplate": "\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>",
+			  "contributors": [],
+			  "contributorsSortAlphabetically": true,
+			  "projectName": "test-repository",
+			  "projectOwner": "test-owner"
+			}",
 			    ".github": {
 			      "workflows": {
 			        "contributors.yml": "jobs:
@@ -174,7 +180,28 @@ describe("blockAllContributors", () => {
 			    },
 			  ],
 			  "files": {
-			    ".all-contributorsrc": "{"badgeTemplate":"\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>","contributors":[{"avatar_url":"https://avatars.githubusercontent.com/u/3335181?v=4","contributions":["bug","code","design","doc","test","tool"],"login":"JoshuaKGoldberg","name":"Josh Goldberg","profile":"http://www.joshuakgoldberg.com"}],"contributorsSortAlphabetically":true,"projectName":"test-repository","projectOwner":"JoshuaKGoldberg"}",
+			    ".all-contributorsrc": "{
+			  "badgeTemplate": "\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>",
+			  "contributors": [
+			    {
+			      "avatar_url": "https://avatars.githubusercontent.com/u/3335181?v=4",
+			      "contributions": [
+			        "bug",
+			        "code",
+			        "design",
+			        "doc",
+			        "test",
+			        "tool"
+			      ],
+			      "login": "JoshuaKGoldberg",
+			      "name": "Josh Goldberg",
+			      "profile": "http://www.joshuakgoldberg.com"
+			    }
+			  ],
+			  "contributorsSortAlphabetically": true,
+			  "projectName": "test-repository",
+			  "projectOwner": "JoshuaKGoldberg"
+			}",
 			    ".github": {
 			      "workflows": {
 			        "contributors.yml": "jobs:
@@ -294,7 +321,28 @@ describe("blockAllContributors", () => {
 			    },
 			  ],
 			  "files": {
-			    ".all-contributorsrc": "{"badgeTemplate":"\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>","contributors":[{"avatar_url":"https://avatars.githubusercontent.com/u/3335181?v=4","contributions":["bug","code","design","doc","test","tool"],"login":"other","name":"Other","profile":"http://www.example.com"}],"contributorsSortAlphabetically":true,"projectName":"test-repository","projectOwner":"test-owner"}",
+			    ".all-contributorsrc": "{
+			  "badgeTemplate": "\\t<a href=\\"#contributors\\" target=\\"_blank\\"><img alt=\\"👪 All Contributors: <%= contributors.length %>\\" src=\\"https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg\\" /></a>",
+			  "contributors": [
+			    {
+			      "avatar_url": "https://avatars.githubusercontent.com/u/3335181?v=4",
+			      "contributions": [
+			        "bug",
+			        "code",
+			        "design",
+			        "doc",
+			        "test",
+			        "tool"
+			      ],
+			      "login": "other",
+			      "name": "Other",
+			      "profile": "http://www.example.com"
+			    }
+			  ],
+			  "contributorsSortAlphabetically": true,
+			  "projectName": "test-repository",
+			  "projectOwner": "test-owner"
+			}",
 			    ".github": {
 			      "workflows": {
 			        "contributors.yml": "jobs:

--- a/src/blocks/blockAllContributors.ts
+++ b/src/blocks/blockAllContributors.ts
@@ -65,14 +65,18 @@ export const blockAllContributors = base.createBlock({
 				}),
 			],
 			files: {
-				".all-contributorsrc": JSON.stringify({
-					badgeTemplate:
-						'	<a href="#contributors" target="_blank"><img alt="👪 All Contributors: <%= contributors.length %>" src="https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg" /></a>',
-					contributors: options.contributors ?? [],
-					contributorsSortAlphabetically: true,
-					projectName: options.repository,
-					projectOwner: options.owner,
-				}),
+				".all-contributorsrc": JSON.stringify(
+					{
+						badgeTemplate:
+							'	<a href="#contributors" target="_blank"><img alt="👪 All Contributors: <%= contributors.length %>" src="https://img.shields.io/badge/%F0%9F%91%AA_all_contributors-<%= contributors.length %>-21bb42.svg" /></a>',
+						contributors: options.contributors ?? [],
+						contributorsSortAlphabetically: true,
+						projectName: options.repository,
+						projectOwner: options.owner,
+					},
+					null,
+					2,
+				),
 				".github": {
 					workflows: {
 						"contributors.yml": createSoloWorkflowFile({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2177
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `null, 2` as JSON.stringify settings - which matches https://github.com/all-contributors/cli/blob/74bc388bd6f0ae2658e6495e9d3781d737438a97/src/util/formatting.js#L2.

🎁 