### PR TITLE
fix: remove redundant `dts` prop from tsdown config

### DIFF
--- a/src/blocks/blockTSDown.test.ts
+++ b/src/blocks/blockTSDown.test.ts
@@ -92,7 +92,7 @@ describe("blockTSDown", () => {
 			  "files": {
 			    "tsdown.config.ts": "import { defineConfig } from "tsdown";
 
-			export default defineConfig({"dts":true,"entry":["src/**/*.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true});
+			export default defineConfig({"entry":["src/**/*.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true});
 			",
 			  },
 			  "scripts": undefined,
@@ -197,7 +197,7 @@ describe("blockTSDown", () => {
 			  "files": {
 			    "tsdown.config.ts": "import { defineConfig } from "tsdown";
 
-			export default defineConfig({"dts":false,"entry":["src/**/*.ts","src/other.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true});
+			export default defineConfig({"entry":["src/**/*.ts","src/other.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true,"dts":false});
 			",
 			  },
 			  "scripts": undefined,
@@ -325,7 +325,7 @@ describe("blockTSDown", () => {
 			  "files": {
 			    "tsdown.config.ts": "import { defineConfig } from "tsdown";
 
-			export default defineConfig({"dts":true,"entry":["src/**/*.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true});
+			export default defineConfig({"entry":["src/**/*.ts"],"fixedExtension":false,"outDir":"lib","unbundle":true});
 			",
 			  },
 			}

--- a/src/blocks/blockTSDown.ts
+++ b/src/blocks/blockTSDown.ts
@@ -111,7 +111,6 @@ pnpm build --watch
 				"tsdown.config.ts": `import { defineConfig } from "tsdown";
 
 export default defineConfig(${JSON.stringify({
-					dts: true,
 					entry: Array.from(new Set(["src/**/*.ts", ...entry])),
 					fixedExtension: false,
 					outDir: "lib",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	dts: true,
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
 	fixedExtension: false,
 	outDir: "lib",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to create-typescript-app! 🎁
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Contributes to, but doesn't close #2384

This change removes the redundant `dts: true` prop from the tsdown config.
