### PR TITLE
fix: create the TypeScript compilerOptions Addons schema with Zod 3

### DIFF
--- a/src/blocks/blockTypeScript.test.ts
+++ b/src/blocks/blockTypeScript.test.ts
@@ -1,5 +1,5 @@
 import { testBlock, testIntake } from "bingo-stratum-testers";
-import { describe, expect, it, test } from "vitest";
+import { describe, expect, it, onTestFinished, test, vi } from "vitest";
 
 import { blockTypeScript } from "./blockTypeScript.js";
 import { optionsBase } from "./options.fakes.js";
@@ -647,6 +647,38 @@ describe(blockTypeScript, () => {
 			  },
 			}
 		`);
+	});
+
+	it("produces a tsconfig.json when zod-tsconfig's schemas are created by Zod 4", async () => {
+		vi.doMock("zod-tsconfig", async () => {
+			const z4 = await import("zod/v4");
+
+			return {
+				CompilerOptionsSchema: z4.object({
+					module: z4.string().optional(),
+				}),
+			};
+		});
+		vi.resetModules();
+		onTestFinished(() => {
+			vi.doUnmock("zod-tsconfig");
+			vi.resetModules();
+		});
+		const { blockTypeScript: blockTypeScriptWithZod4 } =
+			await import("./blockTypeScript.js");
+
+		const creation = testBlock(blockTypeScriptWithZod4, {
+			addons: {
+				compilerOptions: {
+					module: "esnext",
+				},
+			},
+			options: optionsBase,
+		});
+
+		expect(creation.files).toEqual({
+			"tsconfig.json": expect.stringContaining(`"module":"esnext"`),
+		});
 	});
 
 	describe("intake", () => {

--- a/src/blocks/blockTypeScript.ts
+++ b/src/blocks/blockTypeScript.ts
@@ -1,5 +1,6 @@
 import sortKeys from "sort-keys";
-import { CompilerOptionsSchema } from "zod-tsconfig";
+import { z } from "zod";
+import { CompilerOptions, CompilerOptionsSchema } from "zod-tsconfig";
 
 import { base } from "../base.js";
 import { getPackageDependencies } from "../data/packageData.js";
@@ -15,12 +16,19 @@ import { blockVitest } from "./blockVitest.js";
 import { blockVSCode } from "./blockVSCode.js";
 import { intakeFileAsJson } from "./intake/intakeFileAsJson.js";
 
+// zod-tsconfig allows any Zod major, so its schemas can be built by Zod 4 while
+// Stratum parses Addons with Zod 3.
+// https://github.com/JoshuaKGoldberg/create-typescript-app/issues/2437
+const zCompilerOptions = z.custom<CompilerOptions>(
+	(value) => CompilerOptionsSchema.safeParse(value).success,
+);
+
 export const blockTypeScript = base.createBlock({
 	about: {
 		name: "TypeScript",
 	},
 	addons: {
-		compilerOptions: CompilerOptionsSchema.optional(),
+		compilerOptions: zCompilerOptions.optional(),
 	},
 	intake({ files }) {
 		const raw = intakeFileAsJson(files, ["tsconfig.json"]);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2437
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/create-typescript-app/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/create-typescript-app/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

`zod-tsconfig` declares `zod: ">=3.0.0"`, so pnpm's isolated installs can resolve it to Zod 4 while `bingo-stratum` parses Addons with Zod 3.
Handing that Zod 4 schema to Stratum throws `TypeError: keyValidator._parse is not a function`.

Wraps `CompilerOptionsSchema` in this package's own `z.custom()` so Stratum always gets a Zod 3 schema.
Types and `intake()` validation still come from `zod-tsconfig`.

The real fix is upstream: `zod-tsconfig` should peer-depend on a single Zod major.

🎁

🤖 Generated with [Claude Code](https://claude.com/claude-code)