### PR TITLE
fix: remove stale .yml files in transition mode

### DIFF
--- a/src/blocks/blockAllContributors.test.ts
+++ b/src/blocks/blockAllContributors.test.ts
@@ -2,6 +2,7 @@ import { testBlock } from "bingo-stratum-testers";
 import { describe, expect, it } from "vitest";
 
 import { blockAllContributors } from "./blockAllContributors.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { optionsBase } from "./options.fakes.js";
 
 describe("blockAllContributors", () => {
@@ -393,5 +394,16 @@ describe("blockAllContributors", () => {
 			  ],
 			}
 		`);
+	});
+
+	it("removes the previous .yml workflow file when in transition mode", () => {
+		const creation = testBlock(blockAllContributors, {
+			mode: "transition",
+			options: optionsBase,
+		});
+
+		expect(creation.addons).toContainEqual(
+			blockRemoveFiles({ files: [".github/workflows/contributors.yml"] }),
+		);
 	});
 });

--- a/src/blocks/blockAllContributors.ts
+++ b/src/blocks/blockAllContributors.ts
@@ -6,6 +6,7 @@ import { Contributor } from "../schemas.js";
 import { resolveUses } from "./actions/resolveUses.js";
 import { blockPrettier } from "./blockPrettier.js";
 import { blockREADME } from "./blockREADME.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
 import { CommandPhase } from "./phases.js";
@@ -120,6 +121,15 @@ export const blockAllContributors = base.createBlock({
 					],
 					phase: CommandPhase.Process,
 				},
+			],
+		};
+	},
+	transition() {
+		return {
+			addons: [
+				blockRemoveFiles({
+					files: [".github/workflows/contributors.yml"],
+				}),
 			],
 		};
 	},

--- a/src/blocks/blockCTATransitions.test.ts
+++ b/src/blocks/blockCTATransitions.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { packageData } from "../data/packageData.js";
 import { blockCTATransitions } from "./blockCTATransitions.js";
 import { blockPackageJson } from "./blockPackageJson.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { optionsBase } from "./options.fakes.js";
 
@@ -117,5 +118,21 @@ describe("blockCTATransitions", () => {
 			  },
 			}
 		`);
+	});
+
+	test("transition mode", () => {
+		const creation = testBlock(blockCTATransitions, {
+			mode: "transition",
+			options: optionsBase,
+		});
+
+		expect(creation.addons).toContainEqual(
+			blockRemoveFiles({
+				files: [
+					".github/actions/transition/action.yml",
+					".github/workflows/cta.yml",
+				],
+			}),
+		);
 	});
 });

--- a/src/blocks/blockCTATransitions.ts
+++ b/src/blocks/blockCTATransitions.ts
@@ -2,6 +2,7 @@ import { base } from "../base.js";
 import { packageData } from "../data/packageData.js";
 import { resolveUses } from "./actions/resolveUses.js";
 import { blockPackageJson } from "./blockPackageJson.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositoryBranchRuleset } from "./blockRepositoryBranchRuleset.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
 import { formatYaml } from "./files/formatYaml.js";
@@ -161,6 +162,18 @@ export const blockCTATransitions = base.createBlock({
 					},
 				},
 			},
+		};
+	},
+	transition() {
+		return {
+			addons: [
+				blockRemoveFiles({
+					files: [
+						".github/actions/transition/action.yml",
+						".github/workflows/cta.yml",
+					],
+				}),
+			],
 		};
 	},
 });

--- a/src/blocks/blockCodecov.test.ts
+++ b/src/blocks/blockCodecov.test.ts
@@ -60,54 +60,54 @@ describe(blockCodecov, () => {
 		});
 
 		expect(creation).toMatchInlineSnapshot(`
-				{
-				  "addons": [
-				    {
-				      "addons": {
-				        "apps": [
-				          {
-				            "name": "Codecov",
-				            "url": "https://github.com/apps/codecov",
-				          },
-				        ],
-				      },
-				      "block": [Function],
-				    },
-				    {
-				      "addons": {
-				        "badges": [
-				          {
-				            "alt": "🧪 Coverage",
-				            "href": "https://codecov.io/gh/test-owner/test-repository",
-				            "src": "https://img.shields.io/codecov/c/github/test-owner/test-repository?label=%F0%9F%A7%AA%20coverage",
-				          },
-				        ],
-				      },
-				      "block": [Function],
-				    },
-				    {
-				      "addons": {
-				        "actionSteps": [
-				          {
-				            "if": "always()",
-				            "uses": "codecov/codecov-action@v3",
-				          },
-				        ],
-				      },
-				      "block": [Function],
-				    },
-				    {
-				      "addons": {
-				        "files": [
-				          ".github/codecov.yaml",
-				          "codecov.yaml",
-				        ],
-				      },
-				      "block": [Function],
-				    },
-				  ],
-				}
-			`);
+			{
+			  "addons": [
+			    {
+			      "addons": {
+			        "apps": [
+			          {
+			            "name": "Codecov",
+			            "url": "https://github.com/apps/codecov",
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "badges": [
+			          {
+			            "alt": "🧪 Coverage",
+			            "href": "https://codecov.io/gh/test-owner/test-repository",
+			            "src": "https://img.shields.io/codecov/c/github/test-owner/test-repository?label=%F0%9F%A7%AA%20coverage",
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "actionSteps": [
+			          {
+			            "if": "always()",
+			            "uses": "codecov/codecov-action@v3",
+			          },
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			    {
+			      "addons": {
+			        "files": [
+			          ".github/codecov.{yaml,yml}",
+			          "codecov.{yaml,yml}",
+			        ],
+			      },
+			      "block": [Function],
+			    },
+			  ],
+			}
+		`);
 	});
 
 	test("with addons", () => {

--- a/src/blocks/blockCodecov.ts
+++ b/src/blocks/blockCodecov.ts
@@ -78,7 +78,9 @@ export const blockCodecov = base.createBlock({
 	transition() {
 		return {
 			addons: [
-				blockRemoveFiles({ files: [".github/codecov.yaml", "codecov.yaml"] }),
+				blockRemoveFiles({
+					files: [".github/codecov.{yaml,yml}", "codecov.{yaml,yml}"],
+				}),
 			],
 		};
 	},

--- a/src/blocks/blockFunding.test.ts
+++ b/src/blocks/blockFunding.test.ts
@@ -1,0 +1,19 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, test } from "vitest";
+
+import { blockFunding } from "./blockFunding.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe("blockFunding", () => {
+	test("transition mode", () => {
+		const creation = testBlock(blockFunding, {
+			mode: "transition",
+			options: optionsBase,
+		});
+
+		expect(creation.addons).toContainEqual(
+			blockRemoveFiles({ files: [".github/FUNDING.yml"] }),
+		);
+	});
+});

--- a/src/blocks/blockFunding.ts
+++ b/src/blocks/blockFunding.ts
@@ -1,4 +1,5 @@
 import { base } from "../base.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { formatYaml } from "./files/formatYaml.js";
 
 export const blockFunding = base.createBlock({
@@ -13,6 +14,15 @@ export const blockFunding = base.createBlock({
 						options.funding && formatYaml({ github: options.funding }),
 				},
 			},
+		};
+	},
+	transition() {
+		return {
+			addons: [
+				blockRemoveFiles({
+					files: [".github/FUNDING.yml"],
+				}),
+			],
 		};
 	},
 });

--- a/src/blocks/blockGitHubActionsCI.test.ts
+++ b/src/blocks/blockGitHubActionsCI.test.ts
@@ -240,7 +240,10 @@ describe(blockGitHubActionsCI, () => {
 			      "addons": {
 			        "files": [
 			          ".circleci",
-			          "travis.yaml",
+			          ".github/actions/prepare/action.yml",
+			          ".github/workflows/ci.yml",
+			          ".github/workflows/pr-review-requested.yml",
+			          "travis.{yaml,yml}",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockGitHubActionsCI.ts
+++ b/src/blocks/blockGitHubActionsCI.ts
@@ -168,7 +168,13 @@ export const blockGitHubActionsCI = base.createBlock({
 		return {
 			addons: [
 				blockRemoveFiles({
-					files: [".circleci", "travis.yaml"],
+					files: [
+						".circleci",
+						".github/actions/prepare/action.yml",
+						".github/workflows/ci.yml",
+						".github/workflows/pr-review-requested.yml",
+						"travis.{yaml,yml}",
+					],
 				}),
 			],
 		};

--- a/src/blocks/blockGitHubIssueTemplates.test.ts
+++ b/src/blocks/blockGitHubIssueTemplates.test.ts
@@ -1,0 +1,26 @@
+import { testBlock } from "bingo-stratum-testers";
+import { describe, expect, test } from "vitest";
+
+import { blockGitHubIssueTemplates } from "./blockGitHubIssueTemplates.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
+import { optionsBase } from "./options.fakes.js";
+
+describe("blockGitHubIssueTemplates", () => {
+	test("transition mode", () => {
+		const creation = testBlock(blockGitHubIssueTemplates, {
+			mode: "transition",
+			options: optionsBase,
+		});
+
+		expect(creation.addons).toContainEqual(
+			blockRemoveFiles({
+				files: [
+					".github/ISSUE_TEMPLATE/01-bug.yml",
+					".github/ISSUE_TEMPLATE/02-documentation.yml",
+					".github/ISSUE_TEMPLATE/03-feature.yml",
+					".github/ISSUE_TEMPLATE/04-tooling.yml",
+				],
+			}),
+		);
+	});
+});

--- a/src/blocks/blockGitHubIssueTemplates.ts
+++ b/src/blocks/blockGitHubIssueTemplates.ts
@@ -1,4 +1,5 @@
 import { base } from "../base.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { formatYaml } from "./files/formatYaml.js";
 
 export const blockGitHubIssueTemplates = base.createBlock({
@@ -221,6 +222,20 @@ export const blockGitHubIssueTemplates = base.createBlock({
 `,
 				},
 			},
+		};
+	},
+	transition() {
+		return {
+			addons: [
+				blockRemoveFiles({
+					files: [
+						".github/ISSUE_TEMPLATE/01-bug.yml",
+						".github/ISSUE_TEMPLATE/02-documentation.yml",
+						".github/ISSUE_TEMPLATE/03-feature.yml",
+						".github/ISSUE_TEMPLATE/04-tooling.yml",
+					],
+				}),
+			],
 		};
 	},
 });

--- a/src/blocks/blockOctoGuide.test.ts
+++ b/src/blocks/blockOctoGuide.test.ts
@@ -82,8 +82,9 @@ describe(blockOctoGuide, () => {
 			    {
 			      "addons": {
 			        "files": [
-			          ".github/workflows/accessibility-alt-text-bot.yaml",
-			          ".github/workflows/compliance.yaml",
+			          ".github/workflows/accessibility-alt-text-bot.{yaml,yml}",
+			          ".github/workflows/compliance.{yaml,yml}",
+			          ".github/workflows/octoguide.yml",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockOctoGuide.ts
+++ b/src/blocks/blockOctoGuide.ts
@@ -94,8 +94,9 @@ export const blockOctoGuide = base.createBlock({
 			addons: [
 				blockRemoveFiles({
 					files: [
-						".github/workflows/accessibility-alt-text-bot.yaml",
-						".github/workflows/compliance.yaml",
+						".github/workflows/accessibility-alt-text-bot.{yaml,yml}",
+						".github/workflows/compliance.{yaml,yml}",
+						".github/workflows/octoguide.yml",
 					],
 				}),
 			],

--- a/src/blocks/blockReleaseIt.test.ts
+++ b/src/blocks/blockReleaseIt.test.ts
@@ -2,6 +2,7 @@ import { testBlock } from "bingo-stratum-testers";
 import { describe, expect, test } from "vitest";
 
 import { blockReleaseIt } from "./blockReleaseIt.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { optionsBase } from "./options.fakes.js";
 
 describe(blockReleaseIt, () => {
@@ -268,5 +269,21 @@ describe(blockReleaseIt, () => {
 			  ],
 			}
 		`);
+	});
+
+	test("transition mode", () => {
+		const creation = testBlock(blockReleaseIt, {
+			mode: "transition",
+			options: optionsBase,
+		});
+
+		expect(creation.addons).toContainEqual(
+			blockRemoveFiles({
+				files: [
+					".github/workflows/post-release.yml",
+					".github/workflows/release.yml",
+				],
+			}),
+		);
 	});
 });

--- a/src/blocks/blockReleaseIt.ts
+++ b/src/blocks/blockReleaseIt.ts
@@ -5,6 +5,7 @@ import { getPackageDependencies } from "../data/packageData.js";
 import { resolveUses } from "./actions/resolveUses.js";
 import { blockPackageJson } from "./blockPackageJson.js";
 import { blockREADME } from "./blockREADME.js";
+import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { blockRepositorySecrets } from "./blockRepositorySecrets.js";
 import { createSoloWorkflowFile } from "./files/createSoloWorkflowFile.js";
 
@@ -186,6 +187,18 @@ export const blockReleaseIt = base.createBlock({
 					`- add ${options.owner}/${options.repository} and \`release.yaml\` as a Trusted Publisher on:`,
 					`   https://www.npmjs.com/package/${options.repository}/access`,
 				].join("\n"),
+			],
+		};
+	},
+	transition() {
+		return {
+			addons: [
+				blockRemoveFiles({
+					files: [
+						".github/workflows/post-release.yml",
+						".github/workflows/release.yml",
+					],
+				}),
 			],
 		};
 	},

--- a/src/blocks/blockRemoveWorkflows.test.ts
+++ b/src/blocks/blockRemoveWorkflows.test.ts
@@ -59,9 +59,9 @@ describe(blockRemoveWorkflows, () => {
 			    {
 			      "addons": {
 			        "files": [
-			          ".github/workflows/a.yaml",
-			          ".github/workflows/b.yaml",
-			          ".github/workflows/c.yaml",
+			          ".github/workflows/a.{yaml,yml}",
+			          ".github/workflows/b.{yaml,yml}",
+			          ".github/workflows/c.{yaml,yml}",
 			        ],
 			      },
 			      "block": [Function],

--- a/src/blocks/blockRemoveWorkflows.ts
+++ b/src/blocks/blockRemoveWorkflows.ts
@@ -22,7 +22,7 @@ export const blockRemoveWorkflows = base.createBlock({
 			addons: [
 				blockRemoveFiles({
 					files: workflows?.map(
-						(workflow) => `.github/workflows/${workflow}.yaml`,
+						(workflow) => `.github/workflows/${workflow}.{yaml,yml}`,
 					),
 				}),
 			],


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2371
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

After #2310 switched the preferred YAML extension from `.yml` to `.yaml`, transition mode wrote the new `.yaml` files but left the old `.yml` ones in place. Each block that produces a `.yaml` file now trashes its own `.yml` predecessor in `transition()`, using the existing `blockRemoveFiles` mechanism.

#2310 also renamed the paths in the *removal* lists for files CTA never produces, which quietly broke those cleanups: they started looking for `.yaml` files that never existed. Those entries now match both extensions via `{yaml,yml}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🎁