### PR TITLE
feat: add Formatly on Demand block

### DIFF
--- a/.github/workflows/formatly-on-demand-detect.yaml
+++ b/.github/workflows/formatly-on-demand-detect.yaml
@@ -1,0 +1,11 @@
+jobs:
+  detect:
+    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/detect.yaml@v0
+    with:
+      install: corepack enable && pnpm install --frozen-lockfile
+      node-version: 24.19.0
+
+name: Formatly on Demand Detect
+
+on:
+  pull_request: ~

--- a/.github/workflows/formatly-on-demand-format.yaml
+++ b/.github/workflows/formatly-on-demand-format.yaml
@@ -1,0 +1,18 @@
+jobs:
+  format:
+    permissions:
+      issues: write
+      pull-requests: read
+    secrets:
+      push-token: ${{ secrets.FORMATLY_ON_DEMAND_TOKEN }}
+    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/format.yaml@v0
+    with:
+      install: corepack enable && pnpm install --frozen-lockfile
+      node-version: 24.19.0
+
+name: Formatly on Demand Format
+
+on:
+  issue_comment:
+    types:
+      - created

--- a/.github/workflows/formatly-on-demand-offer.yaml
+++ b/.github/workflows/formatly-on-demand-offer.yaml
@@ -1,0 +1,16 @@
+jobs:
+  offer:
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: read
+    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/offer.yaml@v0
+
+name: Formatly on Demand Offer
+
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - Formatly on Demand Detect

--- a/cspell.json
+++ b/cspell.json
@@ -16,6 +16,7 @@
 		"attw",
 		"dbaeumer",
 		"eslint-doc-generatorrc",
+		"formatly",
 		"infile",
 		"joshuakgoldberg",
 		"mshick",

--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -28,6 +28,7 @@ This table summarizes each block and which base levels they're included in:
 | ESLint Regexp Plugin               | `--add-eslint-regexp-plugin`, `--exclude-eslint-regexp-plugin`                             |         |        | 💯         |
 | ESLint YML Plugin                  | `--add-eslint-yml-plugin`, `--exclude-eslint-yml-plugin`                                   |         |        | 💯         |
 | Exports                            | `--add-exports`, `--exclude-exports`                                                       | ✔️      | ✅     | 💯         |
+| Formatly on Demand                 | `--add-formatly-on-demand`, `--exclude-formatly-on-demand`                                 |         |        | 💯         |
 | Funding                            | `--add-funding`, `--exclude-funding`                                                       |         | ✅     | 💯         |
 | GitHub Actions CI                  | `--add-github-actions-ci`, `--exclude-github-actions-ci`                                   | ✔️      | ✅     | 💯         |
 | GitHub Issue Templates             | `--add-github-issue-templates`, `--exclude-github-issue-templates`                         | ✔️      | ✅     | 💯         |
@@ -265,6 +266,7 @@ Using the _"everything"_ level will gain you comprehensive, strict coverage of a
     - [Renovate](#renovate)
     - [Testing](#testing)
   - ["Everything" Base Level](#everything-base-level)
+    - [Formatly on Demand](#formatly-on-demand)
     - [Lint ESLint](#lint-eslint)
     - [Lint JSDoc](#lint-jsdoc)
     - [Lint JSON](#lint-json)
@@ -277,6 +279,12 @@ Using the _"everything"_ level will gain you comprehensive, strict coverage of a
     - [Lint Stylistic](#lint-stylistic)
     - [Lint YML](#lint-yml)
     - [OctoGuide Strict](#octoguide-strict)
+
+### Formatly on Demand
+
+[**formatly-on-demand**](https://github.com/JoshuaKGoldberg/formatly-on-demand): Comments on pull requests whose files aren't formatted, offering to format them.
+It only formats and pushes if the pull request's author or a maintainer asks it to by commenting `/formatly`.
+Pushing to pull requests from forks needs a repository secret containing a GitHub PAT.
 
 ### Lint ESLint
 

--- a/src/blocks/blockFormatlyOnDemand.test.ts
+++ b/src/blocks/blockFormatlyOnDemand.test.ts
@@ -1,0 +1,239 @@
+import { testBlock, testIntake } from "bingo-stratum-testers";
+import { dump } from "js-yaml";
+import { describe, expect, it, test } from "vitest";
+
+import { blockFormatlyOnDemand } from "./blockFormatlyOnDemand.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe(blockFormatlyOnDemand, () => {
+	test("without addons", () => {
+		const creation = testBlock(blockFormatlyOnDemand, {
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "secrets": [
+			          {
+			            "description": "a GitHub PAT with public_repo permissions, so formatting can be pushed to pull requests from forks",
+			            "name": "FORMATLY_ON_DEMAND_TOKEN",
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			  "files": {
+			    ".github": {
+			      "workflows": {
+			        "formatly-on-demand-detect.yaml": "jobs:
+			  detect:
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/detect.yaml@v0
+			    with:
+			      install: corepack enable && pnpm install --frozen-lockfile
+			      node-version: 20.12.0
+
+
+			name: Formatly on Demand Detect
+
+
+			on:
+			  pull_request: ~
+			",
+			        "formatly-on-demand-format.yaml": "jobs:
+			  format:
+			    permissions:
+			      issues: write
+			      pull-requests: read
+			    secrets:
+			      push-token: \${{ secrets.FORMATLY_ON_DEMAND_TOKEN }}
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/format.yaml@v0
+			    with:
+			      install: corepack enable && pnpm install --frozen-lockfile
+			      node-version: 20.12.0
+
+
+			name: Formatly on Demand Format
+
+
+			on:
+			  issue_comment:
+			    types:
+			      - created
+			",
+			        "formatly-on-demand-offer.yaml": "jobs:
+			  offer:
+			    permissions:
+			      actions: read
+			      issues: write
+			      pull-requests: read
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/offer.yaml@v0
+
+
+			name: Formatly on Demand Offer
+
+
+			on:
+			  workflow_run:
+			    types:
+			      - completed
+			    workflows:
+			      - Formatly on Demand Detect
+			",
+			      },
+			    },
+			  },
+			}
+		`);
+	});
+
+	test("with addons", () => {
+		const creation = testBlock(blockFormatlyOnDemand, {
+			addons: {
+				install: "npm ci",
+				pushTokenSecret: "ACCESS_TOKEN",
+			},
+			options: optionsBase,
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "secrets": [
+			          {
+			            "description": "a GitHub PAT with public_repo permissions, so formatting can be pushed to pull requests from forks",
+			            "name": "ACCESS_TOKEN",
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			  "files": {
+			    ".github": {
+			      "workflows": {
+			        "formatly-on-demand-detect.yaml": "jobs:
+			  detect:
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/detect.yaml@v0
+			    with:
+			      install: npm ci
+			      node-version: 20.12.0
+
+
+			name: Formatly on Demand Detect
+
+
+			on:
+			  pull_request: ~
+			",
+			        "formatly-on-demand-format.yaml": "jobs:
+			  format:
+			    permissions:
+			      issues: write
+			      pull-requests: read
+			    secrets:
+			      push-token: \${{ secrets.ACCESS_TOKEN }}
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/format.yaml@v0
+			    with:
+			      install: npm ci
+			      node-version: 20.12.0
+
+
+			name: Formatly on Demand Format
+
+
+			on:
+			  issue_comment:
+			    types:
+			      - created
+			",
+			        "formatly-on-demand-offer.yaml": "jobs:
+			  offer:
+			    permissions:
+			      actions: read
+			      issues: write
+			      pull-requests: read
+			    uses: JoshuaKGoldberg/formatly-on-demand/.github/workflows/offer.yaml@v0
+
+
+			name: Formatly on Demand Offer
+
+
+			on:
+			  workflow_run:
+			    types:
+			      - completed
+			    workflows:
+			      - Formatly on Demand Detect
+			",
+			      },
+			    },
+			  },
+			}
+		`);
+	});
+
+	describe("intake", () => {
+		it("returns undefined when the format workflow does not exist", () => {
+			const actual = testIntake(blockFormatlyOnDemand, {
+				files: {
+					".github": {
+						workflows: {},
+					},
+				},
+			});
+
+			expect(actual).toBeUndefined();
+		});
+
+		it("returns undefined when the format workflow has no format job", () => {
+			const actual = testIntake(blockFormatlyOnDemand, {
+				files: {
+					".github": {
+						workflows: {
+							"formatly-on-demand-format.yaml": [
+								dump({ jobs: { other: { uses: "other/workflow@1" } } }),
+							],
+						},
+					},
+				},
+			});
+
+			expect(actual).toBeUndefined();
+		});
+
+		it("returns the install command and push token secret when the format workflow has them", () => {
+			const actual = testIntake(blockFormatlyOnDemand, {
+				files: {
+					".github": {
+						workflows: {
+							"formatly-on-demand-format.yaml": [
+								dump({
+									jobs: {
+										format: {
+											secrets: {
+												"push-token": "${{ secrets.ACCESS_TOKEN }}",
+											},
+											uses: "JoshuaKGoldberg/formatly-on-demand/.github/workflows/format.yaml@v0",
+											with: { install: "npm ci" },
+										},
+									},
+								}),
+							],
+						},
+					},
+				},
+			});
+
+			expect(actual).toEqual({
+				install: "npm ci",
+				pushTokenSecret: "ACCESS_TOKEN",
+			});
+		});
+	});
+});

--- a/src/blocks/blockFormatlyOnDemand.ts
+++ b/src/blocks/blockFormatlyOnDemand.ts
@@ -1,0 +1,127 @@
+import { z } from "zod";
+
+import { base } from "../base.js";
+import { resolveUses } from "./actions/resolveUses.js";
+import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
+import { createCallerWorkflowFile } from "./files/createCallerWorkflowFile.js";
+import { intakeFileAsYaml } from "./intake/intakeFileAsYaml.js";
+
+interface FormatWorkflowYaml {
+	jobs?: {
+		format?: {
+			secrets?: Record<string, string>;
+			with?: Record<string, string>;
+		};
+	};
+}
+
+const detectWorkflowName = "Formatly on Demand Detect";
+
+const version = "v0";
+
+const workflowsRepository = "JoshuaKGoldberg/formatly-on-demand";
+
+export const blockFormatlyOnDemand = base.createBlock({
+	about: {
+		name: "Formatly on Demand",
+	},
+	addons: {
+		install: z.string().optional(),
+		pushTokenSecret: z.string().optional(),
+	},
+	intake({ files }) {
+		const workflow = intakeFileAsYaml(files, [
+			".github",
+			"workflows",
+			"formatly-on-demand-format.yaml",
+		]) as FormatWorkflowYaml | undefined;
+
+		const job = workflow?.jobs?.format;
+
+		if (!job) {
+			return undefined;
+		}
+
+		return {
+			install: job.with?.install,
+			pushTokenSecret: /secrets\.(\w+)/.exec(
+				job.secrets?.["push-token"] ?? "",
+			)?.[1],
+		};
+	},
+	produce({ addons, options }) {
+		const {
+			install = "corepack enable && pnpm install --frozen-lockfile",
+			pushTokenSecret = "FORMATLY_ON_DEMAND_TOKEN",
+		} = addons;
+
+		const inputs = {
+			install,
+			"node-version": options.node.pinned ?? options.node.minimum,
+		};
+
+		const workflowUses = (workflow: string) =>
+			resolveUses(
+				`${workflowsRepository}/.github/workflows/${workflow}.yaml`,
+				version,
+				options.workflowsVersions,
+			);
+
+		return {
+			addons: [
+				blockRepositorySecrets({
+					secrets: [
+						{
+							description:
+								"a GitHub PAT with public_repo permissions, so formatting can be pushed to pull requests from forks",
+							name: pushTokenSecret,
+						},
+					],
+				}),
+			],
+			files: {
+				".github": {
+					workflows: {
+						"formatly-on-demand-detect.yaml": createCallerWorkflowFile({
+							jobName: "detect",
+							name: detectWorkflowName,
+							on: { pull_request: null },
+							uses: workflowUses("detect"),
+							with: inputs,
+						}),
+						"formatly-on-demand-format.yaml": createCallerWorkflowFile({
+							jobName: "format",
+							name: "Formatly on Demand Format",
+							on: { issue_comment: { types: ["created"] } },
+							permissions: {
+								issues: "write",
+								"pull-requests": "read",
+							},
+							secrets: {
+								"push-token": `\${{ secrets.${pushTokenSecret} }}`,
+							},
+							uses: workflowUses("format"),
+							with: inputs,
+						}),
+						"formatly-on-demand-offer.yaml": createCallerWorkflowFile({
+							jobName: "offer",
+							name: "Formatly on Demand Offer",
+							on: {
+								workflow_run: {
+									types: ["completed"],
+									workflows: [detectWorkflowName],
+								},
+							},
+							permissions: {
+								actions: "read",
+								issues: "write",
+								"pull-requests": "read",
+							},
+							uses: workflowUses("offer"),
+						}),
+					},
+				},
+			},
+		};
+	},
+});

--- a/src/blocks/files/createCallerWorkflowFile.ts
+++ b/src/blocks/files/createCallerWorkflowFile.ts
@@ -1,0 +1,55 @@
+import { createJobName } from "./createJobName.js";
+import { formatWorkflowYaml } from "./formatWorkflowYaml.js";
+
+interface CallerWorkflowFileOn {
+	issue_comment?: {
+		types: string[];
+	};
+	pull_request?: null | {
+		types?: string[];
+	};
+	workflow_run?: {
+		types: string[];
+		workflows: string[];
+	};
+}
+
+interface CallerWorkflowFileOptions {
+	jobName: string;
+	name: string;
+	on: CallerWorkflowFileOn;
+	permissions?: CallerWorkflowFilePermissions;
+	secrets?: Record<string, string>;
+	uses: string;
+	with?: Record<string, string>;
+}
+
+interface CallerWorkflowFilePermissions {
+	actions?: string;
+	contents?: string;
+	issues?: string;
+	"pull-requests"?: string;
+}
+
+export function createCallerWorkflowFile({
+	jobName,
+	name,
+	on,
+	permissions,
+	secrets,
+	uses,
+	with: withValues,
+}: CallerWorkflowFileOptions) {
+	return formatWorkflowYaml({
+		jobs: {
+			[createJobName(jobName)]: {
+				permissions,
+				secrets,
+				uses,
+				with: withValues,
+			},
+		},
+		name,
+		on,
+	});
+}

--- a/src/blocks/index.ts
+++ b/src/blocks/index.ts
@@ -19,6 +19,7 @@ import { blockESLintPlugin } from "./blockESLintPlugin.js";
 import { blockESLintRegexp } from "./blockESLintRegexp.js";
 import { blockESLintYML } from "./blockESLintYML.js";
 import { blockExports } from "./blockExports.js";
+import { blockFormatlyOnDemand } from "./blockFormatlyOnDemand.js";
 import { blockFunding } from "./blockFunding.js";
 import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockGitHubIssueTemplates } from "./blockGitHubIssueTemplates.js";
@@ -71,6 +72,7 @@ export const blocks = {
 	blockESLintRegexp,
 	blockESLintYML,
 	blockExports,
+	blockFormatlyOnDemand,
 	blockFunding,
 	blockGitHubActionsCI,
 	blockGitHubIssueTemplates,
@@ -124,6 +126,7 @@ export { blockESLintPlugin } from "./blockESLintPlugin.js";
 export { blockESLintRegexp } from "./blockESLintRegexp.js";
 export { blockESLintYML } from "./blockESLintYML.js";
 export { blockExports } from "./blockExports.js";
+export { blockFormatlyOnDemand } from "./blockFormatlyOnDemand.js";
 export { blockFunding } from "./blockFunding.js";
 export { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 export { blockGitHubIssueTemplates } from "./blockGitHubIssueTemplates.js";

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -60,6 +60,7 @@ test("Producing the everything preset matches the files in this repository", asy
 						"apexskier",
 						"attw",
 						"dbaeumer",
+						"formatly",
 						"infile",
 						"joshuakgoldberg",
 						"mshick",

--- a/src/presets/everything.ts
+++ b/src/presets/everything.ts
@@ -11,6 +11,7 @@ import { blockESLintPackageJson } from "../blocks/blockESLintPackageJson.js";
 import { blockESLintPerfectionist } from "../blocks/blockESLintPerfectionist.js";
 import { blockESLintRegexp } from "../blocks/blockESLintRegexp.js";
 import { blockESLintYML } from "../blocks/blockESLintYML.js";
+import { blockFormatlyOnDemand } from "../blocks/blockFormatlyOnDemand.js";
 import { blockKnip } from "../blocks/blockKnip.js";
 import { blockNvmrc } from "../blocks/blockNvmrc.js";
 import { blockOctoGuideStrict } from "../blocks/blockOctoGuideStrict.js";
@@ -43,6 +44,7 @@ export const presetEverything = base.createPreset({
 		blockESLintPerfectionist,
 		blockESLintRegexp,
 		blockESLintYML,
+		blockFormatlyOnDemand,
 		blockKnip,
 		blockNvmrc,
 		blockPnpmDedupe,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #139
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `blockFormatlyOnDemand` block templating the three caller workflows for [formatly-on-demand](https://github.com/JoshuaKGoldberg/formatly-on-demand), a bot that formats a pull request and pushes one commit after the author or a maintainer comments `/formatly`.
Included in the _everything_ preset and in this repository.

Draft because a few decisions are yours, and `formatly-on-demand` hasn't had its first release reviewed by anyone but me:

1. **Preset.** _Everything_ since it wants a PAT secret, but _common_ is arguable.
2. **The `install` input.** Templated as `corepack enable && pnpm install --frozen-lockfile`; `formatly-on-demand` could grow a `package-manager` input instead.
3. **The PAT.** A new `FORMATLY_ON_DEMAND_TOKEN` secret rather than reusing `ACCESS_TOKEN`, since fork pull requests need one to push to. Happy to switch.
4. **Version pinning.** Referenced at `@v0` so `workflowsVersions` intake can pin by hash later.

Merging turns the bot on here once `FORMATLY_ON_DEMAND_TOKEN` exists; say the word if you'd rather leave this repo out for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)