### PR TITLE
feat: bingo@0.7.0 (--skip-* flags)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	},
 	"dependencies": {
 		"@typescript-eslint/typescript-estree": "^8.35.0",
-		"bingo": "^0.5.16",
+		"bingo": "^0.7.0",
 		"bingo-fs": "^0.5.5",
 		"bingo-stratum": "^0.5.11",
 		"cached-factory": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,14 +12,14 @@ importers:
         specifier: ^8.35.0
         version: 8.35.0(typescript@5.8.3)
       bingo:
-        specifier: ^0.5.16
-        version: 0.5.16
+        specifier: ^0.7.0
+        version: 0.7.0
       bingo-fs:
         specifier: ^0.5.5
         version: 0.5.5
       bingo-stratum:
         specifier: ^0.5.11
-        version: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)(zod@3.25.67)
+        version: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)(zod@3.25.67)
       cached-factory:
         specifier: ^0.1.0
         version: 0.1.0
@@ -43,13 +43,13 @@ importers:
         version: 2.0.2
       input-from-file:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.16)
+        version: 0.5.4(bingo@0.7.0)
       input-from-file-json:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.16)(zod@3.25.67)
+        version: 0.5.4(bingo@0.7.0)(zod@3.25.67)
       input-from-script:
         specifier: ^0.5.4
-        version: 0.5.4(bingo@0.5.16)
+        version: 0.5.4(bingo@0.7.0)
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
@@ -158,10 +158,10 @@ importers:
         version: 0.5.5
       bingo-stratum-testers:
         specifier: 0.5.9
-        version: 0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)(zod@3.25.67))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16))(bingo@0.5.16)
+        version: 0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)(zod@3.25.67))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0))(bingo@0.7.0)
       bingo-testers:
         specifier: 0.5.7
-        version: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)
+        version: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -1817,8 +1817,8 @@ packages:
       bingo-fs: ^0.5.4
       bingo-systems: ^0.5.4
 
-  bingo@0.5.16:
-    resolution: {integrity: sha512-1gtg5qTJ3Xv7I0yElNjEEtTLbS8XUg8WzF9rWP3vm6V86VCBkZm8CuUYtLzUbZ8iRfMF6cVfXLXKMoRmimBGgA==}
+  bingo@0.7.0:
+    resolution: {integrity: sha512-JxVV5xi8NuEbh4ESg/KrKwCrvkDkwqmAVLLIK1HDitrZqBa+29niFp2LO3T9uyZqfENjD9iZVpoa9XvDeYJV8g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5863,18 +5863,18 @@ snapshots:
     dependencies:
       '@octokit/types': 13.10.0
 
-  bingo-stratum-testers@0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)(zod@3.25.67))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16))(bingo@0.5.16):
+  bingo-stratum-testers@0.5.9(bingo-fs@0.5.5)(bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)(zod@3.25.67))(bingo-systems@0.5.4)(bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0))(bingo@0.7.0):
     dependencies:
-      bingo: 0.5.16
+      bingo: 0.7.0
       bingo-fs: 0.5.5
-      bingo-stratum: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)(zod@3.25.67)
+      bingo-stratum: 0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)(zod@3.25.67)
       bingo-systems: 0.5.4
-      bingo-testers: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)
+      bingo-testers: 0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)
 
-  bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16)(zod@3.25.67):
+  bingo-stratum@0.5.11(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0)(zod@3.25.67):
     dependencies:
       all-properties-lazy: 0.1.0
-      bingo: 0.5.16
+      bingo: 0.7.0
       bingo-fs: 0.5.5
       bingo-systems: 0.5.4
       cached-factory: 0.1.0
@@ -5892,17 +5892,17 @@ snapshots:
       get-github-auth-token: 0.1.1
       octokit: 4.1.2
 
-  bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.5.16):
+  bingo-testers@0.5.7(bingo-fs@0.5.5)(bingo-systems@0.5.4)(bingo@0.7.0):
     dependencies:
       all-properties-lazy: 0.1.0
-      bingo: 0.5.16
+      bingo: 0.7.0
       bingo-fs: 0.5.5
       bingo-systems: 0.5.4
       diff: 7.0.0
       octokit: 4.1.2
       without-undefined-properties: 0.1.1
 
-  bingo@0.5.16:
+  bingo@0.7.0:
     dependencies:
       '@clack/prompts': 0.10.0
       all-properties-lazy: 0.1.0
@@ -7074,20 +7074,20 @@ snapshots:
 
   ini@4.1.3: {}
 
-  input-from-file-json@0.5.4(bingo@0.5.16)(zod@3.25.67):
+  input-from-file-json@0.5.4(bingo@0.7.0)(zod@3.25.67):
     dependencies:
-      bingo: 0.5.16
-      input-from-file: 0.5.4(bingo@0.5.16)
+      bingo: 0.7.0
+      input-from-file: 0.5.4(bingo@0.7.0)
       zod: 3.25.67
 
-  input-from-file@0.5.4(bingo@0.5.16):
+  input-from-file@0.5.4(bingo@0.7.0):
     dependencies:
-      bingo: 0.5.16
+      bingo: 0.7.0
       zod: 3.25.67
 
-  input-from-script@0.5.4(bingo@0.5.16):
+  input-from-script@0.5.4(bingo@0.7.0):
     dependencies:
-      bingo: 0.5.16
+      bingo: 0.7.0
       zod: 3.25.67
 
   inquirer@12.6.3(@types/node@24.0.4):


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2281
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Bumps the dependency on `bingo` to `^0.7.0`.

Pending additional work in https://github.com/bingo-js/bingo/issues/365, this doesn't note the CLI flags in docs yet.

🎁