### PR TITLE
fix: skip checkout in CTA action before transition step

### DIFF
--- a/src/blocks/blockCTATransitions.test.ts
+++ b/src/blocks/blockCTATransitions.test.ts
@@ -69,16 +69,17 @@ describe("blockCTATransitions", () => {
 			    name: Transition
 			    runs-on: ubuntu-latest
 			    steps:
-			      - uses: actions/checkout@v4
+			      - id: checkout
+			        if: (github.actor == 'test-owner' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')
+			        uses: actions/checkout@v4
 			        with:
 			          fetch-depth: 0
 			          ref: \${{github.event.pull_request.head.ref}}
 			          repository: \${{github.event.pull_request.head.repo.full_name}}
 			          token: \${{ secrets.ACCESS_TOKEN }}
-			      - id: check
-			        if: (github.actor == 'test-owner' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')
+			      - if: steps.checkout.outcome != 'skipped'
 			        uses: ./.github/actions/transition
-			      - if: steps.check.outcome == 'skipped'
+			      - if: steps.checkout.outcome == 'skipped'
 			        run: echo 'Skipping transition mode because the PR does not appear to be an automated or owner-created update to create-typescript-app.'
 
 

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -95,6 +95,8 @@ export const blockCTATransitions = base.createBlock({
 							},
 							steps: [
 								{
+									id: "checkout",
+									if: `(github.actor == '${options.owner}' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')`,
 									uses: resolveUses(
 										"actions/checkout",
 										"v4",
@@ -109,12 +111,11 @@ export const blockCTATransitions = base.createBlock({
 									},
 								},
 								{
-									id: "check",
-									if: `(github.actor == '${options.owner}' || github.actor == 'renovate[bot]') && startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'create-typescript-app')`,
+									if: "steps.checkout.outcome != 'skipped'",
 									uses: "./.github/actions/transition",
 								},
 								{
-									if: "steps.check.outcome == 'skipped'",
+									if: "steps.checkout.outcome == 'skipped'",
 									run: "echo 'Skipping transition mode because the PR does not appear to be an automated or owner-created update to create-typescript-app.'",
 								},
 							],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2214
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Upstreaming of https://github.com/JoshuaKGoldberg/formatly/pull/122. Previously, the action would only check on step 2 of 3 `if` it should skip. But step 1 -checkout- requires a token that doesn't exist on fork.

Now, step 1 does the `if`. No more checking out the repo unnecessarily.

🎁 