### PR TITLE
feat: added configEmoji Addon to blockESLintPlugin

### DIFF
--- a/src/blocks/blockESLintPlugin.test.ts
+++ b/src/blocks/blockESLintPlugin.test.ts
@@ -654,6 +654,17 @@ describe("blockESLintPlugin", () => {
 			expect(actual).toEqual(undefined);
 		});
 
+		it("returns nothing when .eslint-doc-generatorrc.js does not have a to const config =", () => {
+			const actual = testIntake(blockESLintPlugin, {
+				files: {
+					".eslint-doc-generatorrc.js": [`const other = {};`],
+				},
+				options: optionsBase,
+			});
+
+			expect(actual).toEqual(undefined);
+		});
+
 		it("returns nothing when .eslint-doc-generatorrc.js passes nothing to config =", () => {
 			const actual = testIntake(blockESLintPlugin, {
 				files: {

--- a/src/blocks/eslint/blockESLintPluginIntake.ts
+++ b/src/blocks/eslint/blockESLintPluginIntake.ts
@@ -1,0 +1,64 @@
+import {
+	AST_NODE_TYPES,
+	parse as parseAST,
+	TSESTree,
+} from "@typescript-eslint/typescript-estree";
+import JSON5 from "json5";
+
+import { tryCatch } from "../../utils/tryCatch.js";
+import { zConfigEmoji } from "./schemas.js";
+
+export function blockESLintPluginIntake(sourceText: string) {
+	const ast = tryCatch(() =>
+		parseAST(sourceText, {
+			comment: true,
+			loc: true,
+			range: true,
+		}),
+	);
+	if (!ast) {
+		return undefined;
+	}
+
+	const config = findConfig(ast.body);
+	if (!config) {
+		return undefined;
+	}
+
+	const configEmoji = findConfigEmoji(config.properties);
+	if (!configEmoji) {
+		return undefined;
+	}
+
+	const { data } = zConfigEmoji.safeParse(
+		JSON5.parse(sourceText.slice(...configEmoji.range)),
+	);
+
+	return data && { configEmoji: data };
+
+	function findConfig(body: TSESTree.ProgramStatement[]) {
+		for (const node of body) {
+			if (
+				node.type === AST_NODE_TYPES.VariableDeclaration &&
+				node.declarations[0].id.type === AST_NODE_TYPES.Identifier &&
+				node.declarations[0].id.name === "config" &&
+				node.declarations[0].init?.type === AST_NODE_TYPES.ObjectExpression
+			) {
+				return node.declarations[0].init;
+			}
+		}
+	}
+
+	function findConfigEmoji(properties: TSESTree.ObjectLiteralElement[]) {
+		for (const node of properties) {
+			if (
+				node.type === AST_NODE_TYPES.Property &&
+				node.key.type === AST_NODE_TYPES.Identifier &&
+				node.key.name === "configEmoji" &&
+				node.value.type === AST_NODE_TYPES.ArrayExpression
+			) {
+				return node.value;
+			}
+		}
+	}
+}

--- a/src/blocks/eslint/schemas.ts
+++ b/src/blocks/eslint/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+export const zConfigEmoji = z
+	.array(z.tuple([z.string(), z.string()]))
+	.optional();
+
 export const zRuleOptions = z.union([
 	z.literal("error"),
 	z.literal("off"),


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2190
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses a similar AST parsing strategy as `blockESLintIntake` to find a `const config = `.

🎁 