### PR TITLE
feat: recommend the Knip VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode",
 		"streetsidesoftware.code-spell-checker",
-		"vitest.explorer"
+		"vitest.explorer",
+		"webpro.vscode-knip"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
 		"mshick",
 		"octoguide",
 		"stefanzweifel",
-		"ts-prunerc"
+		"ts-prunerc",
+		"webpro"
 	]
 }

--- a/src/blocks/blockKnip.test.ts
+++ b/src/blocks/blockKnip.test.ts
@@ -67,6 +67,14 @@ describe(blockKnip, () => {
 			      },
 			      "block": [Function],
 			    },
+			    {
+			      "addons": {
+			        "extensions": [
+			          "webpro.vscode-knip",
+			        ],
+			      },
+			      "block": [Function],
+			    },
 			  ],
 			  "files": {
 			    "knip.config.ts": "import type { KnipConfig } from "knip";
@@ -140,6 +148,14 @@ describe(blockKnip, () => {
 			      },
 			      "block": [Function],
 			    },
+			    {
+			      "addons": {
+			        "extensions": [
+			          "webpro.vscode-knip",
+			        ],
+			      },
+			      "block": [Function],
+			    },
 			  ],
 			  "files": {
 			    "knip.config.ts": "import type { KnipConfig } from "knip";
@@ -205,6 +221,14 @@ describe(blockKnip, () => {
 			      "addons": {
 			        "files": [
 			          ".ts-prunerc*",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "extensions": [
+			          "webpro.vscode-knip",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockKnip.ts
+++ b/src/blocks/blockKnip.ts
@@ -8,6 +8,7 @@ import { blockGitHubActionsCI } from "./blockGitHubActionsCI.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRemoveWorkflows } from "./blockRemoveWorkflows.js";
+import { blockVSCode } from "./blockVSCode.js";
 import { intakeFileAsJson } from "./intake/intakeFileAsJson.js";
 import { intakeFileExportObject } from "./intake/intakeFileExportObject.js";
 
@@ -70,6 +71,9 @@ export const blockKnip = base.createBlock({
 				}),
 				blockRemoveFiles({
 					files: [".ts-prunerc*"],
+				}),
+				blockVSCode({
+					extensions: ["webpro.vscode-knip"],
 				}),
 			],
 			files: {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -66,6 +66,7 @@ test("Producing the everything preset matches the files in this repository", asy
 						"octoguide",
 						"stefanzweifel",
 						"ts-prunerc",
+						"webpro",
 					],
 				}),
 				blockESLint({


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2335
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `blockVSCode` addon to `blockKnip` that contributes `webpro.vscode-knip` to `.vscode/extensions.json`, following the same pattern `blockESLint` and `blockPrettier` use for their editor extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎁