### PR TITLE
feat: enable prefer-describe-function-title

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -96,7 +96,10 @@ export default defineConfig(
 	{
 		extends: [vitest.configs.recommended],
 		files: ["**/*.test.*"],
-		rules: { "@typescript-eslint/no-unsafe-assignment": "off" },
+		rules: {
+			"@typescript-eslint/no-unsafe-assignment": "off",
+			"vitest/prefer-describe-function-title": "error",
+		},
 		settings: { vitest: { typecheck: true } },
 	},
 	{

--- a/src/blocks/blockCSpell.test.ts
+++ b/src/blocks/blockCSpell.test.ts
@@ -8,7 +8,7 @@ vi.mock("../utils/resolveBin.js", () => ({
 	resolveBin: (bin: string) => `path/to/${bin}`,
 }));
 
-describe("blockCSpell", () => {
+describe(blockCSpell, () => {
 	test("without addons or options", () => {
 		const creation = testBlock(blockCSpell, {
 			options: optionsBase,

--- a/src/blocks/blockCodecov.test.ts
+++ b/src/blocks/blockCodecov.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockCodecov } from "./blockCodecov.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockCodecov", () => {
+describe(blockCodecov, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockCodecov, {
 			options: optionsBase,

--- a/src/blocks/blockDevelopmentDocs.test.ts
+++ b/src/blocks/blockDevelopmentDocs.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockDevelopmentDocs } from "./blockDevelopmentDocs.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockDevelopmentDocs", () => {
+describe(blockDevelopmentDocs, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockDevelopmentDocs, {
 			options: optionsBase,

--- a/src/blocks/blockESLint.test.ts
+++ b/src/blocks/blockESLint.test.ts
@@ -14,7 +14,7 @@ vi.mock("./eslint/blockESLintIntake.js", () => ({
 	},
 }));
 
-describe("blockESLint", () => {
+describe(blockESLint, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockESLint, {
 			options: optionsBase,

--- a/src/blocks/blockESLintPlugin.test.ts
+++ b/src/blocks/blockESLintPlugin.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockESLintPlugin } from "./blockESLintPlugin.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockESLintPlugin", () => {
+describe(blockESLintPlugin, () => {
 	test("without addons, mode, or options", () => {
 		const creation = testBlock(blockESLintPlugin, {
 			options: optionsBase,

--- a/src/blocks/blockExampleFiles.test.ts
+++ b/src/blocks/blockExampleFiles.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockExampleFiles } from "./blockExampleFiles.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockExampleFiles", () => {
+describe(blockExampleFiles, () => {
 	test("without addons.files", () => {
 		const creation = testBlock(blockExampleFiles, {
 			addons: {},

--- a/src/blocks/blockGitHubActionsCI.test.ts
+++ b/src/blocks/blockGitHubActionsCI.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockGitHubActionsCI", () => {
+describe(blockGitHubActionsCI, () => {
 	test("without options.node.pinned", () => {
 		const creation = testBlock(blockGitHubActionsCI, {
 			options: {

--- a/src/blocks/blockGitHubApps.test.ts
+++ b/src/blocks/blockGitHubApps.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockGitHubApps } from "./blockGitHubApps.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockGitHubApps", () => {
+describe(blockGitHubApps, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockGitHubApps, {
 			options: optionsBase,

--- a/src/blocks/blockGitignore.test.ts
+++ b/src/blocks/blockGitignore.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockGitignore } from "./blockGitignore.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockGitignore", () => {
+describe(blockGitignore, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockGitignore, {
 			options: optionsBase,

--- a/src/blocks/blockNcc.test.ts
+++ b/src/blocks/blockNcc.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockNcc } from "./blockNcc.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockNcc", () => {
+describe(blockNcc, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockNcc, {
 			options: optionsBase,

--- a/src/blocks/blockOctoGuide.test.ts
+++ b/src/blocks/blockOctoGuide.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockOctoGuide } from "./blockOctoGuide.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockOctoGuide", () => {
+describe(blockOctoGuide, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockOctoGuide, {
 			options: optionsBase,

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -10,7 +10,7 @@ const options = {
 	description: `A very very very very very very very very very very very very very very very very long <em><code>HTML-ish</code> description</em> ending with an emoji. 🧵`,
 };
 
-describe("blockPackageJson", () => {
+describe(blockPackageJson, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockPackageJson, { options });
 

--- a/src/blocks/blockPrettier.test.ts
+++ b/src/blocks/blockPrettier.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockPrettier } from "./blockPrettier.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockPrettier", () => {
+describe(blockPrettier, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockPrettier, {
 			options: optionsBase,

--- a/src/blocks/blockREADME.test.ts
+++ b/src/blocks/blockREADME.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockREADME } from "./blockREADME.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockREADME", () => {
+describe(blockREADME, () => {
 	test("description with one sentence", () => {
 		const creation = testBlock(blockREADME, {
 			options: {

--- a/src/blocks/blockReleaseIt.test.ts
+++ b/src/blocks/blockReleaseIt.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockReleaseIt } from "./blockReleaseIt.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockReleaseIt", () => {
+describe(blockReleaseIt, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockReleaseIt, { options: optionsBase });
 

--- a/src/blocks/blockRemoveDependencies.test.ts
+++ b/src/blocks/blockRemoveDependencies.test.ts
@@ -8,7 +8,7 @@ vi.mock("../utils/resolveBin.js", () => ({
 	resolveBin: (bin: string) => `path/to/${bin}`,
 }));
 
-describe("blockRemoveDependencies", () => {
+describe(blockRemoveDependencies, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockRemoveDependencies, {
 			options: optionsBase,

--- a/src/blocks/blockRemoveFiles.test.ts
+++ b/src/blocks/blockRemoveFiles.test.ts
@@ -8,7 +8,7 @@ vi.mock("../utils/resolveBin.js", () => ({
 	resolveBin: (bin: string) => `path/to/${bin}`,
 }));
 
-describe("blockRemoveFiles", () => {
+describe(blockRemoveFiles, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockRemoveFiles, {
 			options: optionsBase,

--- a/src/blocks/blockRemoveWorkflows.test.ts
+++ b/src/blocks/blockRemoveWorkflows.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockRemoveWorkflows } from "./blockRemoveWorkflows.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockRemoveWorkflows", () => {
+describe(blockRemoveWorkflows, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockRemoveWorkflows, {
 			options: optionsBase,

--- a/src/blocks/blockRenovate.test.ts
+++ b/src/blocks/blockRenovate.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockRenovate } from "./blockRenovate.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockRenovate", () => {
+describe(blockRenovate, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockRenovate, {
 			options: optionsBase,

--- a/src/blocks/blockRepositoryBranchRuleset.test.ts
+++ b/src/blocks/blockRepositoryBranchRuleset.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockRepositoryBranchRuleset", () => {
+describe(blockRepositoryBranchRuleset, () => {
 	test("without addons when mode is undefined", () => {
 		const creation = testBlock(blockRepositoryBranchRuleset, {
 			options: optionsBase,

--- a/src/blocks/blockRepositorySecrets.test.ts
+++ b/src/blocks/blockRepositorySecrets.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockRepositorySecrets", () => {
+describe(blockRepositorySecrets, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockRepositorySecrets, {
 			options: optionsBase,

--- a/src/blocks/blockTSDown.test.ts
+++ b/src/blocks/blockTSDown.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockTSDown } from "./blockTSDown.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockTSDown", () => {
+describe(blockTSDown, () => {
 	test("without addons or options", () => {
 		const creation = testBlock(blockTSDown, {
 			options: optionsBase,

--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, test } from "vitest";
 import { blockTypeScript } from "./blockTypeScript.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockTypeScript", () => {
+describe(blockTypeScript, () => {
 	test("without addons or options", () => {
 		const creation = testBlock(blockTypeScript, {
 			options: optionsBase,

--- a/src/blocks/blockVSCode.test.ts
+++ b/src/blocks/blockVSCode.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from "vitest";
 import { blockVSCode } from "./blockVSCode.js";
 import { optionsBase } from "./options.fakes.js";
 
-describe("blockVSCode", () => {
+describe(blockVSCode, () => {
 	test("without addons", () => {
 		const creation = testBlock(blockVSCode, {
 			options: optionsBase,

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -67,6 +67,7 @@ describe("blockVitest", () => {
 			              {
 			                "entries": {
 			                  "@typescript-eslint/no-unsafe-assignment": "off",
+			                  "vitest/prefer-describe-function-title": "error",
 			                },
 			              },
 			            ],
@@ -312,6 +313,7 @@ describe("blockVitest", () => {
 			              {
 			                "entries": {
 			                  "@typescript-eslint/no-unsafe-assignment": "off",
+			                  "vitest/prefer-describe-function-title": "error",
 			                },
 			              },
 			            ],
@@ -595,6 +597,7 @@ describe("blockVitest", () => {
 			              {
 			                "entries": {
 			                  "@typescript-eslint/no-unsafe-assignment": "off",
+			                  "vitest/prefer-describe-function-title": "error",
 			                },
 			              },
 			            ],
@@ -849,6 +852,7 @@ describe("blockVitest", () => {
 			              {
 			                "entries": {
 			                  "@typescript-eslint/no-unsafe-assignment": "off",
+			                  "vitest/prefer-describe-function-title": "error",
 			                },
 			              },
 			            ],

--- a/src/blocks/blockVitest.test.ts
+++ b/src/blocks/blockVitest.test.ts
@@ -8,7 +8,7 @@ vi.mock("../utils/resolveBin.js", () => ({
 	resolveBin: (bin: string) => `path/to/${bin}`,
 }));
 
-describe("blockVitest", () => {
+describe(blockVitest, () => {
 	test("without addons or mode", () => {
 		const creation = testBlock(blockVitest, {
 			options: optionsBase,

--- a/src/blocks/blockVitest.ts
+++ b/src/blocks/blockVitest.ts
@@ -119,6 +119,7 @@ Calls to \`console.log\`, \`console.warn\`, and other console methods will cause
 								{
 									entries: {
 										"@typescript-eslint/no-unsafe-assignment": "off",
+										"vitest/prefer-describe-function-title": "error",
 									},
 								},
 							],

--- a/src/inputs/inputFromOctokit.test.ts
+++ b/src/inputs/inputFromOctokit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { inputFromOctokit } from "./inputFromOctokit.js";
 
-describe("inputFromOctokit", () => {
+describe(inputFromOctokit, () => {
 	it("returns data when the request resolves", async () => {
 		const data = JSON.stringify({ found: true });
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2388
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Enables `vitest/prefer-describe-function-title` in generated ESLint configurations and applies the same rule to this repository.

🎁