### PR TITLE
feat: use js/ts.tsdk.path in VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,5 @@
 		"yaml"
 	],
 	"eslint.rules.customizations": [{ "rule": "*", "severity": "warn" }],
-	"typescript.tsdk": "node_modules/typescript/lib"
+	"js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -138,7 +138,7 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "debuggers": [],
 			        "settings": {
-			          "typescript.tsdk": "node_modules/typescript/lib",
+			          "js/ts.tsdk.path": "node_modules/typescript/lib",
 			        },
 			        "tasks": [
 			          {
@@ -297,7 +297,7 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "debuggers": [],
 			        "settings": {
-			          "typescript.tsdk": "node_modules/typescript/lib",
+			          "js/ts.tsdk.path": "node_modules/typescript/lib",
 			        },
 			        "tasks": [
 			          {
@@ -465,7 +465,7 @@ describe("blockTypeScript", () => {
 			          },
 			        ],
 			        "settings": {
-			          "typescript.tsdk": "node_modules/typescript/lib",
+			          "js/ts.tsdk.path": "node_modules/typescript/lib",
 			        },
 			        "tasks": [
 			          {
@@ -620,7 +620,7 @@ describe("blockTypeScript", () => {
 			      "addons": {
 			        "debuggers": [],
 			        "settings": {
-			          "typescript.tsdk": "node_modules/typescript/lib",
+			          "js/ts.tsdk.path": "node_modules/typescript/lib",
 			        },
 			        "tasks": [
 			          {

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -127,7 +127,7 @@ greet("Hello, world! ${options.emoji}");
 							]
 						: [],
 					settings: {
-						"typescript.tsdk": "node_modules/typescript/lib",
+						"js/ts.tsdk.path": "node_modules/typescript/lib",
 					},
 					tasks: [
 						{


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2389
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Replaces the deprecated `typescript.tsdk` setting with `js/ts.tsdk.path` in generated and repository VS Code settings.

🎁