### PR TITLE
feat: suggest limiting branches and tags updated in a single push

### DIFF
--- a/src/blocks/blockRepositorySettings.test.ts
+++ b/src/blocks/blockRepositorySettings.test.ts
@@ -40,6 +40,10 @@ describe("blockRepositorySettings", () => {
 			      "type": "octokit",
 			    },
 			  ],
+			  "suggestions": [
+			    "- enable "Limit how many branches and tags can be updated in a single push" with a maximum of 5 on:
+			   https://github.com/test-owner/test-repository/settings",
+			  ],
 			}
 		`);
 	});
@@ -81,6 +85,10 @@ describe("blockRepositorySettings", () => {
 			      },
 			      "type": "octokit",
 			    },
+			  ],
+			  "suggestions": [
+			    "- enable "Limit how many branches and tags can be updated in a single push" with a maximum of 5 on:
+			   https://github.com/test-owner/test-repository/settings",
 			  ],
 			}
 		`);

--- a/src/blocks/blockRepositorySettings.ts
+++ b/src/blocks/blockRepositorySettings.ts
@@ -37,6 +37,12 @@ export const blockRepositorySettings = base.createBlock({
 					type: "octokit",
 				},
 			],
+			suggestions: [
+				[
+					`- enable "Limit how many branches and tags can be updated in a single push" with a maximum of 5 on:`,
+					`   https://github.com/${options.owner}/${options.repository}/settings`,
+				].join("\n"),
+			],
 		};
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2391
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `Repository Settings` suggestion to turn on GitHub's push policy limit, linking to the settings page.

It's a suggestion rather than an API call because GitHub doesn't expose the push policy in the REST API, GraphQL, or rulesets: it's [documented as UI-only](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-push-policy-for-your-repository), and [community#47227](https://github.com/orgs/community/discussions/47227) asking for an API is unanswered.

🎁

🤖 Generated with [Claude Code](https://claude.com/claude-code)