### PR TITLE
fix: use spaces for readme b/c npmjs.org does not format tabs well

### DIFF
--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -102,7 +102,7 @@ describe("blockPrettier", () => {
 			/lib
 			/pnpm-lock.yaml
 			",
-			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","useTabs":true}",
+			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","overrides":[{"files":["README.md"],"options":{"useTabs":false}}],"useTabs":true}",
 			  },
 			  "scripts": [
 			    {
@@ -242,7 +242,7 @@ describe("blockPrettier", () => {
 			/lib
 			/pnpm-lock.yaml
 			",
-			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","useTabs":true}",
+			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","overrides":[{"files":["README.md"],"options":{"useTabs":false}}],"useTabs":true}",
 			  },
 			  "scripts": [
 			    {
@@ -371,7 +371,7 @@ describe("blockPrettier", () => {
 			/pnpm-lock.yaml
 			generated
 			",
-			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","overrides":[{"files":".nvmrc","options":{"parser":"yaml"}}],"plugins":["./lib/index.js","prettier-plugin-curly","prettier-plugin-packagejson","prettier-plugin-sh"],"useTabs":true}",
+			    ".prettierrc.json": "{"$schema":"http://json.schemastore.org/prettierrc","overrides":[{"files":".nvmrc","options":{"parser":"yaml"}},{"files":["README.md"],"options":{"useTabs":false}}],"plugins":["./lib/index.js","prettier-plugin-curly","prettier-plugin-packagejson","prettier-plugin-sh"],"useTabs":true}",
 			  },
 			  "scripts": [
 			    {

--- a/src/blocks/blockPrettier.ts
+++ b/src/blocks/blockPrettier.ts
@@ -99,7 +99,13 @@ pnpm format --write
 				),
 				".prettierrc.json": JSON.stringify({
 					$schema: "http://json.schemastore.org/prettierrc",
-					...(overrides.length && { overrides: overrides.sort() }),
+					overrides: [
+						...(overrides.length ? overrides.sort() : []),
+						{
+							files: ["README.md"],
+							options: { useTabs: false },
+						},
+					],
 					...(plugins.length && { plugins: plugins.sort() }),
 					useTabs: true,
 				}),


### PR DESCRIPTION
first: I love create-typescript-app... it was a fantastic way for me to get my project off the ground with good feeling lint defaults and not having to think much about it 🙌

this is only a recommendation and the more correct fix would be better default tab spaces view on npmjs.com, but that sounds unlikely?

here's an example of when it's bad
https://www.npmjs.com/package/prototypey/v/0.2.3
vs with spaces
https://www.npmjs.com/package/prototypey/v/0.2.4

## PR Checklist

- [x] Addresses an existing open issue: fixes #2277
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This is a recommendation as a default so others don't go through the same pain with npm after publishing, but please feel free to just close if this is out of scope for the project or anything.
