### PR TITLE
fix: apply --email CLI flag to package.json author

### DIFF
--- a/src/base.test.ts
+++ b/src/base.test.ts
@@ -6,6 +6,14 @@ import { base } from "./base.js";
 import { AllContributorsData } from "./types.js";
 
 describe("base", () => {
+	// Bingo's CLI can only map an option to a --flag it knows the type of.
+	// A z.transform() hides the string, so --email would be parsed as a boolean.
+	test("email option schema accepts a plain string", () => {
+		const result = base.options.email.safeParse("test@example.com");
+
+		expect(result).toEqual({ data: "test@example.com", success: true });
+	});
+
 	test("production from create-typescript-app", async () => {
 		const options = await prepareOptions(base);
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -38,7 +38,12 @@ import { readRulesetId } from "./options/readRulesetId.js";
 import { readTitle } from "./options/readTitle.js";
 import { readWords } from "./options/readWords.js";
 import { readWorkflowsVersions } from "./options/readWorkflowsVersions.js";
-import { zContributor, zDocumentation, zWorkflowsVersions } from "./schemas.js";
+import {
+	zContributor,
+	zDocumentation,
+	zEmails,
+	zWorkflowsVersions,
+} from "./schemas.js";
 
 export const base = createBase({
 	options: {
@@ -66,18 +71,7 @@ export const base = createBase({
 			"additional docs to add to .md files",
 		),
 		email: z
-			.union([
-				z.string(),
-				z.object({
-					github: z.string(),
-					npm: z.string(),
-				}),
-			])
-			// TODO: Test this? Is it still working?
-			// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1991
-			.transform((email) =>
-				typeof email === "string" ? { github: email, npm: email } : email,
-			)
+			.union([z.string(), zEmails])
 			.describe(
 				"email address to be listed as the point of contact in docs and packages",
 			),

--- a/src/blocks/blockContributorCovenant.ts
+++ b/src/blocks/blockContributorCovenant.ts
@@ -1,4 +1,5 @@
 import { base } from "../base.js";
+import { resolveEmails } from "../utils/resolveEmails.js";
 import { blockREADME } from "./blockREADME.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 
@@ -83,7 +84,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-${options.email.github}.
+${resolveEmails(options.email).github}.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/src/blocks/blockPackageJson.test.ts
+++ b/src/blocks/blockPackageJson.test.ts
@@ -131,6 +131,31 @@ describe(blockPackageJson, () => {
 		`);
 	});
 
+	test("with options.email set to a string", () => {
+		const creation = testBlock(blockPackageJson, {
+			options: {
+				...options,
+				email: "string@email.com",
+			},
+		});
+
+		expect(creation).toMatchInlineSnapshot(`
+			{
+			  "files": {
+			    "package.json": "{"name":"test-repository","version":"0.0.0","description":"A very very very very very very very very very very very very very very very very long HTML-ish description ending with an emoji. 🧵","repository":{"type":"git","url":"git+https://github.com/test-owner/test-repository.git"},"author":{"email":"string@email.com"},"type":"module","engines":{"node":">=20.12.0"}}",
+			  },
+			  "scripts": [
+			    {
+			      "commands": [
+			        "pnpm install --no-frozen-lockfile",
+			      ],
+			      "phase": 1,
+			    },
+			  ],
+			}
+		`);
+	});
+
 	test("with options.type set to commonjs", () => {
 		const creation = testBlock(blockPackageJson, {
 			options: {

--- a/src/blocks/blockPackageJson.ts
+++ b/src/blocks/blockPackageJson.ts
@@ -6,6 +6,7 @@ import { PackageJson } from "zod-package-json";
 
 import { base } from "../base.js";
 import { htmlToTextSafe } from "../utils/htmlToTextSafe.js";
+import { resolveEmails } from "../utils/resolveEmails.js";
 import { blockRemoveFiles } from "./blockRemoveFiles.js";
 import { CommandPhase } from "./phases.js";
 
@@ -44,7 +45,10 @@ export const blockPackageJson = base.createBlock({
 						removeUndefinedObjects({
 							...options.packageData,
 							...addons.properties,
-							author: { email: options.email.npm, name: options.author },
+							author: {
+								email: resolveEmails(options.email).npm,
+								name: options.author,
+							},
 							bin: options.bin,
 							dependencies: Object.keys(dependencies).length
 								? dependencies

--- a/src/blocks/blockSecurityDocs.ts
+++ b/src/blocks/blockSecurityDocs.ts
@@ -1,4 +1,5 @@
 import { base } from "../base.js";
+import { resolveEmails } from "../utils/resolveEmails.js";
 
 export const blockSecurityDocs = base.createBlock({
 	about: {
@@ -14,7 +15,7 @@ We take all security vulnerabilities seriously.
 If you have a vulnerability or other security issues to disclose:
 
 - Thank you very much, please do!
-- Please send them to us by emailing \`${options.email.github}\`
+- Please send them to us by emailing \`${resolveEmails(options.email).github}\`
 
 We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 `,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+export const zEmails = z.object({
+	github: z.string(),
+	npm: z.string(),
+});
+
+export type Emails = z.infer<typeof zEmails>;
+
 export const zContributor = z.object({
 	avatar_url: z.string(),
 	contributions: z.array(z.string()),

--- a/src/utils/resolveEmails.test.ts
+++ b/src/utils/resolveEmails.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveEmails } from "./resolveEmails.js";
+
+describe(resolveEmails, () => {
+	test("string", () => {
+		const actual = resolveEmails("test@example.com");
+
+		expect(actual).toEqual({
+			github: "test@example.com",
+			npm: "test@example.com",
+		});
+	});
+
+	test("object", () => {
+		const actual = resolveEmails({
+			github: "github@example.com",
+			npm: "npm@example.com",
+		});
+
+		expect(actual).toEqual({
+			github: "github@example.com",
+			npm: "npm@example.com",
+		});
+	});
+});

--- a/src/utils/resolveEmails.ts
+++ b/src/utils/resolveEmails.ts
@@ -1,0 +1,5 @@
+import { Emails } from "../schemas.js";
+
+export function resolveEmails(email: Emails | string): Emails {
+	return typeof email === "string" ? { github: email, npm: email } : email;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2435
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`--email` was silently dropped on the CLI because of the `z.transform()` on the `email` option:

1. Bingo can't map a `ZodEffects` to a `parseArgs` flag type, so the value became a stray positional.
2. Bingo never `.parse()`s options through their schemas, so the transform never ran anyway.

Replaces the transform with a plain union and a `resolveEmails` helper at the consuming blocks.

The `// TODO` pointing at #1991 is still there. That issue is still open and blocked upstream.

🎁
