### PR TITLE
feat: update CI conventions

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -52,7 +52,6 @@ Each should be shown in VS Code, and can be run manually on the command-line:
 
 - `pnpm lint` ([ESLint](https://eslint.org) with [typescript-eslint](https://typescript-eslint.io)): Lints source files, including JavaScript, Markdown, and TypeScript
 - `pnpm lint:knip` ([knip](https://github.com/webpro/knip)): Detects unused files, dependencies, and code exports
-- `pnpm lint:packages` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the `pnpm-lock.yaml` file
 - `pnpm lint:spelling` ([cspell](https://cspell.org)): Spell checks across all source files
 
 Read the individual documentation for each linter to understand how it can be configured and used best.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,20 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: node ./lib/index.js --version
+  dedupe_check:
+    name: Dedupe Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: ./.github/actions/prepare
+      - run: pnpm dedupe --check
+  format_check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - uses: ./.github/actions/prepare
+      - run: pnpm format --list-different
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -30,13 +44,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/prepare
       - run: pnpm lint:knip
-  lint_packages:
-    name: Lint Packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: ./.github/actions/prepare
-      - run: pnpm lint:packages
   lint_spelling:
     name: Lint Spelling
     runs-on: ubuntu-latest
@@ -44,13 +51,6 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/prepare
       - run: pnpm lint:spelling
-  prettier:
-    name: Prettier
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: ./.github/actions/prepare
-      - run: pnpm format --list-different
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/octoguide.yaml
+++ b/.github/workflows/octoguide.yaml
@@ -1,6 +1,10 @@
 jobs:
   octoguide:
     if: ${{ !endsWith(github.actor, '[bot]') }}
+    permissions:
+      discussions: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: JoshuaKGoldberg/octoguide@2323755a369bb2daf760304df78385f144cb4ce0 # 0.21.0
@@ -38,8 +42,3 @@ on:
     types:
       - edited
       - opened
-
-permissions:
-  discussions: write
-  issues: write
-  pull-requests: write

--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -1,5 +1,8 @@
 jobs:
   post_release:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -25,7 +28,3 @@ on:
   release:
     types:
       - published
-
-permissions:
-  issues: write
-  pull-requests: write

--- a/.github/workflows/pr-review-requested.yaml
+++ b/.github/workflows/pr-review-requested.yaml
@@ -1,5 +1,7 @@
 jobs:
   pr_review_requested:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
@@ -16,6 +18,3 @@ on:
   pull_request_target:
     types:
       - review_requested
-
-permissions:
-  pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ concurrency:
 
 jobs:
   release:
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
@@ -22,7 +25,3 @@ on:
   push:
     branches:
       - main
-
-permissions:
-  contents: write
-  id-token: write

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -29,6 +29,8 @@ As a consequence we should:
      ```yaml
      jobs:
        build:
+         permissions:
+           contents: read
          runs-on: ubuntu-latest
          steps:
            - uses: actions/checkout@v4
@@ -58,9 +60,6 @@ As a consequence we should:
        push:
          branches:
            - main
-
-     permissions:
-       contents: read
      ```
 
       </details>
@@ -95,7 +94,7 @@ Delete `tsdown.config.ts` then execute the following commands:
    npx lint-staged
    ```
 
-2. Create an [`action.yaml` metadata file](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#creating-an-action-metadata-file).
+1. Create an [`action.yaml` metadata file](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#creating-an-action-metadata-file).
 
 It's worth reading the [GitHub Actions documentation](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action#writing-the-action-code).
 

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
 		"format": "prettier .",
 		"lint": "eslint . --max-warnings 0",
 		"lint:knip": "knip",
-		"lint:packages": "pnpm dedupe --check",
 		"lint:spelling": "cspell \"**\" \".github/**/*\"",
 		"prepare": "husky",
-		"test": "vitest",
-		"tsc": "tsc"
+		"test": "vitest"
 	},
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"

--- a/src/blocks/blockCTATransitions.test.ts
+++ b/src/blocks/blockCTATransitions.test.ts
@@ -85,6 +85,8 @@ describe("blockCTATransitions", () => {
 			      "cta.yaml": "jobs:
 			  transition:
 			    name: Transition
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - id: checkout
@@ -110,10 +112,6 @@ describe("blockCTATransitions", () => {
 			  pull_request:
 			    branches:
 			      - main
-
-
-			permissions:
-			  pull-requests: write
 			",
 			    },
 			  },

--- a/src/blocks/blockGitHubActionsCI.test.ts
+++ b/src/blocks/blockGitHubActionsCI.test.ts
@@ -51,6 +51,8 @@ describe("blockGitHubActionsCI", () => {
 			        "ci.yaml": undefined,
 			        "pr-review-requested.yaml": "jobs:
 			  pr_review_requested:
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions-ecosystem/action-remove-labels@v1
@@ -69,10 +71,6 @@ describe("blockGitHubActionsCI", () => {
 			  pull_request_target:
 			    types:
 			      - review_requested
-
-
-			permissions:
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -127,6 +125,8 @@ describe("blockGitHubActionsCI", () => {
 			        "ci.yaml": undefined,
 			        "pr-review-requested.yaml": "jobs:
 			  pr_review_requested:
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions-ecosystem/action-remove-labels@v1
@@ -145,10 +145,6 @@ describe("blockGitHubActionsCI", () => {
 			  pull_request_target:
 			    types:
 			      - review_requested
-
-
-			permissions:
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -197,6 +193,8 @@ describe("blockGitHubActionsCI", () => {
 			        "ci.yaml": undefined,
 			        "pr-review-requested.yaml": "jobs:
 			  pr_review_requested:
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions-ecosystem/action-remove-labels@v1
@@ -215,10 +213,6 @@ describe("blockGitHubActionsCI", () => {
 			  pull_request_target:
 			    types:
 			      - review_requested
-
-
-			permissions:
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -277,6 +271,8 @@ describe("blockGitHubActionsCI", () => {
 			        "ci.yaml": undefined,
 			        "pr-review-requested.yaml": "jobs:
 			  pr_review_requested:
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions-ecosystem/action-remove-labels@v1
@@ -295,10 +291,6 @@ describe("blockGitHubActionsCI", () => {
 			  pull_request_target:
 			    types:
 			      - review_requested
-
-
-			permissions:
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -387,6 +379,8 @@ describe("blockGitHubActionsCI", () => {
 			",
 			        "pr-review-requested.yaml": "jobs:
 			  pr_review_requested:
+			    permissions:
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions-ecosystem/action-remove-labels@v1
@@ -405,10 +399,6 @@ describe("blockGitHubActionsCI", () => {
 			  pull_request_target:
 			    types:
 			      - review_requested
-
-
-			permissions:
-			  pull-requests: write
 			",
 			      },
 			    },

--- a/src/blocks/blockOctoGuide.test.ts
+++ b/src/blocks/blockOctoGuide.test.ts
@@ -19,6 +19,10 @@ describe("blockOctoGuide", () => {
 			        "octoguide.yaml": "jobs:
 			  octoguide:
 			    if: \${{ !endsWith(github.actor, '[bot]') }}
+			    permissions:
+			      discussions: write
+			      issues: write
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: JoshuaKGoldberg/octoguide@0.11.1
@@ -58,12 +62,6 @@ describe("blockOctoGuide", () => {
 			    types:
 			      - edited
 			      - opened
-
-
-			permissions:
-			  discussions: write
-			  issues: write
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -97,6 +95,10 @@ describe("blockOctoGuide", () => {
 			        "octoguide.yaml": "jobs:
 			  octoguide:
 			    if: \${{ !endsWith(github.actor, '[bot]') }}
+			    permissions:
+			      discussions: write
+			      issues: write
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: JoshuaKGoldberg/octoguide@0.11.1
@@ -136,12 +138,6 @@ describe("blockOctoGuide", () => {
 			    types:
 			      - edited
 			      - opened
-
-
-			permissions:
-			  discussions: write
-			  issues: write
-			  pull-requests: write
 			",
 			      },
 			    },
@@ -166,6 +162,10 @@ describe("blockOctoGuide", () => {
 			        "octoguide.yaml": "jobs:
 			  octoguide:
 			    if: \${{ !endsWith(github.actor, '[bot]') }}
+			    permissions:
+			      discussions: write
+			      issues: write
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: JoshuaKGoldberg/octoguide@0.11.1
@@ -205,12 +205,6 @@ describe("blockOctoGuide", () => {
 			    types:
 			      - edited
 			      - opened
-
-
-			permissions:
-			  discussions: write
-			  issues: write
-			  pull-requests: write
 			",
 			      },
 			    },

--- a/src/blocks/blockPnpmDedupe.test.ts
+++ b/src/blocks/blockPnpmDedupe.test.ts
@@ -15,26 +15,12 @@ describe("blockPnpmDedupe", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "sections": {
-			          "Linting": {
-			            "contents": {
-			              "items": [
-			                "- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yaml\` file",
-			              ],
-			            },
-			          },
-			        },
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "jobs": [
 			          {
-			            "name": "Lint Packages",
+			            "name": "Dedupe Check",
 			            "steps": [
 			              {
-			                "run": "pnpm lint:packages",
+			                "run": "pnpm dedupe --check",
 			              },
 			            ],
 			          },
@@ -47,11 +33,6 @@ describe("blockPnpmDedupe", () => {
 			        "cleanupCommands": [
 			          "pnpm dedupe",
 			        ],
-			        "properties": {
-			          "scripts": {
-			            "lint:packages": "pnpm dedupe --check",
-			          },
-			        },
 			      },
 			      "block": [Function],
 			    },
@@ -71,26 +52,12 @@ describe("blockPnpmDedupe", () => {
 			  "addons": [
 			    {
 			      "addons": {
-			        "sections": {
-			          "Linting": {
-			            "contents": {
-			              "items": [
-			                "- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yaml\` file",
-			              ],
-			            },
-			          },
-			        },
-			      },
-			      "block": [Function],
-			    },
-			    {
-			      "addons": {
 			        "jobs": [
 			          {
-			            "name": "Lint Packages",
+			            "name": "Dedupe Check",
 			            "steps": [
 			              {
-			                "run": "pnpm lint:packages",
+			                "run": "pnpm dedupe --check",
 			              },
 			            ],
 			          },
@@ -103,11 +70,6 @@ describe("blockPnpmDedupe", () => {
 			        "cleanupCommands": [
 			          "pnpm dedupe",
 			        ],
-			        "properties": {
-			          "scripts": {
-			            "lint:packages": "pnpm dedupe --check",
-			          },
-			        },
 			      },
 			      "block": [Function],
 			    },

--- a/src/blocks/blockPnpmDedupe.ts
+++ b/src/blocks/blockPnpmDedupe.ts
@@ -1,5 +1,4 @@
 import { base } from "../base.js";
-import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRemoveWorkflows } from "./blockRemoveWorkflows.js";
@@ -11,32 +10,16 @@ export const blockPnpmDedupe = base.createBlock({
 	produce() {
 		return {
 			addons: [
-				blockDevelopmentDocs({
-					sections: {
-						Linting: {
-							contents: {
-								items: [
-									`- \`pnpm lint:packages\` ([pnpm dedupe --check](https://pnpm.io/cli/dedupe)): Checks for unnecessarily duplicated packages in the \`pnpm-lock.yaml\` file`,
-								],
-							},
-						},
-					},
-				}),
 				blockGitHubActionsCI({
 					jobs: [
 						{
-							name: "Lint Packages",
-							steps: [{ run: "pnpm lint:packages" }],
+							name: "Dedupe Check",
+							steps: [{ run: "pnpm dedupe --check" }],
 						},
 					],
 				}),
 				blockPackageJson({
 					cleanupCommands: ["pnpm dedupe"],
-					properties: {
-						scripts: {
-							"lint:packages": "pnpm dedupe --check",
-						},
-					},
 				}),
 			],
 		};

--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -44,7 +44,7 @@ describe("blockPrettier", () => {
 			      "addons": {
 			        "jobs": [
 			          {
-			            "name": "Prettier",
+			            "name": "Format Check",
 			            "steps": [
 			              {
 			                "run": "pnpm format --list-different",
@@ -156,7 +156,7 @@ describe("blockPrettier", () => {
 			      "addons": {
 			        "jobs": [
 			          {
-			            "name": "Prettier",
+			            "name": "Format Check",
 			            "steps": [
 			              {
 			                "run": "pnpm format --list-different",
@@ -306,7 +306,7 @@ describe("blockPrettier", () => {
 			      "addons": {
 			        "jobs": [
 			          {
-			            "name": "Prettier",
+			            "name": "Format Check",
 			            "steps": [
 			              {
 			                "run": "pnpm build || exit 0",

--- a/src/blocks/blockPrettier.ts
+++ b/src/blocks/blockPrettier.ts
@@ -59,7 +59,7 @@ pnpm format --write
 				blockGitHubActionsCI({
 					jobs: [
 						{
-							name: "Prettier",
+							name: "Format Check",
 							steps: [
 								...runBefore.map((run) => ({ run })),
 								{ run: "pnpm format --list-different" },

--- a/src/blocks/blockReleaseIt.test.ts
+++ b/src/blocks/blockReleaseIt.test.ts
@@ -54,6 +54,9 @@ describe("blockReleaseIt", () => {
 			      "workflows": {
 			        "post-release.yaml": "jobs:
 			  post_release:
+			    permissions:
+			      issues: write
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions/checkout@v4
@@ -81,11 +84,6 @@ describe("blockReleaseIt", () => {
 			  release:
 			    types:
 			      - published
-
-
-			permissions:
-			  issues: write
-			  pull-requests: write
 			",
 			        "release.yaml": "concurrency:
 			  group: \${{ github.workflow }}
@@ -93,6 +91,9 @@ describe("blockReleaseIt", () => {
 
 			jobs:
 			  release:
+			    permissions:
+			      contents: write
+			      id-token: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions/checkout@v4
@@ -113,11 +114,6 @@ describe("blockReleaseIt", () => {
 			  push:
 			    branches:
 			      - main
-
-
-			permissions:
-			  contents: write
-			  id-token: write
 			",
 			      },
 			    },
@@ -198,6 +194,9 @@ describe("blockReleaseIt", () => {
 			      "workflows": {
 			        "post-release.yaml": "jobs:
 			  post_release:
+			    permissions:
+			      issues: write
+			      pull-requests: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions/checkout@v4
@@ -225,11 +224,6 @@ describe("blockReleaseIt", () => {
 			  release:
 			    types:
 			      - published
-
-
-			permissions:
-			  issues: write
-			  pull-requests: write
 			",
 			        "release.yaml": "concurrency:
 			  group: \${{ github.workflow }}
@@ -237,6 +231,9 @@ describe("blockReleaseIt", () => {
 
 			jobs:
 			  release:
+			    permissions:
+			      contents: write
+			      id-token: write
 			    runs-on: ubuntu-latest
 			    steps:
 			      - uses: actions/checkout@v4
@@ -260,11 +257,6 @@ describe("blockReleaseIt", () => {
 			  push:
 			    branches:
 			      - main
-
-
-			permissions:
-			  contents: write
-			  id-token: write
 			",
 			      },
 			    },

--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -41,14 +41,14 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "files": {
 			          "greet.ts": "import { GreetOptions } from "./types.js";
-				
+
 				export function greet(options: GreetOptions | string) {
 					const {
 						logger = console.log.bind(console),
 						message,
 						times = 1,
 					} = typeof options === "string" ? { message: options } : options;
-				
+
 					for (let i = 0; i < times; i += 1) {
 						logger(message);
 					}
@@ -117,9 +117,6 @@ describe("blockTypeScript", () => {
 			          "files": [
 			            "lib/",
 			          ],
-			          "scripts": {
-			            "tsc": "tsc",
-			          },
 			        },
 			      },
 			      "block": [Function],
@@ -203,14 +200,14 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "files": {
 			          "greet.ts": "import { GreetOptions } from "./types.js";
-				
+
 				export function greet(options: GreetOptions | string) {
 					const {
 						logger = console.log.bind(console),
 						message,
 						times = 1,
 					} = typeof options === "string" ? { message: options } : options;
-				
+
 					for (let i = 0; i < times; i += 1) {
 						logger(message);
 					}
@@ -279,9 +276,6 @@ describe("blockTypeScript", () => {
 			          "files": [
 			            "lib/",
 			          ],
-			          "scripts": {
-			            "tsc": "tsc",
-			          },
 			        },
 			      },
 			      "block": [Function],
@@ -363,14 +357,14 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "files": {
 			          "greet.ts": "import { GreetOptions } from "./types.js";
-				
+
 				export function greet(options: GreetOptions | string) {
 					const {
 						logger = console.log.bind(console),
 						message,
 						times = 1,
 					} = typeof options === "string" ? { message: options } : options;
-				
+
 					for (let i = 0; i < times; i += 1) {
 						logger(message);
 					}
@@ -439,9 +433,6 @@ describe("blockTypeScript", () => {
 			          "files": [
 			            "lib/",
 			          ],
-			          "scripts": {
-			            "tsc": "tsc",
-			          },
 			        },
 			      },
 			      "block": [Function],
@@ -532,14 +523,14 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "files": {
 			          "greet.ts": "import { GreetOptions } from "./types.js";
-				
+
 				export function greet(options: GreetOptions | string) {
 					const {
 						logger = console.log.bind(console),
 						message,
 						times = 1,
 					} = typeof options === "string" ? { message: options } : options;
-				
+
 					for (let i = 0; i < times; i += 1) {
 						logger(message);
 					}
@@ -608,9 +599,6 @@ describe("blockTypeScript", () => {
 			          "files": [
 			            "lib/",
 			          ],
-			          "scripts": {
-			            "tsc": "tsc",
-			          },
 			        },
 			      },
 			      "block": [Function],

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -63,14 +63,14 @@ pnpm tsc --watch
 				blockExampleFiles({
 					files: {
 						"greet.ts": `import { GreetOptions } from "./types.js";
-	
+
 	export function greet(options: GreetOptions | string) {
 		const {
 			logger = console.log.bind(console),
 			message,
 			times = 1,
 		} = typeof options === "string" ? { message: options } : options;
-	
+
 		for (let i = 0; i < times; i += 1) {
 			logger(message);
 		}
@@ -110,9 +110,6 @@ greet("Hello, world! ${options.emoji}");
 					properties: {
 						devDependencies: getPackageDependencies("typescript"),
 						files: ["lib/"],
-						scripts: {
-							tsc: "tsc",
-						},
 					},
 				}),
 				blockVitest({ coverage: { include: ["src"] }, exclude: ["lib"] }),

--- a/src/blocks/files/createSoloWorkflowFile.ts
+++ b/src/blocks/files/createSoloWorkflowFile.ts
@@ -82,12 +82,12 @@ export function createSoloWorkflowFile({
 			[createJobName(jobName ?? name)]: {
 				...(options.if && { if: options.if }),
 				...(jobName && { name: jobName }),
+				permissions,
 				"runs-on": "ubuntu-latest",
 				steps: options.steps,
 			},
 		},
 		name,
 		on,
-		permissions,
 	});
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 🎁
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2379
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change does the following:
- Removed dedicated lint:packages (pnpm dedupe --check) package script
- Renamed CI Job "Lint Packages" -> "Dedupe Check"
- Renamed CI Job "Prettier" -> "Format Check"
- Moved workflow permissions to be at the job level instead of at the workflow level
