### PR TITLE
fix: update blocks to conform to latest eslint-plugin-package-json standards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/prepare
       - run: pnpm build
-      - run: npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm
+      - run: npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm --profile esm-only
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/prepare
       - run: pnpm build
-      - run: node lib/index.js --version
+      - run: node ./lib/index.js --version
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -26,13 +26,13 @@ This table summarizes each block and which base levels they're included in:
 | ESLint Plugin                      | `--add-eslint-plugin`, `--exclude-eslint-plugin`                                           |         |        |            |
 | ESLint Regexp Plugin               | `--add-eslint-regexp-plugin`, `--exclude-eslint-regexp-plugin`                             |         |        | 💯         |
 | ESLint YML Plugin                  | `--add-eslint-yml-plugin`, `--exclude-eslint-yml-plugin`                                   |         |        | 💯         |
+| Exports                            | `--add-exports`, `--exclude-exports`                                                       | ✔️      | ✅     | 💯         |
 | Funding                            | `--add-funding`, `--exclude-funding`                                                       |         | ✅     | 💯         |
 | GitHub Actions CI                  | `--add-github-actions-ci`, `--exclude-github-actions-ci`                                   | ✔️      | ✅     | 💯         |
 | GitHub Issue Templates             | `--add-github-issue-templates`, `--exclude-github-issue-templates`                         | ✔️      | ✅     | 💯         |
 | GitHub PR Template                 | `--add-github-pr-template`, `--exclude-github-pr-template`                                 | ✔️      | ✅     | 💯         |
 | Gitignore                          | `--add-gitignore`, `--exclude-gitignore`                                                   | ✔️      | ✅     | 💯         |
 | Knip                               | `--add-knip`, `--exclude-knip`                                                             |         |        | 💯         |
-| Main                               | `--add-main`, `--exclude-main`                                                             | ✔️      | ✅     | 💯         |
 | MIT License                        | `--add-mit-license`, `--exclude-mit-license`                                               | ✔️      | ✅     | 💯         |
 | ncc                                | `--add-ncc`, `--exclude-ncc`                                                               |         |        |            |
 | nvmrc                              | `--add-nvmrc`, `--exclude-nvmrc`                                                           |         |        | 💯         |
@@ -49,6 +49,7 @@ This table summarizes each block and which base levels they're included in:
 | release-it                         | `--add-release-it`, `--exclude-release-it`                                                 |         | ✅     | 💯         |
 | Renovate                           | `--add-renovate`, `--exclude-renovate`                                                     |         |        | 💯         |
 | Security Docs                      | `--add-security-docs`, `--exclude-security-docs`                                           | ✔️      | ✅     | 💯         |
+| Side Effects                       | `--add-side-effects`, `--exclude-side-effects`                                             | ✔️      | ✅     | 💯         |
 | Templated With                     | `--add-templated-with`, `--exclude-templated-with`                                         | ✔️      | ✅     | 💯         |
 | TSDown                             | `--add-tsdown`, `--exclude-tsdown`                                                         | ✔️      | ✅     | 💯         |
 | TypeScript                         | `--add-typescript`, `--exclude-typescript`                                                 | ✔️      | ✅     | 💯         |
@@ -247,18 +248,34 @@ pnpm run test run --coverage
 This level is for developers who are eager to get the maximum tooling benefits in a repository.
 Using the _"everything"_ level will gain you comprehensive, strict coverage of all sorts of repository issues, including auto-sorting of properties and strict ESLint configs.
 
-- [Lint ESLint](#lint-eslint)
-- [Lint JSDoc](#lint-jsdoc)
-- [Lint JSON](#lint-json)
-- [Lint Package JSON](#lint-package-json)
-- [Lint Packages](#lint-packages)
-- [Lint Perfectionist](#lint-perfectionist)
-- [Lint Regexp](#lint-regexp)
-- [Lint Spelling](#lint-spelling)
-- [Lint Strict](#lint-strict)
-- [Lint Stylistic](#lint-stylistic)
-- [Lint YML](#lint-yml)
-- [OctoGuide Strict](#octoguide-strict)
+- [Blocks](#blocks)
+  - ["Minimal" Base Level](#minimal-base-level)
+    - [Building](#building)
+    - [Formatting](#formatting)
+    - [Linting](#linting)
+    - [Package Management](#package-management)
+    - [Repository Templates](#repository-templates)
+    - [Type Checking](#type-checking)
+  - ["Common" Base Level](#common-base-level)
+    - [Contributors](#contributors)
+    - [Lint Knip](#lint-knip)
+    - [OctoGuide](#octoguide)
+    - [Releases](#releases)
+    - [Renovate](#renovate)
+    - [Testing](#testing)
+  - ["Everything" Base Level](#everything-base-level)
+    - [Lint ESLint](#lint-eslint)
+    - [Lint JSDoc](#lint-jsdoc)
+    - [Lint JSON](#lint-json)
+    - [Lint Package JSON](#lint-package-json)
+    - [Lint Packages](#lint-packages)
+    - [Lint Perfectionist](#lint-perfectionist)
+    - [Lint Regexp](#lint-regexp)
+    - [Lint Spelling](#lint-spelling)
+    - [Lint Strict](#lint-strict)
+    - [Lint Stylistic](#lint-stylistic)
+    - [Lint YML](#lint-yml)
+    - [OctoGuide Strict](#octoguide-strict)
 
 ### Lint ESLint
 

--- a/docs/Transition.md
+++ b/docs/Transition.md
@@ -14,7 +14,7 @@ The transition script will:
 - Create or rewrite configuration files for the new tooling
 - Run ESLint and Prettier auto-fixers to align formatting and style to the new settings
 
-For example, if the repository previously using Jest for testing:
+For example, if the repository previously used Jest for testing:
 
 - `eslint-plugin-jest`, `jest`, and other Jest-related packages will be uninstalled
 - Any Jest config file like `jest.config.js` will be deleted

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -117,5 +117,8 @@ export default defineConfig(
 			],
 		},
 	},
-	{ extends: [packageJson.configs.recommended], files: ["package.json"] },
+	{
+		extends: [packageJson.configs.recommended, packageJson.configs.stylistic],
+		files: ["package.json"],
+	},
 );

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
 		"name": "Josh Goldberg ✨",
 		"email": "npm@joshuakgoldberg.com"
 	},
+	"sideEffects": false,
 	"type": "module",
-	"main": "lib/index.js",
+	"exports": {
+		".": "./lib/index.js"
+	},
 	"bin": "bin/index.js",
 	"files": [
 		"lib/"

--- a/src/blocks/blockAreTheTypesWrong.test.ts
+++ b/src/blocks/blockAreTheTypesWrong.test.ts
@@ -23,7 +23,7 @@ describe("blockAreTheTypesWrong", () => {
 			                "run": "pnpm build",
 			              },
 			              {
-			                "run": "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
+			                "run": "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm --profile esm-only",
 			              },
 			            ],
 			          },

--- a/src/blocks/blockAreTheTypesWrong.ts
+++ b/src/blocks/blockAreTheTypesWrong.ts
@@ -15,7 +15,7 @@ export const blockAreTheTypesWrong = base.createBlock({
 							steps: [
 								{ run: "pnpm build" },
 								{
-									run: "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm",
+									run: "npx --yes @arethetypeswrong/cli --pack . --ignore-rules cjs-resolves-to-esm --profile esm-only",
 								},
 							],
 						},

--- a/src/blocks/blockESLintPackageJson.test.ts
+++ b/src/blocks/blockESLintPackageJson.test.ts
@@ -19,6 +19,7 @@ describe("blockESLintPackageJson", () => {
 			          {
 			            "extends": [
 			              "packageJson.configs.recommended",
+			              "packageJson.configs.stylistic",
 			            ],
 			            "files": [
 			              "package.json",
@@ -64,6 +65,7 @@ describe("blockESLintPackageJson", () => {
 			          {
 			            "extends": [
 			              "packageJson.configs.recommended",
+			              "packageJson.configs.stylistic",
 			            ],
 			            "files": [
 			              "package.json",

--- a/src/blocks/blockESLintPackageJson.ts
+++ b/src/blocks/blockESLintPackageJson.ts
@@ -15,7 +15,10 @@ export const blockESLintPackageJson = base.createBlock({
 				blockESLint({
 					extensions: [
 						{
-							extends: ["packageJson.configs.recommended"],
+							extends: [
+								"packageJson.configs.recommended",
+								"packageJson.configs.stylistic",
+							],
 							files: ["package.json"],
 						},
 					],

--- a/src/blocks/blockExports.test.ts
+++ b/src/blocks/blockExports.test.ts
@@ -1,12 +1,12 @@
 import { testBlock } from "bingo-stratum-testers";
 import { describe, expect, it } from "vitest";
 
-import { blockMain } from "./blockMain.js";
+import { blockExports } from "./blockExports.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockMain", () => {
+describe(blockExports, () => {
 	it("without addons", () => {
-		const creation = testBlock(blockMain, { options: optionsBase });
+		const creation = testBlock(blockExports, { options: optionsBase });
 
 		expect(creation).toMatchInlineSnapshot(`
 			{
@@ -14,7 +14,9 @@ describe("blockMain", () => {
 			    {
 			      "addons": {
 			        "properties": {
-			          "main": "lib/index.js",
+			          "exports": {
+			            ".": "./lib/index.js",
+			          },
 			        },
 			      },
 			      "block": [Function],
@@ -22,7 +24,7 @@ describe("blockMain", () => {
 			    {
 			      "addons": {
 			        "runInCI": [
-			          "node lib/index.js",
+			          "node ./lib/index.js",
 			        ],
 			      },
 			      "block": [Function],
@@ -33,7 +35,7 @@ describe("blockMain", () => {
 	});
 
 	it("with addons", () => {
-		const creation = testBlock(blockMain, {
+		const creation = testBlock(blockExports, {
 			addons: {
 				filePath: "other.js",
 				runArgs: ["--version"],
@@ -47,7 +49,9 @@ describe("blockMain", () => {
 			    {
 			      "addons": {
 			        "properties": {
-			          "main": "other.js",
+			          "exports": {
+			            ".": "./other.js",
+			          },
 			        },
 			      },
 			      "block": [Function],

--- a/src/blocks/blockExports.ts
+++ b/src/blocks/blockExports.ts
@@ -4,22 +4,24 @@ import { base } from "../base.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockTSDown } from "./blockTSDown.js";
 
-export const blockMain = base.createBlock({
+export const blockExports = base.createBlock({
 	about: {
-		name: "Main",
+		name: "Exports",
 	},
 	addons: {
 		filePath: z.string().optional(),
 		runArgs: z.array(z.string()).default([]),
 	},
 	produce({ addons }) {
-		const { filePath = "lib/index.js", runArgs } = addons;
+		const { filePath = "./lib/index.js", runArgs } = addons;
 
 		return {
 			addons: [
 				blockPackageJson({
 					properties: {
-						main: filePath,
+						exports: {
+							".": filePath.startsWith(".") ? filePath : `./${filePath}`,
+						},
 					},
 				}),
 				blockTSDown({

--- a/src/blocks/blockSideEffects.test.ts
+++ b/src/blocks/blockSideEffects.test.ts
@@ -1,0 +1,76 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, it } from "vitest";
+
+import { blockSideEffects } from "./blockSideEffects.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe(blockSideEffects, () => {
+	it("without addons", () => {
+		const creation = testBlock(blockSideEffects, { options: optionsBase });
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "properties": {
+			          "sideEffects": false,
+			        },
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
+
+	it("with addons (boolean)", () => {
+		const creation = testBlock(blockSideEffects, {
+			addons: {
+				sideEffects: true,
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "properties": {
+			          "sideEffects": true,
+			        },
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
+
+	it("with addons (Array)", () => {
+		const creation = testBlock(blockSideEffects, {
+			addons: {
+				sideEffects: ["./main.js"],
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "properties": {
+			          "sideEffects": [
+			            "./main.js",
+			          ],
+			        },
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			}
+		`);
+	});
+});

--- a/src/blocks/blockSideEffects.ts
+++ b/src/blocks/blockSideEffects.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import { base } from "../base.js";
+import { blockPackageJson } from "./blockPackageJson.js";
+
+export const blockSideEffects = base.createBlock({
+	about: {
+		name: "Side Effects",
+	},
+	addons: {
+		sideEffects: z.union([z.boolean(), z.array(z.string())]).optional(),
+	},
+	produce({ addons }) {
+		const { sideEffects = false } = addons;
+
+		return {
+			addons: [
+				blockPackageJson({
+					properties: {
+						sideEffects,
+					},
+				}),
+			],
+		};
+	},
+});

--- a/src/blocks/index.ts
+++ b/src/blocks/index.ts
@@ -17,13 +17,13 @@ import { blockESLintPerfectionist } from "./blockESLintPerfectionist.js";
 import { blockESLintPlugin } from "./blockESLintPlugin.js";
 import { blockESLintRegexp } from "./blockESLintRegexp.js";
 import { blockESLintYML } from "./blockESLintYML.js";
+import { blockExports } from "./blockExports.js";
 import { blockFunding } from "./blockFunding.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockGitHubIssueTemplates } from "./blockGitHubIssueTemplates.js";
 import { blockGitHubPRTemplate } from "./blockGitHubPRTemplate.js";
 import { blockGitignore } from "./blockGitignore.js";
 import { blockKnip } from "./blockKnip.js";
-import { blockMain } from "./blockMain.js";
 import { blockMITLicense } from "./blockMITLicense.js";
 import { blockNcc } from "./blockNcc.js";
 import { blockNvmrc } from "./blockNvmrc.js";
@@ -40,6 +40,7 @@ import { blockREADME } from "./blockREADME.js";
 import { blockReleaseIt } from "./blockReleaseIt.js";
 import { blockRenovate } from "./blockRenovate.js";
 import { blockSecurityDocs } from "./blockSecurityDocs.js";
+import { blockSideEffects } from "./blockSideEffects.js";
 import { blockTemplatedWith } from "./blockTemplatedWith.js";
 import { blockTSDown } from "./blockTSDown.js";
 import { blockTypeScript } from "./blockTypeScript.js";
@@ -67,13 +68,13 @@ export const blocks = {
 	blockESLintPlugin,
 	blockESLintRegexp,
 	blockESLintYML,
+	blockExports,
 	blockFunding,
 	blockGitHubActionsCI,
 	blockGitHubIssueTemplates,
 	blockGitHubPRTemplate,
 	blockGitignore,
 	blockKnip,
-	blockMain,
 	blockMITLicense,
 	blockNcc,
 	blockNvmrc,
@@ -90,6 +91,7 @@ export const blocks = {
 	blockReleaseIt,
 	blockRenovate,
 	blockSecurityDocs,
+	blockSideEffects,
 	blockTemplatedWith,
 	blockTSDown,
 	blockTypeScript,
@@ -118,13 +120,13 @@ export { blockESLintPerfectionist } from "./blockESLintPerfectionist.js";
 export { blockESLintPlugin } from "./blockESLintPlugin.js";
 export { blockESLintRegexp } from "./blockESLintRegexp.js";
 export { blockESLintYML } from "./blockESLintYML.js";
+export { blockExports } from "./blockExports.js";
 export { blockFunding } from "./blockFunding.js";
 export { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 export { blockGitHubIssueTemplates } from "./blockGitHubIssueTemplates.js";
 export { blockGitHubPRTemplate } from "./blockGitHubPRTemplate.js";
 export { blockGitignore } from "./blockGitignore.js";
 export { blockKnip } from "./blockKnip.js";
-export { blockMain } from "./blockMain.js";
 export { blockMITLicense } from "./blockMITLicense.js";
 export { blockNcc } from "./blockNcc.js";
 export { blockNvmrc } from "./blockNvmrc.js";
@@ -141,6 +143,7 @@ export { blockREADME } from "./blockREADME.js";
 export { blockReleaseIt } from "./blockReleaseIt.js";
 export { blockRenovate } from "./blockRenovate.js";
 export { blockSecurityDocs } from "./blockSecurityDocs.js";
+export { blockSideEffects } from "./blockSideEffects.js";
 export { blockTemplatedWith } from "./blockTemplatedWith.js";
 export { blockTSDown } from "./blockTSDown.js";
 export { blockTypeScript } from "./blockTypeScript.js";

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -14,8 +14,8 @@ import {
 	blockCodecov,
 	blockCSpell,
 	blockESLint,
+	blockExports,
 	blockKnip,
-	blockMain,
 	blockRenovate,
 	blockTemplatedWith,
 	presets,
@@ -121,7 +121,7 @@ If you're interested in learning more, see the 'getting started' docs on:
 						"trash-cli",
 					],
 				}),
-				blockMain({
+				blockExports({
 					runArgs: ["--version"],
 				}),
 				blockRenovate({

--- a/src/presets/minimal.ts
+++ b/src/presets/minimal.ts
@@ -4,12 +4,12 @@ import { blockContributorCovenant } from "../blocks/blockContributorCovenant.js"
 import { blockDevelopmentDocs } from "../blocks/blockDevelopmentDocs.js";
 import { blockESLint } from "../blocks/blockESLint.js";
 import { blockExampleFiles } from "../blocks/blockExampleFiles.js";
+import { blockExports } from "../blocks/blockExports.js";
 import { blockGitHubActionsCI } from "../blocks/blockGitHubActionsCI.js";
 import { blockGitHubApps } from "../blocks/blockGitHubApps.js";
 import { blockGitHubIssueTemplates } from "../blocks/blockGitHubIssueTemplates.js";
 import { blockGitHubPRTemplate } from "../blocks/blockGitHubPRTemplate.js";
 import { blockGitignore } from "../blocks/blockGitignore.js";
-import { blockMain } from "../blocks/blockMain.js";
 import { blockMITLicense } from "../blocks/blockMITLicense.js";
 import { blockPackageJson } from "../blocks/blockPackageJson.js";
 import { blockPrettier } from "../blocks/blockPrettier.js";
@@ -22,6 +22,7 @@ import { blockRepositoryLabels } from "../blocks/blockRepositoryLabels.js";
 import { blockRepositorySecrets } from "../blocks/blockRepositorySecrets.js";
 import { blockRepositorySettings } from "../blocks/blockRepositorySettings.js";
 import { blockSecurityDocs } from "../blocks/blockSecurityDocs.js";
+import { blockSideEffects } from "../blocks/blockSideEffects.js";
 import { blockTemplatedWith } from "../blocks/blockTemplatedWith.js";
 import { blockTSDown } from "../blocks/blockTSDown.js";
 import { blockTypeScript } from "../blocks/blockTypeScript.js";
@@ -37,13 +38,13 @@ export const presetMinimal = base.createPreset({
 		blockContributorCovenant,
 		blockDevelopmentDocs,
 		blockESLint,
+		blockExports,
 		blockExampleFiles,
 		blockGitHubActionsCI,
 		blockGitHubApps,
 		blockGitHubIssueTemplates,
 		blockGitHubPRTemplate,
 		blockGitignore,
-		blockMain,
 		blockMITLicense,
 		blockPackageJson,
 		blockPrettier,
@@ -56,6 +57,7 @@ export const presetMinimal = base.createPreset({
 		blockRepositorySecrets,
 		blockRepositorySettings,
 		blockSecurityDocs,
+		blockSideEffects,
 		blockTemplatedWith,
 		blockTSDown,
 		blockTypeScript,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 🎁
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2374
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates both this repo and blocks that generate new repos, to properly conform to the latest `eslint-plugin-package-json` rules.  Namely changing the `blockMain` to `blockExports`, which now generates exports conditions, and a new `blockSideEffects` which adds `sideEffects` to the package.json.
