### PR TITLE
fix: default author.name to git config.user

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -177,7 +177,12 @@ export const base = createBase({
 
 		const getAuthor = lazyValue(
 			async () =>
-				await readAuthor(getPackageAuthor, getNpmDefaults, options.owner),
+				await readAuthor(
+					getPackageAuthor,
+					getNpmDefaults,
+					getGitUser,
+					options.owner,
+				),
 		);
 
 		const getBin = lazyValue(async () => await readBin(getPackageData));
@@ -235,6 +240,11 @@ export const base = createBase({
 		const getFunding = lazyValue(async () => await readFunding(take));
 
 		const getGitDefaults = lazyValue(async () => await readGitDefaults(take));
+
+		const getGitUser = lazyValue(
+			async () =>
+				await take(inputFromScript, { command: "git config user.name" }),
+		);
 
 		const getGuide = lazyValue(async () => await readGuide(take));
 

--- a/src/options/readAuthor.test.ts
+++ b/src/options/readAuthor.test.ts
@@ -1,3 +1,4 @@
+import { Result } from "execa";
 import { describe, expect, it, vi } from "vitest";
 
 import { readAuthor } from "./readAuthor.js";
@@ -10,6 +11,7 @@ describe(readAuthor, () => {
 		const actual = await readAuthor(
 			() => Promise.resolve({ name }),
 			getNpmDefaults,
+			() => Promise.resolve(undefined),
 			undefined,
 		);
 
@@ -23,6 +25,7 @@ describe(readAuthor, () => {
 		const actual = await readAuthor(
 			() => Promise.resolve({}),
 			() => Promise.resolve({ name }),
+			() => Promise.resolve(undefined),
 			undefined,
 		);
 
@@ -35,15 +38,30 @@ describe(readAuthor, () => {
 		const actual = await readAuthor(
 			() => Promise.resolve({}),
 			() => Promise.resolve(undefined),
+			() => Promise.resolve(undefined),
 			owner,
 		);
 
 		expect(actual).toBe(owner);
 	});
 
+	it("returns gitUser when only it exists", async () => {
+		const gitUser = "test-owner";
+
+		const actual = await readAuthor(
+			() => Promise.resolve({}),
+			() => Promise.resolve(undefined),
+			() => Promise.resolve({ stdout: gitUser } as Result),
+			undefined,
+		);
+
+		expect(actual).toBe(gitUser);
+	});
+
 	it("returns undefined when no sources provide a value", async () => {
 		const actual = await readAuthor(
 			() => Promise.resolve({}),
+			() => Promise.resolve(undefined),
 			() => Promise.resolve(undefined),
 			undefined,
 		);

--- a/src/options/readAuthor.ts
+++ b/src/options/readAuthor.ts
@@ -1,11 +1,17 @@
+import { ExecaError, Result } from "execa";
+
 import { PackageAuthor } from "./readPackageAuthor.js";
 
 export async function readAuthor(
 	getPackageAuthor: () => Promise<PackageAuthor>,
 	getNpmDefaults: () => Promise<undefined | { name?: string }>,
+	getGitUser: () => Promise<ExecaError | Result | undefined>,
 	owner: string | undefined,
 ) {
 	return (
-		(await getPackageAuthor()).name ?? (await getNpmDefaults())?.name ?? owner
+		(await getPackageAuthor()).name ??
+		(await getNpmDefaults())?.name ??
+		(await getGitUser())?.stdout?.toString() ??
+		owner
 	);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2279
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

If `getNpmDefaults` ([`npm-user`](https://npmjs.com/package/npm-user)) isn't able to retrieve the npm name, then we can always fall back to `git config user.name`.

🎁