### PR TITLE
feat: bump Node.js minimum to 20.12.0 and pinned to 24.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
 	},
 	"packageManager": "pnpm@10.8.0",
 	"engines": {
-		"node": ">=18.3.0"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": true

--- a/src/blocks/blockNvmrc.test.ts
+++ b/src/blocks/blockNvmrc.test.ts
@@ -22,7 +22,7 @@ describe("blockNvmrc", () => {
 		const creation = testBlock(blockNvmrc, {
 			options: {
 				...optionsBase,
-				node: { minimum: ">=18.3.0", pinned: "20.18.0" },
+				node: { minimum: ">=20.19.0", pinned: "24.3.0" },
 			},
 		});
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const defaults = {
 	node: {
-		minimum: "18.3.0",
-		pinned: "20.18.0",
+		minimum: "20.19.0",
+		pinned: "24.3.0",
 	},
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2184
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates the versions to:

* Minimum: 20.19.0, the oldest LTS 20.x version with require(esm)
* Pinned: 24.3.0, the recent release with no-warning type stripping

Now that #2229 is merged, this should now be doable without risk to downstream packages.

🎁 