### PR TITLE
feat: add Prettier Plugin Padding Lines block

### DIFF
--- a/docs/Blocks.md
+++ b/docs/Blocks.md
@@ -44,6 +44,7 @@ This table summarizes each block and which base levels they're included in:
 | Prettier                           | `--add-prettier`, `--exclude-prettier`                                                     | ✔️      | ✅     | 💯         |
 | Prettier Plugin Curly              | `--add-prettier-plugin-curly`, `--exclude-prettier-plugin-curly`                           |         |        | 💯         |
 | Prettier Plugin Package JSON       | `--add-prettier-plugin-package-json`, `--exclude-prettier-plugin-package-json`             |         |        | 💯         |
+| Prettier Plugin Padding Lines      | `--add-prettier-plugin-padding-lines`, `--exclude-prettier-plugin-padding-lines`           |         |        | 💯         |
 | Prettier Plugin Sentences Per Line | `--add-prettier-plugin-sentences-per-line`, `--exclude-prettier-plugin-sentences-per-line` |         |        | 💯         |
 | Prettier Plugin Sh                 | `--add-prettier-plugin-sh`, `--exclude-prettier-plugin-sh`                                 |         |        | 💯         |
 | README.md                          | `--add-readme-md`, `--exclude-readme-md`                                                   | ✔️      | ✅     | 💯         |
@@ -106,6 +107,7 @@ It's run on file save per [VS Code](https://code.visualstudio.com/docs/getstarte
 Additional formatting can be provided by the following plugins:
 
 - [prettier-plugin-curly](https://github.com/JoshuaKGoldberg/prettier-plugin-curly)
+- [prettier-plugin-padding-lines](https://github.com/JoshuaKGoldberg/prettier-plugin-padding-lines)
 - [prettier-plugin-sentences-per-line](https://github.com/JoshuaKGoldberg/sentences-per-line/tree/main/packages/prettier-plugin-sentences-per-line)
 - [prettier-plugin-sh](https://github.com/un-ts/prettier/tree/master/packages/sh)
 - [prettier-plugin-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson)

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"prettier": "3.9.6",
 		"prettier-plugin-curly": "0.4.1",
 		"prettier-plugin-packagejson": "3.0.2",
+		"prettier-plugin-padding-lines": "0.1.0",
 		"prettier-plugin-sentences-per-line": "0.2.4",
 		"prettier-plugin-sh": "0.19.0",
 		"release-it": "21.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       prettier-plugin-packagejson:
         specifier: 3.0.2
         version: 3.0.2(prettier@3.9.6)
+      prettier-plugin-padding-lines:
+        specifier: 0.1.0
+        version: 0.1.0(prettier@3.9.6)
       prettier-plugin-sentences-per-line:
         specifier: 0.2.4
         version: 0.2.4(prettier@3.9.6)
@@ -3586,6 +3589,12 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
+
+  prettier-plugin-padding-lines@0.1.0:
+    resolution: {integrity: sha512-CYZyfSyHdlCnP0T4qe/tdY9ninLhpe7XbSS8dZYvzu1ZeCUK8tQ8P9Z5Ep7ofZL6X6laq01xzYAeZq4o9jWAEw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      prettier: ^3
 
   prettier-plugin-sentences-per-line@0.2.4:
     resolution: {integrity: sha512-1SSPJxwvekA6wVb4VqJYcVZw39Ak7Oy/IKd4qCGG48hO7oWg/DF0EWPo4PrEROy2LWLl3/U570NM7SurMKQNSA==}
@@ -7928,6 +7937,10 @@ snapshots:
     dependencies:
       sort-package-json: 3.7.1
     optionalDependencies:
+      prettier: 3.9.6
+
+  prettier-plugin-padding-lines@0.1.0(prettier@3.9.6):
+    dependencies:
       prettier: 3.9.6
 
   prettier-plugin-sentences-per-line@0.2.4(prettier@3.9.6):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ minimumReleaseAgeExclude:
   - eslint-plugin-jsdoc@64.2.1
   - jsdoc-type-pratt-parser@9.1.2
   - marked@18.0.10
+  - prettier-plugin-padding-lines@0.1.0

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -5,6 +5,7 @@ export default {
 	plugins: [
 		"prettier-plugin-curly",
 		"prettier-plugin-packagejson",
+		"prettier-plugin-padding-lines",
 		"prettier-plugin-sentences-per-line",
 		"prettier-plugin-sh",
 	],

--- a/src/blocks/blockPrettierPluginPaddingLines.ts
+++ b/src/blocks/blockPrettierPluginPaddingLines.ts
@@ -1,0 +1,17 @@
+import { base } from "../base.js";
+import { blockPrettier } from "./blockPrettier.js";
+
+export const blockPrettierPluginPaddingLines = base.createBlock({
+	about: {
+		name: "Prettier Plugin Padding Lines",
+	},
+	produce() {
+		return {
+			addons: [
+				blockPrettier({
+					plugins: ["prettier-plugin-padding-lines"],
+				}),
+			],
+		};
+	},
+});

--- a/src/presets/everything.ts
+++ b/src/presets/everything.ts
@@ -17,6 +17,7 @@ import { blockOctoGuideStrict } from "../blocks/blockOctoGuideStrict.js";
 import { blockPnpmDedupe } from "../blocks/blockPnpmDedupe.js";
 import { blockPrettierPluginCurly } from "../blocks/blockPrettierPluginCurly.js";
 import { blockPrettierPluginPackageJson } from "../blocks/blockPrettierPluginPackageJson.js";
+import { blockPrettierPluginPaddingLines } from "../blocks/blockPrettierPluginPaddingLines.js";
 import { blockPrettierPluginSentencesPerLine } from "../blocks/blockPrettierPluginSentencesPerLine.js";
 import { blockPrettierPluginSh } from "../blocks/blockPrettierPluginSh.js";
 import { blockRenovate } from "../blocks/blockRenovate.js";
@@ -49,6 +50,7 @@ export const presetEverything = base.createPreset({
 		blockOctoGuideStrict,
 		blockPrettierPluginCurly,
 		blockPrettierPluginPackageJson,
+		blockPrettierPluginPaddingLines,
 		blockPrettierPluginSentencesPerLine,
 		blockPrettierPluginSh,
 		blockRenovate,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #493
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `Prettier Plugin Padding Lines` block to the _Everything_ preset, wiring in [prettier-plugin-padding-lines](https://github.com/JoshuaKGoldberg/prettier-plugin-padding-lines) 🛋️.

It enforces the equivalent of the `@typescript-eslint/padding-line-between-statements` option this repo used to ship.

🎁 