### PR TITLE
fix: stop all-contributors-cli from being updated beyond 6.26.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
 		"config:best-practices",
 		"replacements:all"
 	],
-	"ignoreDeps": ["codecov/codecov-action"],
+	"ignoreDeps": ["all-contributors-cli", "codecov/codecov-action"],
 	"labels": ["dependencies"],
 	"minimumReleaseAge": "7 days",
 	"patch": { "enabled": false },

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -14,6 +14,7 @@ import {
 	blockESLint,
 	blockKnip,
 	blockMain,
+	blockRenovate,
 	blockTemplatedWith,
 	presets,
 } from "./index.js";
@@ -106,6 +107,9 @@ If you're interested in learning more, see the 'getting started' docs on:
 				}),
 				blockMain({
 					runArgs: ["--version"],
+				}),
+				blockRenovate({
+					ignoreDeps: ["all-contributors-cli"],
 				}),
 			],
 			blocks: {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2177
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Along with #2180, this will keep `all-contributors-cli` on the version that ignores Prettier. Because the app does too.

🎁