### PR TITLE
feat: add globalIgnores helper to eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,13 +19,14 @@ import packageJson from "eslint-plugin-package-json";
 import perfectionist from "eslint-plugin-perfectionist";
 import * as regexp from "eslint-plugin-regexp";
 import yml from "eslint-plugin-yml";
-import { defineConfig } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig(
-	{
-		ignores: ["**/*.snap", "coverage", "lib", "node_modules", "pnpm-lock.yaml"],
-	},
+	globalIgnores(
+		["**/*.snap", "coverage", "lib", "node_modules", "pnpm-lock.yaml"],
+		"Global Ignores",
+	),
 	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 	{
 		extends: [

--- a/src/blocks/blockESLint.test.ts
+++ b/src/blocks/blockESLint.test.ts
@@ -114,11 +114,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -268,11 +268,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -425,11 +425,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.mjs": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ files: ["*.mjs"], languageOptions: {"sourceType":"module"}, },{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,mjs,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -595,11 +595,11 @@ describe("blockESLint", () => {
 			import a from "@eslint/markdown"
 			import b from "eslint-plugin-regexp"
 			import c from "eslint-plugin-unknown"
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["generated", "lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["generated", "lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [a.configs.recommended], files: ["**/*.a"], rules: {"a/b":"error","a/c":["error",{"d":"e"}]}, },{ extends: [b.configs.recommended], files: ["**/*.b"], rules: {"b/c":"error","b/d":["error",{"e":"f"}]}, settings: {"react":{"version":"detect"}}, },{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -753,11 +753,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [], files: ["**/*.js"], rules: {
 
@@ -900,11 +900,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ files: ["**/*.js"], rules: {
 
@@ -1060,11 +1060,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [a.configs.recommended], files: ["**/*.a"], languageOptions: {"languageOption":true}, linterOptions: {"linterOption":true} rules: {"a/b":"error"}, settings: {"react":{"version":"detect"}}, },{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -1208,11 +1208,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [a.configs.recommended], files: ["**/*.a"], languageOptions: {"languageOption":true}, linterOptions: {"linterOption":true} rules: {"a/b":"error"}, settings: {"react":{"version":"detect"}}, },{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -1334,11 +1334,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s","bin/index.js"]}}}, }
 			);",
@@ -1460,11 +1460,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s","bin/index.js"]}}}, }
 			);",
@@ -1583,11 +1583,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.mjs": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ files: ["*.mjs"], languageOptions: {"sourceType":"module"}, },{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,mjs,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",
@@ -1706,11 +1706,11 @@ describe("blockESLint", () => {
 			  ],
 			  "files": {
 			    "eslint.config.js": "import eslint from "@eslint/js";
-			import { defineConfig } from "eslint/config";
+			import { defineConfig, globalIgnores } from "eslint/config";
 			import tseslint from "typescript-eslint";
 
 			export default defineConfig(
-				{ ignores: ["lib", "node_modules", "pnpm-lock.yaml"] },
+				globalIgnores( ["lib", "node_modules", "pnpm-lock.yaml"], "Global Ignores" ),
 				{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 				{ extends: [eslint.configs.recommended, tseslint.configs.strictTypeChecked, tseslint.configs.stylisticTypeChecked], files: ["**/*.{js,ts}"], languageOptions: {"parserOptions":{"projectService":{"allowDefaultProject":["*.config.*s"]}}}, }
 			);",

--- a/src/blocks/blockESLint.ts
+++ b/src/blocks/blockESLint.ts
@@ -58,7 +58,7 @@ export const blockESLint = base.createBlock({
 
 		const importLines = [
 			'import eslint from "@eslint/js";',
-			'import { defineConfig } from "eslint/config";',
+			'import { defineConfig, globalIgnores } from "eslint/config";',
 			'import tseslint from "typescript-eslint";',
 			...imports.map(
 				(packageImport) =>
@@ -220,7 +220,7 @@ Each should be shown in VS Code, and can be run manually on the command-line:
 				[configFileName]: `${explanation}${importLines.join("\n")}
 
 export default defineConfig(
-	{ ignores: [${ignoreLines.join(", ")}] },
+	globalIgnores( [${ignoreLines.join(", ")}], "Global Ignores" ),
 	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 	${extensionLines.join(",")}
 );`,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 🎁
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2321 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
<!-- Description of what is changed and how the code change does that. -->
Adds globalIgnores helper to eslint config for ensuring global ignores are properly configured and to allow for them to be labeled. 

| before | after|
| ----------|--------|
| <img width="1722" height="282" alt="Screenshot From 2025-12-16 20-00-41" src="https://github.com/user-attachments/assets/f5b90a4e-e159-4b0e-99e6-b00913a72498" />|<img width="1722" height="282" alt="Screenshot From 2025-12-16 19-53-59" src="https://github.com/user-attachments/assets/c6119f1a-b2c6-4752-8b9f-f95eaa86b08b" /> |


🌍
