### PR TITLE
fix: infer full emoji grapheme clusters for the emoji option

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,7 +18,6 @@
 		"eslint-doc-generatorrc",
 		"infile",
 		"joshuakgoldberg",
-		"keycap",
 		"mshick",
 		"octoguide",
 		"stefanzweifel",

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
 		"eslint-doc-generatorrc",
 		"infile",
 		"joshuakgoldberg",
+		"keycap",
 		"mshick",
 		"octoguide",
 		"stefanzweifel",

--- a/src/options/readEmoji.test.ts
+++ b/src/options/readEmoji.test.ts
@@ -59,7 +59,7 @@ describe(readEmoji, () => {
 		expect(actual).toBe("👍🏽");
 	});
 
-	it("resolves with the full emoji when the description has a keycap sequence", async () => {
+	it("resolves with the full emoji when the description has a key cap sequence", async () => {
 		const getDescription = () => Promise.resolve("Hello. 1️⃣");
 
 		const actual = await readEmoji(getDescription);

--- a/src/options/readEmoji.test.ts
+++ b/src/options/readEmoji.test.ts
@@ -34,4 +34,44 @@ describe(readEmoji, () => {
 
 		expect(actual).toBe("😊");
 	});
+
+	it("resolves with the full emoji when the description has an emoji with a variation selector", async () => {
+		const getDescription = () => Promise.resolve("Informative docs. ℹ️");
+
+		const actual = await readEmoji(getDescription);
+
+		expect(actual).toBe("ℹ️");
+	});
+
+	it("resolves with the full emoji when the description has a zero width joiner sequence", async () => {
+		const getDescription = () => Promise.resolve("Hello. 👩‍💻");
+
+		const actual = await readEmoji(getDescription);
+
+		expect(actual).toBe("👩‍💻");
+	});
+
+	it("resolves with the full emoji when the description has a skin tone modifier", async () => {
+		const getDescription = () => Promise.resolve("Hello. 👍🏽");
+
+		const actual = await readEmoji(getDescription);
+
+		expect(actual).toBe("👍🏽");
+	});
+
+	it("resolves with the full emoji when the description has a keycap sequence", async () => {
+		const getDescription = () => Promise.resolve("Hello. 1️⃣");
+
+		const actual = await readEmoji(getDescription);
+
+		expect(actual).toBe("1️⃣");
+	});
+
+	it("resolves with the full emoji when the description has a flag", async () => {
+		const getDescription = () => Promise.resolve("Hello. 🇺🇸");
+
+		const actual = await readEmoji(getDescription);
+
+		expect(actual).toBe("🇺🇸");
+	});
 });

--- a/src/options/readEmoji.ts
+++ b/src/options/readEmoji.ts
@@ -1,8 +1,22 @@
+const graphemeSegmenter = new Intl.Segmenter(undefined, {
+	granularity: "grapheme",
+});
+
+const pictographicPattern = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u;
+const keycapPattern = /\p{Emoji}\uFE0F?\u20E3/u;
+
 export async function readEmoji(
 	getDescription: () => Promise<string | undefined>,
 ) {
+	const description = await getDescription();
+
 	return (
-		(await getDescription())?.match(/\p{Extended_Pictographic}/gu)?.at(-1) ??
-		"💖"
+		Array.from(
+			graphemeSegmenter.segment(description ?? ""),
+			({ segment }) => segment,
+		).findLast(
+			(grapheme) =>
+				pictographicPattern.test(grapheme) || keycapPattern.test(grapheme),
+		) ?? "💖"
 	);
 }

--- a/src/options/readEmoji.ts
+++ b/src/options/readEmoji.ts
@@ -3,7 +3,7 @@ const graphemeSegmenter = new Intl.Segmenter(undefined, {
 });
 
 const pictographicPattern = /\p{Extended_Pictographic}|\p{Regional_Indicator}/u;
-const keycapPattern = /\p{Emoji}\uFE0F?\u20E3/u;
+const keyCapPattern = /\p{Emoji}\uFE0F?\u20E3/u;
 
 export async function readEmoji(
 	getDescription: () => Promise<string | undefined>,
@@ -16,7 +16,7 @@ export async function readEmoji(
 			({ segment }) => segment,
 		).findLast(
 			(grapheme) =>
-				pictographicPattern.test(grapheme) || keycapPattern.test(grapheme),
+				pictographicPattern.test(grapheme) || keyCapPattern.test(grapheme),
 		) ?? "💖"
 	);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2013
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`readEmoji` matched `/\p{Extended_Pictographic}/gu` against the description and took the last match.
That regex matches a single code point, so multi-code-point emoji were truncated to their first code point: `ℹ️` (`U+2139 U+FE0F`) came back as `ℹ` (`U+2139`), and the same would happen to ZWJ sequences, skin tone modifiers, keycaps, and flags.

Now the description is split into grapheme clusters with `Intl.Segmenter`, and the last cluster that looks like an emoji is returned whole. A cluster counts as an emoji if it contains an `Extended_Pictographic` or `Regional_Indicator` code point, or if it's a keycap sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎁
