### PR TITLE
fix: issues with Vitest 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
 		"bingo-requests": "0.5.6",
 		"bingo-stratum-testers": "0.5.10",
 		"bingo-testers": "0.5.8",
-		"console-fail-test": "0.5.0",
+		"console-fail-test": "0.6.1",
 		"cspell": "9.4.0",
 		"eslint": "9.39.1",
 		"eslint-plugin-jsdoc": "61.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: 0.5.8
         version: 0.5.8(bingo-fs@0.5.6)(bingo-systems@0.5.5)(bingo@0.8.1)
       console-fail-test:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.6.1
+        version: 0.6.1
       cspell:
         specifier: 9.4.0
         version: 9.4.0
@@ -2063,9 +2063,9 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  console-fail-test@0.5.0:
-    resolution: {integrity: sha512-nghkQcJ9DJMYtdN1L/ZNu1GvnLMo38DTneWX23+WbIdvjuVkbcshGFxgIG5LbI9j/th4dgwUc0Hiwtq85VWb/Q==}
-    engines: {node: '>=18'}
+  console-fail-test@0.6.1:
+    resolution: {integrity: sha512-KxgTskG1eCVCKB6f3XuM3lkzuM+0ASGCPVLIJU8r6Lv6lzCCk4FEoYkHJubEnUKzqHAQNVl1lw5UOyufTTILjg==}
+    engines: {node: '>=20.19.0'}
 
   conventional-changelog-angular@8.1.0:
     resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
@@ -6038,7 +6038,7 @@ snapshots:
 
   consola@3.4.2: {}
 
-  console-fail-test@0.5.0: {}
+  console-fail-test@0.6.1: {}
 
   conventional-changelog-angular@8.1.0:
     dependencies:

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -179,7 +179,7 @@ describe("blockVitest", () => {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "4.0.15",
 			            "@vitest/eslint-plugin": "1.5.1",
-			            "console-fail-test": "0.5.0",
+			            "console-fail-test": "0.6.1",
 			            "vitest": "4.0.15",
 			          },
 			          "scripts": {
@@ -240,7 +240,6 @@ describe("blockVitest", () => {
 				test: {
 					clearMocks: true,
 					coverage: {
-						all: true,
 						include: undefined,
 						reporter: ["html", "lcov"],
 					},
@@ -425,7 +424,7 @@ describe("blockVitest", () => {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "4.0.15",
 			            "@vitest/eslint-plugin": "1.5.1",
-			            "console-fail-test": "0.5.0",
+			            "console-fail-test": "0.6.1",
 			            "vitest": "4.0.15",
 			          },
 			          "scripts": {
@@ -516,7 +515,6 @@ describe("blockVitest", () => {
 				test: {
 					clearMocks: true,
 					coverage: {
-						all: true,
 						include: undefined,
 						reporter: ["html", "lcov"],
 					},
@@ -709,7 +707,7 @@ describe("blockVitest", () => {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "4.0.15",
 			            "@vitest/eslint-plugin": "1.5.1",
-			            "console-fail-test": "0.5.0",
+			            "console-fail-test": "0.6.1",
 			            "vitest": "4.0.15",
 			          },
 			          "scripts": {
@@ -770,7 +768,6 @@ describe("blockVitest", () => {
 				test: {
 					clearMocks: true,
 					coverage: {
-						all: true,
 						exclude: ["other"],
 						include: ["src/"],
 						reporter: ["html", "lcov"],
@@ -964,7 +961,7 @@ describe("blockVitest", () => {
 			          "devDependencies": {
 			            "@vitest/coverage-v8": "4.0.15",
 			            "@vitest/eslint-plugin": "1.5.1",
-			            "console-fail-test": "0.5.0",
+			            "console-fail-test": "0.6.1",
 			            "vitest": "4.0.15",
 			          },
 			          "scripts": {
@@ -1025,7 +1022,6 @@ describe("blockVitest", () => {
 				test: {
 					clearMocks: true,
 					coverage: {
-						all: true,
 						exclude: ["other"],
 						include: ["src/"],
 						reporter: ["html", "lcov"],

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -236,7 +236,6 @@ export default defineConfig({
 	test: {
 		clearMocks: true,
 		coverage: {
-			all: true,
 			${
 				coverage.exclude?.length
 					? `exclude: ${JSON.stringify(coverage.exclude)},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
 	test: {
 		clearMocks: true,
 		coverage: {
-			all: true,
 			include: ["src"],
 			reporter: ["html", "lcov"],
 		},


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2305
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

* Removes the `coverage.all: true` that's unnecessary now per https://vitest.dev/guide/migration.html#removed-options-coverage-all-and-coverage-extensions
* Brings in `console-fail-test@0.6.1`

🎁