### PR TITLE
fix(cli): add --remote to help output via bingo patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"scripts": {
 		"build": "tsdown",
 		"format": "prettier .",
+		"postinstall": "patch-package",
 		"lint": "eslint . --max-warnings 0",
 		"lint:knip": "knip",
 		"lint:packages": "pnpm dedupe --check",
@@ -55,6 +56,7 @@
 		"object-strings-deep": "^0.1.2",
 		"parse-author": "^2.0.0",
 		"parse-package-name": "^1.0.0",
+		"patch-package": "^8.0.1",
 		"remove-dependencies": "^0.1.1",
 		"remove-undefined-objects": "^7.0.0",
 		"semver": "^7.7.3",
@@ -98,6 +100,7 @@
 		"husky": "9.1.7",
 		"knip": "5.71.0",
 		"lint-staged": "16.2.7",
+		"patch-package": "^8.0.1",
 		"prettier": "3.7.3",
 		"prettier-plugin-curly": "0.4.1",
 		"prettier-plugin-packagejson": "2.5.20",

--- a/patches/bingo+0.9.2.patch
+++ b/patches/bingo+0.9.2.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/bingo/lib/cli/loggers/logHelpText.js b/node_modules/bingo/lib/cli/loggers/logHelpText.js
+index 5ddc239..b8021f3 100644
+--- a/node_modules/bingo/lib/cli/loggers/logHelpText.js
++++ b/node_modules/bingo/lib/cli/loggers/logHelpText.js
+@@ -38,6 +38,24 @@ export function logHelpText(mode, from, template) {
+             text: 'Whether to run in an "offline" mode that skips network requests.',
+             type: "boolean",
+         },
++        {
++            examples: ["--remote"],
++            flag: "--remote",
++            text: "Whether to create a remote repository on GitHub if one does not already exist.",
++            type: "boolean",
++        },
++        {
++            examples: ["--skip-files"],
++            flag: "--skip-files",
++            text: "Whether to skip creating files on disk.",
++            type: "boolean",
++        },
++        {
++            examples: ["--skip-requests"],
++            flag: "--skip-requests",
++            text: "Whether to skip sending network requests as specified by templates.",
++            type: "boolean",
++        },
+         {
+             examples: ["--version"],
+             flag: "--version",


### PR DESCRIPTION
Fixes #2369.

## Problem
The `--remote`, `--skip-files`, and `--skip-requests` CLI options are supported by bingo's `runTemplateCLI` but were missing from the help text in the published bingo v0.9.2.

## Solution
This PR adds a `patch-package` patch for bingo that includes the missing options in the help output. The upstream fix is already committed to [bingo-js/bingo main](https://github.com/bingo-js/bingo/commit/3605d7f77443ee0d97584da4422146d28cb16c66) but hasn't been released to npm yet.

Once bingo publishes a new version, this patch can be removed and bingo can be bumped instead.