### PR TITLE
feat: add ESLint Markdown Links plugin block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,155 +18,155 @@
 
 - update most deps to latest (August 18, 2026) ([#2399](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2399)) ([0c4d268](https://github.com/JoshuaKGoldberg/create-typescript-app/commit/0c4d26897aa62b4b738a61098739214e9e879c0f)), closes [#2397](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2397)
 
-## [2.62.0](///compare/2.61.2...2.62.0) (2026-08-18)
+## [2.62.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.61.2...2.62.0) (2026-08-18)
 
 ### Features
 
-- convert knip.json to knip.config.ts ([#2398](undefined/undefined/undefined/issues/2398)) a2bc4ce, closes #2393
+- convert knip.json to knip.config.ts ([#2398](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2398)) a2bc4ce, closes #2393
 
-## [2.61.2](///compare/2.61.1...2.61.2) (2026-08-18)
-
-### Bug Fixes
-
-- remove redundant `dts` prop from tsdown config ([#2385](undefined/undefined/undefined/issues/2385)) 08d4c61, closes #000 #2384
-
-## [2.61.1](///compare/2.61.0...2.61.1) (2026-07-11)
+## [2.61.2](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.61.1...2.61.2) (2026-08-18)
 
 ### Bug Fixes
 
-- remove redundant tsc script ([#2383](undefined/undefined/undefined/issues/2383)) 7e1d9d7, closes #2375
+- remove redundant `dts` prop from tsdown config ([#2385](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2385)) 08d4c61, closes #000 #2384
 
-## [2.61.0](///compare/2.60.3...2.61.0) (2026-06-20)
+## [2.61.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.61.0...2.61.1) (2026-07-11)
+
+### Bug Fixes
+
+- remove redundant tsc script ([#2383](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2383)) 7e1d9d7, closes #2375
+
+## [2.61.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.60.3...2.61.0) (2026-06-20)
 
 ### Features
 
-- update CI conventions ([#2380](undefined/undefined/undefined/issues/2380)) 9b9c669, closes #2379
+- update CI conventions ([#2380](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2380)) 9b9c669, closes #2379
 
-## [2.60.3](///compare/2.60.2...2.60.3) (2026-06-18)
-
-### Bug Fixes
-
-- update blocks to conform to latest eslint-plugin-package-json standards ([#2377](undefined/undefined/undefined/issues/2377)) 266a405, closes #2374
-
-## [2.60.2](///compare/2.60.1...2.60.2) (2026-05-04)
+## [2.60.3](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.60.2...2.60.3) (2026-06-18)
 
 ### Bug Fixes
 
-- bump bingo to ^0.9.3 ([#2373](undefined/undefined/undefined/issues/2373)) 7741ff4, closes #2369
+- update blocks to conform to latest eslint-plugin-package-json standards ([#2377](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2377)) 266a405, closes #2374
 
-## [2.60.1](///compare/2.60.0...2.60.1) (2026-02-17)
+## [2.60.2](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.60.1...2.60.2) (2026-05-04)
 
 ### Bug Fixes
 
-- generalize DEVELOPMENT.md lint files description ([#2367](undefined/undefined/undefined/issues/2367)) a350a93, closes #2366
+- bump bingo to ^0.9.3 ([#2373](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2373)) 7741ff4, closes #2369
 
-## [2.60.0](///compare/2.59.0...2.60.0) (2026-01-14)
+## [2.60.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.60.0...2.60.1) (2026-02-17)
+
+### Bug Fixes
+
+- generalize DEVELOPMENT.md lint files description ([#2367](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2367)) a350a93, closes #2366
+
+## [2.60.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.59.0...2.60.0) (2026-01-14)
 
 ### Features
 
-- switched ESLint config from JS to TS ([#2351](undefined/undefined/undefined/issues/2351)) 98fca73, closes #000
+- switched ESLint config from JS to TS ([#2351](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2351)) 98fca73, closes #000
 
-## [2.59.0](///compare/2.58.1...2.59.0) (2026-01-02)
+## [2.59.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.58.1...2.59.0) (2026-01-02)
 
 ### Features
 
-- add globalIgnores helper to eslint ([#2324](undefined/undefined/undefined/issues/2324)) 884be05, closes #2321
-- enable trusted publishing for release-it ([#2337](undefined/undefined/undefined/issues/2337)) 6f90b26, closes #2270
+- add globalIgnores helper to eslint ([#2324](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2324)) 884be05, closes #2321
+- enable trusted publishing for release-it ([#2337](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2337)) 6f90b26, closes #2270
 
 ### Bug Fixes
 
-- bump release-it-action to 0.4.0 ([#2339](undefined/undefined/undefined/issues/2339)) 5febaab, closes #2270
-- don't mention `main` in bug or tooling issue templates ([#2326](undefined/undefined/undefined/issues/2326)) 326d9c5, closes #2325
+- bump release-it-action to 0.4.0 ([#2339](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2339)) 5febaab, closes #2270
+- don't mention `main` in bug or tooling issue templates ([#2326](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2326)) 326d9c5, closes #2325
 
-## [2.58.1](///compare/2.58.0...2.58.1) (2025-12-09)
+## [2.58.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.58.0...2.58.1) (2025-12-09)
 
 ### Bug Fixes
 
 - bingo@0.9.2 f3eff84
 
-## [2.58.0](///compare/2.57.2...2.58.0) (2025-12-08)
+## [2.58.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.57.2...2.58.0) (2025-12-08)
 
 ### Features
 
-- brought in Bingo's 0.9 `--remote` flag ([#2315](undefined/undefined/undefined/issues/2315)) f6ba94a, closes #2314
+- brought in Bingo's 0.9 `--remote` flag ([#2315](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2315)) f6ba94a, closes #2314
 
-## [2.57.2](///compare/2.57.1...2.57.2) (2025-12-08)
-
-### Bug Fixes
-
-- upgrade trash from 10.0.0 to 10.0.1 ([#2313](undefined/undefined/undefined/issues/2313)) fcdd75e, closes #2304
-
-## [2.57.1](///compare/2.57.0...2.57.1) (2025-12-08)
+## [2.57.2](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.57.1...2.57.2) (2025-12-08)
 
 ### Bug Fixes
 
-- prefer gh user over package.json author for owner option ([#2312](undefined/undefined/undefined/issues/2312)) a53f3bf, closes #2311
+- upgrade trash from 10.0.0 to 10.0.1 ([#2313](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2313)) fcdd75e, closes #2304
 
-## [2.57.0](///compare/2.56.3...2.57.0) (2025-12-05)
+## [2.57.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.57.0...2.57.1) (2025-12-08)
+
+### Bug Fixes
+
+- prefer gh user over package.json author for owner option ([#2312](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2312)) a53f3bf, closes #2311
+
+## [2.57.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.56.3...2.57.0) (2025-12-05)
 
 ### Features
 
-- switch YAML extension preference from .yml to .yaml ([#2310](undefined/undefined/undefined/issues/2310)) 6ea8011, closes #2309
+- switch YAML extension preference from .yml to .yaml ([#2310](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2310)) 6ea8011, closes #2309
 
-## [2.56.3](///compare/2.56.2...2.56.3) (2025-12-04)
+## [2.56.3](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.56.2...2.56.3) (2025-12-04)
 
 ### Bug Fixes
 
 - bingo@0.8.2 7ccbaef
 
-## [2.56.2](///compare/2.56.1...2.56.2) (2025-12-04)
+## [2.56.2](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.56.1...2.56.2) (2025-12-04)
 
 ### Bug Fixes
 
-- issues with Vitest 4 ([#2307](undefined/undefined/undefined/issues/2307)) f693847, closes #2305
+- issues with Vitest 4 ([#2307](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2307)) f693847, closes #2305
 
-## [2.56.1](///compare/2.56.0...2.56.1) (2025-12-03)
-
-### Bug Fixes
-
-- correct main-branch phrasing in issue templates ([#2301](undefined/undefined/undefined/issues/2301)) 341c2d0, closes #2217
-
-## [2.56.0](///compare/2.55.0...2.56.0) (2025-12-03)
-
-### Features
-
-- enable Knip's treatConfigHintsAsErrors ([#2300](undefined/undefined/undefined/issues/2300)) 3934596, closes #2213
-
-## [2.55.0](///compare/2.54.0...2.55.0) (2025-12-03)
-
-### Features
-
-- remove ts-prune config files in blockKnip ([#2299](undefined/undefined/undefined/issues/2299)) 0bfe033, closes #2126
-
-## [2.54.0](///compare/2.53.0...2.54.0) (2025-12-03)
-
-### Features
-
-- remove Markdownlint ([#2298](undefined/undefined/undefined/issues/2298)) 1dd9763, closes #1926
-
-## [2.53.0](///compare/2.52.1...2.53.0) (2025-12-03)
-
-### Features
-
-- switch from deprecated `eslint-plugin-markdown` to `@eslint/markdown` ([#2297](undefined/undefined/undefined/issues/2297)) eef0d97, closes #2273 #1926
-
-## [2.52.1](///compare/2.52.0...2.52.1) (2025-12-02)
+## [2.56.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.56.0...2.56.1) (2025-12-03)
 
 ### Bug Fixes
 
-- bump eslint-plugin-package-json to 0.85.0 ([#2294](undefined/undefined/undefined/issues/2294)) 93d5171, closes #2271 #2288
+- correct main-branch phrasing in issue templates ([#2301](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2301)) 341c2d0, closes #2217
 
-## [2.52.0](///compare/2.51.0...2.52.0) (2025-12-02)
-
-### Features
-
-- move all ESLint configuration into files-based blocks ([#2291](undefined/undefined/undefined/issues/2291)) 9e97d56, closes #2275
-
-## [2.51.0](///compare/2.50.0...2.51.0) (2025-12-02)
+## [2.56.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.55.0...2.56.0) (2025-12-03)
 
 ### Features
 
-- bumped most packages to latest as of Dec 2nd, 2025 ([#2288](undefined/undefined/undefined/issues/2288)) 0074af5, closes #2287 #2275
+- enable Knip's treatConfigHintsAsErrors ([#2300](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2300)) 3934596, closes #2213
+
+## [2.55.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.54.0...2.55.0) (2025-12-03)
+
+### Features
+
+- remove ts-prune config files in blockKnip ([#2299](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2299)) 0bfe033, closes #2126
+
+## [2.54.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.53.0...2.54.0) (2025-12-03)
+
+### Features
+
+- remove Markdownlint ([#2298](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2298)) 1dd9763, closes #1926
+
+## [2.53.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.52.1...2.53.0) (2025-12-03)
+
+### Features
+
+- switch from deprecated `eslint-plugin-markdown` to `@eslint/markdown` ([#2297](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2297)) eef0d97, closes #2273 #1926
+
+## [2.52.1](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.52.0...2.52.1) (2025-12-02)
+
+### Bug Fixes
+
+- bump eslint-plugin-package-json to 0.85.0 ([#2294](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2294)) 93d5171, closes #2271 #2288
+
+## [2.52.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.51.0...2.52.0) (2025-12-02)
+
+### Features
+
+- move all ESLint configuration into files-based blocks ([#2291](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2291)) 9e97d56, closes #2275
+
+## [2.51.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.50.0...2.51.0) (2025-12-02)
+
+### Features
+
+- bumped most packages to latest as of Dec 2nd, 2025 ([#2288](https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2288)) 0074af5, closes #2287 #2275
 
 ## [2.50.0](https://github.com/JoshuaKGoldberg/create-typescript-app/compare/2.49.0...2.50.0) (2025-12-02)
 

--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -19,6 +19,7 @@ This table summarizes each block and which base levels they're included in:
 | ESLint JSDoc Plugin                | `--add-eslint-jsdoc-plugin`, `--exclude-eslint-jsdoc-plugin`                               |         |        | 💯         |
 | ESLint JSONC Plugin                | `--add-eslint-jsonc-plugin`, `--exclude-eslint-jsonc-plugin`                               |         |        | 💯         |
 | ESLint Markdown Plugin             | `--add-eslint-markdown-plugin`, `--exclude-eslint-markdown-plugin`                         |         |        | 💯         |
+| ESLint Markdown Links Plugin       | `--add-eslint-markdown-links-plugin`, `--exclude-eslint-markdown-links-plugin`             |         |        | 💯         |
 | ESLint More Styling                | `--add-eslint-more-styling`, `--exclude-eslint-more-styling`                               |         |        | 💯         |
 | ESLint Node Plugin                 | `--add-eslint-node-plugin`, `--exclude-eslint-node-plugin`                                 |         |        | 💯         |
 | ESLint package.json Plugin         | `--add-eslint-package-json-plugin`, `--exclude-eslint-package-json-plugin`                 |         |        | 💯         |

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -14,6 +14,7 @@ import markdown from "@eslint/markdown";
 import vitest from "@vitest/eslint-plugin";
 import jsdoc from "eslint-plugin-jsdoc";
 import jsonc from "eslint-plugin-jsonc";
+import markdownLinks from "eslint-plugin-markdown-links";
 import n from "eslint-plugin-n";
 import packageJson from "eslint-plugin-package-json";
 import perfectionist from "eslint-plugin-perfectionist";
@@ -81,7 +82,7 @@ export default defineConfig(
 		files: ["**/*.json"],
 	},
 	{
-		extends: [markdown.configs.recommended],
+		extends: [markdown.configs.recommended, markdownLinks.configs.recommended],
 		files: ["**/*.md"],
 		rules: {
 			// https://github.com/eslint/markdown/issues/294

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"eslint": "10.8.1",
 		"eslint-plugin-jsdoc": "64.2.1",
 		"eslint-plugin-jsonc": "3.4.1",
+		"eslint-plugin-markdown-links": "0.9.1",
 		"eslint-plugin-n": "18.3.0",
 		"eslint-plugin-package-json": "1.7.1",
 		"eslint-plugin-perfectionist": "5.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       eslint-plugin-jsonc:
         specifier: 3.4.1
         version: 3.4.1(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
+      eslint-plugin-markdown-links:
+        specifier: 0.9.1
+        version: 0.9.1(@eslint/markdown@8.0.3(supports-color@7.2.0))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
       eslint-plugin-n:
         specifier: 18.3.0
         version: 18.3.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(typescript@5.9.3)
@@ -801,6 +804,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mdit-vue/shared@3.0.2':
+    resolution: {integrity: sha512-anFGls154h0iVzUt5O43EaqYvPwzfUxQ34QpNQsUQML7pbEJMhcgkRNvYw9hZBspab+/TP45agdPw5joh6/BBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@mdit-vue/types@3.0.2':
+    resolution: {integrity: sha512-00aAZ0F0NLik6I6Yba2emGbHLxv+QYrPH00qQ5dFKXlAo1Ll2RHDXwY7nN2WAfrx2pP+WrvSRFTGFCNGdzBDHw==}
+    engines: {node: '>=20.0.0'}
+
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
@@ -1408,11 +1419,20 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -2265,6 +2285,10 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@4.0.0:
     resolution: {integrity: sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw==}
     engines: {node: '>=20'}
@@ -2333,6 +2357,13 @@ packages:
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     peerDependencies:
       eslint: '>=9.38.0'
+
+  eslint-plugin-markdown-links@0.9.1:
+    resolution: {integrity: sha512-dDVhweFe44HOf6inWAfQe59pqVsRvyTAFw3MtN/CYz0YJ8s5/jj/4u6dQTdZSEY/mNkVZCSw3/70/kFD+PSPZQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@eslint/markdown': ^7.1.0 || ^8.0.0
+      eslint: '>=9.0.0'
 
   eslint-plugin-n@18.3.0:
     resolution: {integrity: sha512-cPVguuDe6DrIPb/qUXHf8P89MaVTUmiYWwpt5gX5AILsvRIiZAxMFXcFR6QHYBksqKJpjfUBlL/RleCJUWcD7w==}
@@ -2451,6 +2482,9 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2986,6 +3020,9 @@ packages:
     resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   lint-staged@17.3.0:
     resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
@@ -3052,6 +3089,10 @@ packages:
   make-synchronized@0.8.0:
     resolution: {integrity: sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==}
 
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -3098,6 +3139,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
@@ -3595,6 +3639,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3735,6 +3783,10 @@ packages:
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
+
+  sdbm@3.0.0:
+    resolution: {integrity: sha512-9FHNk9qJKuRxkUeQQdRp8WLCFaL4hvPtYz/2xNAOkuZzQ3ZqMMkZ1CrkKPDA4lxbenMml0JRKHGyTyucK/JBBg==}
+    engines: {node: '>=20'}
 
   selderee@0.12.0:
     resolution: {integrity: sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==}
@@ -4046,6 +4098,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   unbash@4.0.10:
     resolution: {integrity: sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==}
@@ -4921,6 +4976,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdit-vue/shared@3.0.2':
+    dependencies:
+      '@mdit-vue/types': 3.0.2
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+
+  '@mdit-vue/types@3.0.2': {}
+
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -5393,11 +5456,20 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
   '@types/lodash@4.17.25': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
 
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -6304,6 +6376,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  entities@8.0.0: {}
+
   env-paths@4.0.0:
     dependencies:
       is-safe-filename: 0.1.1
@@ -6382,6 +6456,18 @@ snapshots:
       synckit: 0.11.13
     transitivePeerDependencies:
       - '@eslint/json'
+
+  eslint-plugin-markdown-links@0.9.1(@eslint/markdown@8.0.3(supports-color@7.2.0))(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0)):
+    dependencies:
+      '@eslint/markdown': 8.0.3(supports-color@7.2.0)
+      '@mdit-vue/shared': 3.0.2
+      entities: 8.0.0
+      eslint: 10.8.1(jiti@2.7.0)(supports-color@7.2.0)
+      fast-content-type-parse: 3.0.0
+      github-slugger: 2.0.0
+      sdbm: 3.0.0
+      synckit: 0.11.13
+      undici: 7.29.0
 
   eslint-plugin-n@18.3.0(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(typescript@5.9.3):
     dependencies:
@@ -6569,6 +6655,8 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -7051,6 +7139,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.33.0
       lightningcss-win32-x64-msvc: 1.33.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   lint-staged@17.3.0:
     dependencies:
       picomatch: 4.0.5
@@ -7109,6 +7201,15 @@ snapshots:
       semver: 7.8.5
 
   make-synchronized@0.8.0: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -7238,6 +7339,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdurl@2.1.0: {}
 
   meow@14.1.0: {}
 
@@ -7874,6 +7977,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   quansync@1.0.0: {}
@@ -8033,6 +8138,8 @@ snapshots:
       '@eslint-community/regexpp': 4.12.2
       refa: 0.12.1
       regexp-ast-analysis: 0.7.1
+
+  sdbm@3.0.0: {}
 
   selderee@0.12.0:
     dependencies:
@@ -8305,6 +8412,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   unbash@4.0.10: {}
 

--- a/src/blocks/blockESLintMarkdownLinks.ts
+++ b/src/blocks/blockESLintMarkdownLinks.ts
@@ -1,0 +1,28 @@
+import { base } from "../base.js";
+import { blockESLint } from "./blockESLint.js";
+
+export const blockESLintMarkdownLinks = base.createBlock({
+	about: {
+		name: "ESLint Markdown Links Plugin",
+	},
+	produce() {
+		return {
+			addons: [
+				blockESLint({
+					extensions: [
+						{
+							extends: ["markdownLinks.configs.recommended"],
+							files: ["**/*.md"],
+						},
+					],
+					imports: [
+						{
+							source: "eslint-plugin-markdown-links",
+							specifier: "markdownLinks",
+						},
+					],
+				}),
+			],
+		};
+	},
+});

--- a/src/blocks/index.ts
+++ b/src/blocks/index.ts
@@ -10,6 +10,7 @@ import { blockESLintComments } from "./blockESLintComments.js";
 import { blockESLintJSDoc } from "./blockESLintJSDoc.js";
 import { blockESLintJSONC } from "./blockESLintJSONC.js";
 import { blockESLintMarkdown } from "./blockESLintMarkdown.js";
+import { blockESLintMarkdownLinks } from "./blockESLintMarkdownLinks.js";
 import { blockESLintMoreStyling } from "./blockESLintMoreStyling.js";
 import { blockESLintNode } from "./blockESLintNode.js";
 import { blockESLintPackageJson } from "./blockESLintPackageJson.js";
@@ -61,6 +62,7 @@ export const blocks = {
 	blockESLintJSDoc,
 	blockESLintJSONC,
 	blockESLintMarkdown,
+	blockESLintMarkdownLinks,
 	blockESLintMoreStyling,
 	blockESLintNode,
 	blockESLintPackageJson,
@@ -113,6 +115,7 @@ export { blockESLintComments } from "./blockESLintComments.js";
 export { blockESLintJSDoc } from "./blockESLintJSDoc.js";
 export { blockESLintJSONC } from "./blockESLintJSONC.js";
 export { blockESLintMarkdown } from "./blockESLintMarkdown.js";
+export { blockESLintMarkdownLinks } from "./blockESLintMarkdownLinks.js";
 export { blockESLintMoreStyling } from "./blockESLintMoreStyling.js";
 export { blockESLintNode } from "./blockESLintNode.js";
 export { blockESLintPackageJson } from "./blockESLintPackageJson.js";

--- a/src/presets/everything.ts
+++ b/src/presets/everything.ts
@@ -4,6 +4,7 @@ import { blockESLintComments } from "../blocks/blockESLintComments.js";
 import { blockESLintJSDoc } from "../blocks/blockESLintJSDoc.js";
 import { blockESLintJSONC } from "../blocks/blockESLintJSONC.js";
 import { blockESLintMarkdown } from "../blocks/blockESLintMarkdown.js";
+import { blockESLintMarkdownLinks } from "../blocks/blockESLintMarkdownLinks.js";
 import { blockESLintMoreStyling } from "../blocks/blockESLintMoreStyling.js";
 import { blockESLintNode } from "../blocks/blockESLintNode.js";
 import { blockESLintPackageJson } from "../blocks/blockESLintPackageJson.js";
@@ -35,6 +36,7 @@ export const presetEverything = base.createPreset({
 		blockESLintJSDoc,
 		blockESLintJSONC,
 		blockESLintMarkdown,
+		blockESLintMarkdownLinks,
 		blockESLintMoreStyling,
 		blockESLintNode,
 		blockESLintPackageJson,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #814; fixes #2331
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds `blockESLintMarkdownLinks`, an opt-in block in the Everything preset that extends `markdownLinks.configs.recommended` from [`eslint-plugin-markdown-links`](https://github.com/ota-meshi/eslint-plugin-markdown-links) over `**/*.md`.

```
docs/probe.md
  3:1  error  The file './Migrate.md' does not exist. Please check the path or update it to a valid file  markdown-links/no-missing-path
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎁 